### PR TITLE
Add a fastReplace option to TileLayerOptions.

### DIFF
--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -232,6 +232,11 @@ class TileLayerOptions extends LayerOptions {
   /// being temporarily visible), the old layer is removed as quickly as
   /// possible when this is set to `true` (default `false`).
   ///
+  /// This option is likely to cause some flickering of the transparent layer,
+  /// most noticeable when using pinch-to-zoom. It's best used with maps that
+  /// have `interactive` set to `false`, and zoom using buttons that call
+  /// `MapController.move()`.
+  ///
   /// When set to `true`, the `tileFadeIn*` options will be ignored.
   final bool fastReplace;
 


### PR DESCRIPTION
Based on [this comment](https://github.com/fleaflet/flutter_map/pull/572#issuecomment-610269536), this PR adds a `fastReplace` option to `TileLayerOptions`.

The purpose of this option is to force tiles to be removed as soon as their replacement tile is ready, skipping `tileFadeIn*` options, as well as the hardcoded delay in `_tileReady()`.

## Screenshots

These screenshots are based on [this config](https://github.com/pento/TidyWeather/blob/try/map-improvements/lib/cards/radar.dart#L71-L113): the top layer (the place names) uses transparent tiles.

### Before

Note how different zoom levels of the top layer are visible at the same time while zooming.

![](https://user-images.githubusercontent.com/352291/100535457-46779c00-326d-11eb-93fd-13fbe897aabb.gif)

### After

It no longer shows multiple zoom levels at the same time, though there is sometimes a small flicker where no tile is visible at all, even after the tiles have been cached. I'm happy to make adjustments if there's a way to avoid this, but otherwise, I think this is an improvement.

![](https://user-images.githubusercontent.com/352291/100535465-50999a80-326d-11eb-9612-5870b9422b29.gif)

