### PR TITLE
Add pad function to LatLngBounds

### DIFF
--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -111,4 +111,12 @@ class LatLngBounds {
     }
     return true;
   }
+
+  void pad(double bufferRatio) {
+    var heightBuffer = (_sw.latitude - _ne.latitude).abs() * bufferRatio;
+    var widthBuffer = (_sw.longitude - _ne.longitude).abs() * bufferRatio;
+
+    _sw = LatLng(_sw.latitude - heightBuffer, _sw.longitude - widthBuffer);
+    _ne = LatLng(_ne.latitude + heightBuffer, _ne.longitude + widthBuffer);
+  }
 }


### PR DESCRIPTION
This PR is to add a pad function to the LatLngBounds class. The logic is based on Leaflet's pad function. This is useful when showing markers on the map with a bit of padding around the edges. Below are Leaflet's comments on the function.

// Returns bounds created by extending or retracting the current bounds by a given ratio in each direction.
// For example, a ratio of 0.5 extends the bounds by 50% in each direction.
// Negative values will retract the bounds.