### PR TITLE
Add scrolling support

### DIFF
--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -18,6 +18,7 @@ export 'package:flutter_map/src/core/point.dart';
 export 'package:flutter_map/src/geo/crs/crs.dart';
 export 'package:flutter_map/src/geo/latlng_bounds.dart';
 export 'package:flutter_map/src/gestures/interactive_flag.dart';
+export 'package:flutter_map/src/gestures/latlng_tween.dart';
 export 'package:flutter_map/src/gestures/map_events.dart';
 export 'package:flutter_map/src/gestures/multi_finger_gesture.dart';
 export 'package:flutter_map/src/layer/circle_layer.dart';

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -86,6 +86,7 @@ class FlutterMapState extends MapGestureMixin {
           onPointerDown: savePointer,
           onPointerCancel: removePointer,
           onPointerUp: removePointer,
+          onPointerSignal: handlePointerSignal,
           child: PositionedTapDetector2(
             controller: _positionedTapController,
             onTap: handleTap,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,4 +27,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.9.0
-  mockito: ^4.1.4
+  mockito: ^5.0.9


### PR DESCRIPTION
A problem is that if scroll and the scroll again during the animation it first animates to the first location, but then animates to the second location which was during the animation.
I also noticed that the zoom and move animations have a little offset, but I think it's a flutter performance problem rather than one of this package.

fixes #660
fixes #820