### PR TITLE
Key management

### DIFF
--- a/example/lib/pages/plugin_api.dart
+++ b/example/lib/pages/plugin_api.dart
@@ -43,7 +43,11 @@ class PluginPage extends StatelessWidget {
 
 class MyCustomPluginOptions extends LayerOptions {
   final String text;
-  MyCustomPluginOptions({this.text = ''});
+  MyCustomPluginOptions({
+    Key key,
+    this.text = '',
+    rebuild,
+  }) : super(key: key, rebuild: rebuild);
 }
 
 class MyCustomPlugin implements MapPlugin {
@@ -58,6 +62,7 @@ class MyCustomPlugin implements MapPlugin {
       );
       return Text(
         options.text,
+        key: options.key,
         style: style,
       );
     }

--- a/example/lib/pages/scale_layer_plugin_option.dart
+++ b/example/lib/pages/scale_layer_plugin_option.dart
@@ -1,8 +1,10 @@
 import 'dart:math';
 import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/plugin_api.dart';
+
 import './scalebar_utils.dart' as util;
 
 class ScaleLayerPluginOption extends LayerOptions {
@@ -11,11 +13,14 @@ class ScaleLayerPluginOption extends LayerOptions {
   double lineWidth;
   final EdgeInsets padding;
 
-  ScaleLayerPluginOption(
-      {this.textStyle,
-      this.lineColor = Colors.white,
-      this.lineWidth = 2,
-      this.padding});
+  ScaleLayerPluginOption({
+    Key key,
+    this.textStyle,
+    this.lineColor = Colors.white,
+    this.lineWidth = 2,
+    this.padding,
+    rebuild,
+  }) : super(key: key, rebuild: rebuild);
 }
 
 class ScaleLayerPlugin implements MapPlugin {
@@ -64,7 +69,8 @@ class ScaleLayer extends StatelessWidget {
     5
   ];
 
-  ScaleLayer(this.scaleLayerOpts, this.map, this.stream);
+  ScaleLayer(this.scaleLayerOpts, this.map, this.stream)
+      : super(key: scaleLayerOpts.key);
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/pages/zoombuttons_plugin_option.dart
+++ b/example/lib/pages/zoombuttons_plugin_option.dart
@@ -13,16 +13,19 @@ class ZoomButtonsPluginOption extends LayerOptions {
   final IconData zoomInIcon;
   final IconData zoomOutIcon;
 
-  ZoomButtonsPluginOption(
-      {this.minZoom = 1,
-      this.maxZoom = 18,
-      this.mini = true,
-      this.padding = 2.0,
-      this.alignment = Alignment.topRight,
-      this.zoomInColor,
-      this.zoomInIcon = Icons.zoom_in,
-      this.zoomOutColor,
-      this.zoomOutIcon = Icons.zoom_out});
+  ZoomButtonsPluginOption({
+    Key key,
+    this.minZoom = 1,
+    this.maxZoom = 18,
+    this.mini = true,
+    this.padding = 2.0,
+    this.alignment = Alignment.topRight,
+    this.zoomInColor,
+    this.zoomInIcon = Icons.zoom_in,
+    this.zoomOutColor,
+    this.zoomOutIcon = Icons.zoom_out,
+    rebuild,
+  }) : super(key: key, rebuild: rebuild);
 }
 
 class ZoomButtonsPlugin implements MapPlugin {
@@ -48,7 +51,8 @@ class ZoomButtons extends StatelessWidget {
   final FitBoundsOptions options =
       const FitBoundsOptions(padding: EdgeInsets.all(12.0));
 
-  ZoomButtons(this.zoomButtonsOpts, this.map, this.stream);
+  ZoomButtons(this.zoomButtonsOpts, this.map, this.stream)
+      : super(key: zoomButtonsOpts.key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/layer/circle_layer.dart
+++ b/lib/src/layer/circle_layer.dart
@@ -7,8 +7,11 @@ import 'package:latlong/latlong.dart' hide Path; // conflict with Path from UI
 
 class CircleLayerOptions extends LayerOptions {
   final List<CircleMarker> circles;
-  CircleLayerOptions({this.circles = const [], rebuild})
-      : super(rebuild: rebuild);
+  CircleLayerOptions({
+    Key key,
+    this.circles = const [],
+    rebuild,
+  }) : super(key: key, rebuild: rebuild);
 }
 
 class CircleMarker {
@@ -33,7 +36,7 @@ class CircleMarker {
 class CircleLayerWidget extends StatelessWidget {
   final CircleLayerOptions options;
 
-  CircleLayerWidget({@required this.options});
+  CircleLayerWidget({@required this.options}) : super(key: options.key);
 
   @override
   Widget build(BuildContext context) {
@@ -46,7 +49,8 @@ class CircleLayer extends StatelessWidget {
   final CircleLayerOptions circleOpts;
   final MapState map;
   final Stream<Null> stream;
-  CircleLayer(this.circleOpts, this.map, this.stream);
+  CircleLayer(this.circleOpts, this.map, this.stream)
+      : super(key: circleOpts.key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/layer/group_layer.dart
+++ b/lib/src/layer/group_layer.dart
@@ -6,13 +6,17 @@ import 'package:flutter_map/src/map/map.dart';
 class GroupLayerOptions extends LayerOptions {
   List<LayerOptions> group = <LayerOptions>[];
 
-  GroupLayerOptions({this.group});
+  GroupLayerOptions({
+    Key key,
+    this.group,
+    rebuild,
+  }) : super(key: key, rebuild: rebuild);
 }
 
 class GroupLayerWidget extends StatelessWidget {
   final GroupLayerOptions options;
 
-  GroupLayerWidget({@required this.options});
+  GroupLayerWidget({@required this.options}) : super(key: options.key);
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +30,7 @@ class GroupLayer extends StatelessWidget {
   final MapState map;
   final Stream<Null> stream;
 
-  GroupLayer(this.groupOpts, this.map, this.stream);
+  GroupLayer(this.groupOpts, this.map, this.stream) : super(key: groupOpts.key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/layer/layer.dart
+++ b/lib/src/layer/layer.dart
@@ -1,8 +1,11 @@
+import 'package:flutter/foundation.dart';
+
 /// Common type between all LayerOptions.
 ///
 /// All LayerOptions have access to a stream that notifies when the map needs
 /// rebuilding.
 class LayerOptions {
-  Stream<Null> rebuild;
-  LayerOptions({this.rebuild});
+  final Key key;
+  final Stream<Null> rebuild;
+  LayerOptions({this.key, this.rebuild});
 }

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -6,8 +6,11 @@ import 'package:latlong/latlong.dart';
 
 class MarkerLayerOptions extends LayerOptions {
   final List<Marker> markers;
-  MarkerLayerOptions({this.markers = const [], rebuild})
-      : super(rebuild: rebuild);
+  MarkerLayerOptions({
+    Key key,
+    this.markers = const [],
+    rebuild,
+  }) : super(key: key, rebuild: rebuild);
 }
 
 class Anchor {
@@ -90,7 +93,7 @@ class Marker {
 class MarkerLayerWidget extends StatelessWidget {
   final MarkerLayerOptions options;
 
-  MarkerLayerWidget({@required this.options});
+  MarkerLayerWidget({@required this.options}) : super(key: options.key);
 
   @override
   Widget build(BuildContext context) {
@@ -104,7 +107,8 @@ class MarkerLayer extends StatelessWidget {
   final MapState map;
   final Stream<Null> stream;
 
-  MarkerLayer(this.markerOpts, this.map, this.stream);
+  MarkerLayer(this.markerOpts, this.map, this.stream)
+      : super(key: markerOpts.key);
 
   bool _boundsContainsMarker(Marker marker) {
     var pixelPoint = map.project(marker.point);

--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -8,8 +8,11 @@ import 'package:flutter_map/src/map/map.dart';
 class OverlayImageLayerOptions extends LayerOptions {
   final List<OverlayImage> overlayImages;
 
-  OverlayImageLayerOptions({this.overlayImages = const [], rebuild})
-      : super(rebuild: rebuild);
+  OverlayImageLayerOptions({
+    Key key,
+    this.overlayImages = const [],
+    rebuild,
+  }) : super(key: key, rebuild: rebuild);
 }
 
 class OverlayImage {
@@ -29,7 +32,7 @@ class OverlayImage {
 class OverlayImageLayerWidget extends StatelessWidget {
   final OverlayImageLayerOptions options;
 
-  OverlayImageLayerWidget({@required this.options});
+  OverlayImageLayerWidget({@required this.options}) : super(key: options.key);
 
   @override
   Widget build(BuildContext context) {
@@ -43,7 +46,8 @@ class OverlayImageLayer extends StatelessWidget {
   final MapState map;
   final Stream<Null> stream;
 
-  OverlayImageLayer(this.overlayImageOpts, this.map, this.stream);
+  OverlayImageLayer(this.overlayImageOpts, this.map, this.stream)
+      : super(key: overlayImageOpts.key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer.dart
@@ -12,10 +12,11 @@ class PolygonLayerOptions extends LayerOptions {
 
   /// screen space culling of polygons based on bounding box
   PolygonLayerOptions({
+    Key key,
     this.polygons = const [],
     this.polygonCulling = false,
     rebuild,
-  }) : super(rebuild: rebuild) {
+  }) : super(key: key, rebuild: rebuild) {
     if (polygonCulling) {
       for (var polygon in polygons) {
         polygon.boundingBox = LatLngBounds.fromPoints(polygon.points);
@@ -51,7 +52,7 @@ class Polygon {
 
 class PolygonLayerWidget extends StatelessWidget {
   final PolygonLayerOptions options;
-  PolygonLayerWidget({@required this.options});
+  PolygonLayerWidget({@required this.options}) : super(key: options.key);
 
   @override
   Widget build(BuildContext context) {
@@ -65,7 +66,8 @@ class PolygonLayer extends StatelessWidget {
   final MapState map;
   final Stream stream;
 
-  PolygonLayer(this.polygonOpts, this.map, this.stream);
+  PolygonLayer(this.polygonOpts, this.map, this.stream)
+      : super(key: polygonOpts.key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -11,10 +11,11 @@ class PolylineLayerOptions extends LayerOptions {
   final bool polylineCulling;
 
   PolylineLayerOptions({
+    Key key,
     this.polylines = const [],
     this.polylineCulling = false,
     rebuild,
-  }) : super(rebuild: rebuild) {
+  }) : super(key: key, rebuild: rebuild) {
     if (polylineCulling) {
       for (var polyline in polylines) {
         polyline.boundingBox = LatLngBounds.fromPoints(polyline.points);
@@ -49,7 +50,7 @@ class Polyline {
 
 class PolylineLayerWidget extends StatelessWidget {
   final PolylineLayerOptions options;
-  PolylineLayerWidget({@required this.options});
+  PolylineLayerWidget({@required this.options}) : super(key: options.key);
 
   @override
   Widget build(BuildContext context) {
@@ -63,7 +64,8 @@ class PolylineLayer extends StatelessWidget {
   final MapState map;
   final Stream<Null> stream;
 
-  PolylineLayer(this.polylineOpts, this.map, this.stream);
+  PolylineLayer(this.polylineOpts, this.map, this.stream)
+      : super(key: polylineOpts.key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -455,8 +455,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
         ),
       )..listen(_update);
     }
-
-    super.initState();
   }
 
   @override

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -190,6 +190,7 @@ class TileLayerOptions extends LayerOptions {
   final ErrorTileCallBack errorTileCallback;
 
   TileLayerOptions({
+    Key key,
     this.urlTemplate,
     double tileSize = 256.0,
     double minZoom = 0.0,
@@ -246,7 +247,7 @@ class TileLayerOptions extends LayerOptions {
         tileSize = wmsOptions == null && retinaMode && maxZoom > 0.0
             ? (tileSize / 2.0).floorToDouble()
             : tileSize,
-        super(rebuild: rebuild);
+        super(key: key, rebuild: rebuild);
 }
 
 class WMSTileLayerOptions {
@@ -336,7 +337,7 @@ class WMSTileLayerOptions {
 class TileLayerWidget extends StatefulWidget {
   final TileLayerOptions options;
 
-  TileLayerWidget({@required this.options});
+  TileLayerWidget({@required this.options}) : super(key: options.key);
 
   @override
   State<StatefulWidget> createState() => _TileLayerWidgetState();
@@ -364,7 +365,7 @@ class TileLayer extends StatefulWidget {
     this.options,
     this.mapState,
     this.stream,
-  });
+  }) : super(key: options.key);
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -15,6 +15,7 @@ import 'package:positioned_tap_detector/positioned_tap_detector.dart';
 
 class FlutterMapState extends MapGestureMixin {
   final Key _layerStackKey = GlobalKey();
+  final Key _positionedTapDetector = GlobalKey();
   final MapControllerImpl mapController;
   final List<StreamGroup<Null>> groups = <StreamGroup<Null>>[];
   final _positionedTapController = PositionedTapController();
@@ -113,6 +114,7 @@ class FlutterMapState extends MapGestureMixin {
         mapRoot = layerStack;
       } else {
         mapRoot = PositionedTapDetector(
+          key: _positionedTapDetector,
           controller: _positionedTapController,
           onTap: handleTap,
           onLongPress: handleLongPress,

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -15,7 +15,7 @@ import 'package:positioned_tap_detector/positioned_tap_detector.dart';
 
 class FlutterMapState extends MapGestureMixin {
   final Key _layerStackKey = GlobalKey();
-  final Key _positionedTapDetector = GlobalKey();
+  final Key _positionedTapDetectorKey = GlobalKey();
   final MapControllerImpl mapController;
   final List<StreamGroup<Null>> groups = <StreamGroup<Null>>[];
   final _positionedTapController = PositionedTapController();
@@ -114,7 +114,7 @@ class FlutterMapState extends MapGestureMixin {
         mapRoot = layerStack;
       } else {
         mapRoot = PositionedTapDetector(
-          key: _positionedTapDetector,
+          key: _positionedTapDetectorKey,
           controller: _positionedTapController,
           onTap: handleTap,
           onLongPress: handleLongPress,

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:async/async.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/core/point.dart';
@@ -11,9 +12,9 @@ import 'package:flutter_map/src/map/map.dart';
 import 'package:flutter_map/src/map/map_state_widget.dart';
 import 'package:latlong/latlong.dart';
 import 'package:positioned_tap_detector/positioned_tap_detector.dart';
-import 'package:async/async.dart';
 
 class FlutterMapState extends MapGestureMixin {
+  final Key _layerStackKey = GlobalKey();
   final MapControllerImpl mapController;
   final List<StreamGroup<Null>> groups = <StreamGroup<Null>>[];
   final _positionedTapController = PositionedTapController();
@@ -97,6 +98,7 @@ class FlutterMapState extends MapGestureMixin {
       }
 
       var layerStack = Stack(
+        key: _layerStackKey,
         children: [
           ...widget.children ?? [],
           ...widget.layers.map(


### PR DESCRIPTION
This PR adds some key management feature for this project.
_Basicly keys preserve state when widgets move around in the widget tree._

There was two problems:
1. If I have forexample 3 `TileLayer layers` (`I.`, `II.`, `III.`) and if I swap `II.` and `III. widget layers` then `new II. layer` will have the `old II. layer's state` and `new III. layer` will have the `old III. layer's state` => so the loaded `_tiles` which are stored in state will have a hard time because it will show old tiles and panning will load new ones. If no keys provided then #584 PR will think url has been changed so the wrong `_tiles` will we reloaded, however this can avoided by using keys. This may happen forinstance if you want swap two wms layers.
2. In `flutter_map_state.dart` the `layerStack` may move around in widget tree which causes for statefull layers (forinstance `TileLayer`) to fully loose their states, this happens if map is `rotated` and/or `intercative property changes` so GlobalKey needed.