### PR TITLE
feat: support resetting TileLayer

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,6 +20,7 @@ import './pages/plugin_api.dart';
 import './pages/plugin_scalebar.dart';
 import './pages/plugin_zoombuttons.dart';
 import './pages/polyline.dart';
+import './pages/reset_tile_layer.dart';
 import './pages/sliding_map.dart';
 import './pages/stateful_markers.dart';
 import './pages/tap_to_add.dart';
@@ -70,6 +71,7 @@ class MyApp extends StatelessWidget {
         ManyMarkersPage.route: (context) => ManyMarkersPage(),
         StatefulMarkersPage.route: (context) => StatefulMarkersPage(),
         MapInsideListViewPage.route: (context) => MapInsideListViewPage(),
+        ResetTileLayerPage.route: (context) => ResetTileLayerPage(),
       },
     );
   }

--- a/example/lib/pages/reset_tile_layer.dart
+++ b/example/lib/pages/reset_tile_layer.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../widgets/drawer.dart';
+
+class ResetTileLayerPage extends StatefulWidget {
+  static const String route = '/reset_tilelayer';
+  @override
+  ResetTileLayerPageState createState() {
+    return ResetTileLayerPageState();
+  }
+}
+
+class ResetTileLayerPageState extends State<ResetTileLayerPage> {
+  StreamController<Null> resetController = StreamController.broadcast();
+
+  String layer1 = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+  String layer2 = 'http://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png';
+  bool layerToggle = true;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  void _resetTiles() {
+    setState(() {
+      layerToggle = !layerToggle;
+    });
+    resetController.add(null);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var markers = <Marker>[
+      Marker(
+        width: 80.0,
+        height: 80.0,
+        point: LatLng(51.5, -0.09),
+        builder: (ctx) => Container(
+          child: FlutterLogo(),
+        ),
+      ),
+    ];
+
+    return Scaffold(
+      appBar: AppBar(title: Text('TileLayer Reset')),
+      drawer: buildDrawer(context, ResetTileLayerPage.route),
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Text(
+                  'TileLayers can be progromatically reset, disposing of cached files'),
+            ),
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Wrap(
+                children: <Widget>[
+                  MaterialButton(
+                    onPressed: _resetTiles,
+                    child: Text('Reset'),
+                  ),
+                ],
+              ),
+            ),
+            Flexible(
+              child: FlutterMap(
+                options: MapOptions(
+                  center: LatLng(51.5, -0.09),
+                  zoom: 5.0,
+                ),
+                layers: [
+                  TileLayerOptions(
+                      reset: resetController.stream,
+                      urlTemplate: layerToggle ? layer1 : layer2,
+                      subdomains: ['a', 'b', 'c']),
+                  MarkerLayerOptions(markers: markers)
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -21,6 +21,7 @@ import '../pages/plugin_api.dart';
 import '../pages/plugin_scalebar.dart';
 import '../pages/plugin_zoombuttons.dart';
 import '../pages/polyline.dart';
+import '../pages/reset_tile_layer.dart';
 import '../pages/sliding_map.dart';
 import '../pages/stateful_markers.dart';
 import '../pages/tap_to_add.dart';
@@ -210,6 +211,13 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           selected: currentRoute == ManyMarkersPage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, ManyMarkersPage.route);
+          },
+        ),
+        ListTile(
+          title: const Text('Reset Tile Layer'),
+          selected: currentRoute == ResetTileLayerPage.route,
+          onTap: () {
+            Navigator.pushReplacementNamed(context, ResetTileLayerPage.route);
           },
         ),
         _buildMenuItem(

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -246,58 +246,57 @@ class TileLayerOptions extends LayerOptions {
   ///aligment of the attribution text on the map widget
   final Alignment attributionAlignment;
 
-
   /// Stream to notify the [TileLayer] that it needs resetting
   Stream<Null>? reset;
 
-  TileLayerOptions({
-    this.attributionAlignment = Alignment.bottomRight,
-    this.attributionBuilder,
-    Key? key,
-    // TODO: make required
-    this.urlTemplate,
-    double tileSize = 256.0,
-    double minZoom = 0.0,
-    double maxZoom = 18.0,
-    this.minNativeZoom,
-    this.maxNativeZoom,
-    this.zoomReverse = false,
-    double zoomOffset = 0.0,
-    Map<String, String>? additionalOptions,
-    this.subdomains = const <String>[],
-    this.keepBuffer = 2,
-    this.backgroundColor = const Color(0xFFE0E0E0),
-    this.placeholderImage,
-    this.errorImage,
-    this.tileProvider = const NonCachingNetworkTileProvider(),
-    this.tms = false,
-    // ignore: avoid_init_to_null
-    this.wmsOptions = null,
-    this.opacity = 1.0,
-    // Tiles will not update more than once every `updateInterval` milliseconds
-    // (default 200) when panning. It can be 0 (but it will calculating for
-    // loading tiles every frame when panning / zooming, flutter is fast) This
-    // can save some fps and even bandwidth (ie. when fast panning / animating
-    // between long distances in short time)
-    // TODO: change to Duration
-    int updateInterval = 200,
-    // Tiles fade in duration in milliseconds (default 100).  This can be set to
-    // 0 to avoid fade in
-    // TODO: change to Duration
-    int tileFadeInDuration = 100,
-    this.tileFadeInStart = 0.0,
-    this.tileFadeInStartWhenOverride = 0.0,
-    this.overrideTilesWhenUrlChanges = false,
-    this.retinaMode = false,
-    this.errorTileCallback,
-    Stream<Null>? rebuild,
-    this.templateFunction = util.template,
-    this.tileBuilder,
-    this.tilesContainerBuilder,
-    this.evictErrorTileStrategy = EvictErrorTileStrategy.none,
-    this.fastReplace = false,
-    this.reset
-  })  : updateInterval =
+  TileLayerOptions(
+      {this.attributionAlignment = Alignment.bottomRight,
+      this.attributionBuilder,
+      Key? key,
+      // TODO: make required
+      this.urlTemplate,
+      double tileSize = 256.0,
+      double minZoom = 0.0,
+      double maxZoom = 18.0,
+      this.minNativeZoom,
+      this.maxNativeZoom,
+      this.zoomReverse = false,
+      double zoomOffset = 0.0,
+      Map<String, String>? additionalOptions,
+      this.subdomains = const <String>[],
+      this.keepBuffer = 2,
+      this.backgroundColor = const Color(0xFFE0E0E0),
+      this.placeholderImage,
+      this.errorImage,
+      this.tileProvider = const NonCachingNetworkTileProvider(),
+      this.tms = false,
+      // ignore: avoid_init_to_null
+      this.wmsOptions = null,
+      this.opacity = 1.0,
+      // Tiles will not update more than once every `updateInterval` milliseconds
+      // (default 200) when panning. It can be 0 (but it will calculating for
+      // loading tiles every frame when panning / zooming, flutter is fast) This
+      // can save some fps and even bandwidth (ie. when fast panning / animating
+      // between long distances in short time)
+      // TODO: change to Duration
+      int updateInterval = 200,
+      // Tiles fade in duration in milliseconds (default 100).  This can be set to
+      // 0 to avoid fade in
+      // TODO: change to Duration
+      int tileFadeInDuration = 100,
+      this.tileFadeInStart = 0.0,
+      this.tileFadeInStartWhenOverride = 0.0,
+      this.overrideTilesWhenUrlChanges = false,
+      this.retinaMode = false,
+      this.errorTileCallback,
+      Stream<Null>? rebuild,
+      this.templateFunction = util.template,
+      this.tileBuilder,
+      this.tilesContainerBuilder,
+      this.evictErrorTileStrategy = EvictErrorTileStrategy.none,
+      this.fastReplace = false,
+      this.reset})
+      : updateInterval =
             updateInterval <= 0 ? null : Duration(milliseconds: updateInterval),
         tileFadeInDuration = tileFadeInDuration <= 0
             ? null


### PR DESCRIPTION
This change supports the clearing of in memory tiles from the TileLayerState as described in  #666 

I created a separate Stream to manage reset events instead of using the LayerOptions rebuild stream as this is currently consumed by the onMove event subscriber and any changes to this may affect existing implementations using the rebuild. 

I have also added an example for resetting the a TileLayer