### PR TITLE
Add extras property to markers

### DIFF
--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -77,12 +77,14 @@ class Marker {
   final double width;
   final double height;
   final Anchor anchor;
+  final Map<String, dynamic> extras;
 
   Marker({
     this.point,
     this.builder,
     this.width = 30.0,
     this.height = 30.0,
+    this.extras,
     AnchorPos anchorPos,
   }) : anchor = Anchor.forPos(anchorPos, width, height);
 }


### PR DESCRIPTION
Using https://github.com/lpongetti/flutter_map_marker_cluster I needed to add extra properties to markers (so I can sum this props to show a total number on the cluster). 

Doing so requires to update the `Marker` class here and I think it can be helpful in many other cases. 

Please tell me if I need to change anything. 

Thanks!