### PR TITLE
On Android: map loading in release build works now.

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -44,4 +44,5 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -45,4 +45,5 @@
             android:value="2" />
     </application>
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 </manifest>


### PR DESCRIPTION
I wanted to 'feel' the performance of the flutter_map on android, by release building the example. 
Then I discovered no maps were loaded due to the release app not having INTERNET permission. I added the permission in the AndroidManifest.xml of the release configuration.

Br
Carl.