### PR TITLE
Fix gray tiles when tile image is already avaible

### DIFF
--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -936,7 +936,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
 
   void _addTile(Coords<double> coords) {
     var tileCoordsToKey = _tileCoordsToKey(coords);
-    _tiles[tileCoordsToKey] = Tile(
+    var tile = _tiles[tileCoordsToKey] = Tile(
       coords: coords,
       coordsKey: tileCoordsToKey,
       tilePos: _getTilePos(coords),
@@ -946,6 +946,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
           options.tileProvider.getImage(_wrapCoords(coords), options),
       tileReady: _tileReady,
     );
+
+    tile.loadTileImage();
   }
 
   void _tileReady(Coords<double> coords, dynamic error, Tile tile) {
@@ -1078,9 +1080,7 @@ class Tile implements Comparable<Tile> {
     this.active = false,
     this.retain = false,
     this.loadError = false,
-  }) {
-    loadTileImage();
-  }
+  });
 
   void loadTileImage() {
     try {
@@ -1132,14 +1132,14 @@ class Tile implements Comparable<Tile> {
   void _tileOnLoad(ImageInfo imageInfo, bool synchronousCall) {
     if (null != tileReady) {
       this.imageInfo = imageInfo;
-      Timer.run(() => tileReady(coords, null, this));
+      tileReady(coords, null, this);
     }
   }
 
   void _tileOnError(dynamic exception, StackTrace stackTrace) {
     if (null != tileReady) {
-      Timer.run(() => tileReady(
-          coords, exception ?? 'Unknown exception during loadTileImage', this));
+      tileReady(
+          coords, exception ?? 'Unknown exception during loadTileImage', this);
     }
   }
 

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -1079,7 +1079,7 @@ class Tile implements Comparable<Tile> {
     this.retain = false,
     this.loadError = false,
   }) {
-    Timer.run(loadTileImage);
+    loadTileImage();
   }
 
   void loadTileImage() {
@@ -1132,14 +1132,14 @@ class Tile implements Comparable<Tile> {
   void _tileOnLoad(ImageInfo imageInfo, bool synchronousCall) {
     if (null != tileReady) {
       this.imageInfo = imageInfo;
-      tileReady(coords, null, this);
+      Timer.run(() => tileReady(coords, null, this));
     }
   }
 
   void _tileOnError(dynamic exception, StackTrace stackTrace) {
     if (null != tileReady) {
-      tileReady(
-          coords, exception ?? 'Unknown exception during loadTileImage', this);
+      Timer.run(() => tileReady(
+          coords, exception ?? 'Unknown exception during loadTileImage', this));
     }
   }
 

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -1079,7 +1079,7 @@ class Tile implements Comparable<Tile> {
     this.retain = false,
     this.loadError = false,
   }) {
-    loadTileImage();
+    Timer.run(loadTileImage);
   }
 
   void loadTileImage() {


### PR DESCRIPTION
Hello, this PR make sure the `loadTileImage`'s listeners runs after the `tile` is in `_tiles` map .

```dart
  /// Adds a listener callback that is called whenever a new concrete [ImageInfo]
  /// object is available or an error is reported. If a concrete image is
  /// already available, or if an error has been already reported, this object
  /// will notify the listener synchronously.
  ///
  /// If the [ImageStreamCompleter] completes multiple images over its lifetime,
  /// this listener's [ImageStreamListener.onImage] will fire multiple times.
  ///
  /// {@macro flutter.painting.imageStream.addListener}
  void addListener(ImageStreamListener listener) {
```

> If a concrete image is already available, or if an error has been already reported, this object will notify the listener synchronously.

Since this code:
```dart
var key = _tileCoordsToKey(coords);
tile = _tiles[key];
if (null == tile) {
  return;
}
```
skipped fade-in part, the tiles remained gray. This only happaned if `image object` was in phone's ram so there wasn't an async callback since `image` was instantly avaible, however this fix doesn't assume `async image load` anymore.

closes #707
closes #713
closes #636
closes #608