### PR TITLE
Better Offline Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,17 @@ Then execute `ulimit -S -n 2048` ([ref](https://github.com/trentpiercy/trace/iss
 Then execute `flutter run` with a running emulator.
 
 ## Offline maps
+Full offline map functionality has been created by JaffaKetchup. Use `PersistentAdvancedCacheTileProvider()` as the `TileLayerOptions > tileProvider` option, and set `TileLayerOptions > saveDir` to a variable containing (await) `getApplicationDocumentsDirectory()` from library [`path_provider`](https://pub.dev/packages/path_provider).
+
+As the user scrolls around the map, tiles will be saved to `[saveDir]/tiles`. Then, when requested again, tiles will be taken from that directory if available, else a network tile request will be made. Thus, this is a file first solution.
+
+This configuration should be used where offline functionality is required because cached tiles from other tile providers can be cleaned by the system without user notification at any point. With this setup, only the user (through App Settings > Storage > Clear Storage) or the app itself can clear the tiles. It is up to the app developer (you) to manage these tiles...
+
+If your user wants to get the latest tiles from the server for tiles already loaded, you must clear the tiles folder. If the user wishes to remove tiles altogether, you must provide that functionality. This library will not handle that for you.
+
+A recommended (however untested) integration is to use another tile provider (such as the default) whilst not in 'Offline Mode' so that the newest tiles are always loaded, then switch to this provider once the user enters 'Download & Offline Mode'. Then, when the user switches back out, clear the tiles folder.
+
+## Preconfigured maps (previously 'Offline maps')
 
 [Follow this guide to grab offline tiles](https://tilemill-project.github.io/tilemill/docs/guides/osm-bright-mac-quickstart/)<br>
 Once you have your map exported to `.mbtiles`, you can use [mbtilesToPng](https://github.com/alfanhui/mbtilesToPngs) to unpack into `/{z}/{x}/{y}.png`.

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -118,6 +118,11 @@ class TileLayerOptions extends LayerOptions {
   /// TileProvider
   ///
   final TileProvider tileProvider;
+  
+  // If using PersistentAdvancedCacheTileProvider()
+  // First set `final Directory saveDir = await getApplicationDocumentsDirectory();`
+  // Then pass to this option `saveDir.path`
+  final Directory saveDir;
 
   /// When panning the map, keep this many rows and columns of tiles before
   /// unloading them.
@@ -206,6 +211,7 @@ class TileLayerOptions extends LayerOptions {
     this.placeholderImage,
     this.errorImage,
     this.tileProvider = const CachedNetworkTileProvider(),
+    this.saveDir = false,
     this.tms = false,
     // ignore: avoid_init_to_null
     this.wmsOptions = null,

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -211,7 +211,7 @@ class TileLayerOptions extends LayerOptions {
     this.placeholderImage,
     this.errorImage,
     this.tileProvider = const CachedNetworkTileProvider(),
-    this.saveDir = false,
+    this.saveDir,
     this.tms = false,
     // ignore: avoid_init_to_null
     this.wmsOptions = null,

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -121,8 +121,7 @@ class TileLayerOptions extends LayerOptions {
   final TileProvider tileProvider;
   
   // If using PersistentAdvancedCacheTileProvider()
-  // First set `final Directory saveDir = await getApplicationDocumentsDirectory();`
-  // Then pass to this option `saveDir.path`
+  // Set this to: `await getApplicationDocumentsDirectory()`
   final Directory saveDir;
 
   /// When panning the map, keep this many rows and columns of tiles before

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math' as math;
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';

--- a/lib/src/layer/tile_provider/tile_provider.dart
+++ b/lib/src/layer/tile_provider/tile_provider.dart
@@ -103,7 +103,7 @@ class PersistentAdvancedCacheTileProvider extends TileProvider {
   @override
   ImageProvider getImage(Coords<num> coords, TileLayerOptions options) {
     final Directory _appDocDirFolder =
-        Directory(globals.saveDir.path + '/tiles/');
+        Directory(options.appDir + '/tiles/');
     if (!_appDocDirFolder.existsSync()) {
       _appDocDirFolder.createSync(recursive: true);
     }
@@ -111,7 +111,7 @@ class PersistentAdvancedCacheTileProvider extends TileProvider {
       url: getTileUrl(coords, options),
       file: File(
         p.join(
-            globals.saveDir.path + '/tiles/',
+            options.appDir + '/tiles/',
             getTileUrl(coords, options)
                 .replaceAll('https://', '')
                 .replaceAll('http://', '')

--- a/lib/src/layer/tile_provider/tile_provider.dart
+++ b/lib/src/layer/tile_provider/tile_provider.dart
@@ -103,7 +103,7 @@ class PersistentAdvancedCacheTileProvider extends TileProvider {
   @override
   ImageProvider getImage(Coords<num> coords, TileLayerOptions options) {
     final Directory _appDocDirFolder =
-        Directory(options.appDir + '/tiles/');
+        Directory(options.saveDir.path + '/tiles/');
     if (!_appDocDirFolder.existsSync()) {
       _appDocDirFolder.createSync(recursive: true);
     }
@@ -111,7 +111,7 @@ class PersistentAdvancedCacheTileProvider extends TileProvider {
       url: getTileUrl(coords, options),
       file: File(
         p.join(
-            options.appDir + '/tiles/',
+            options.saveDir.path + '/tiles/',
             getTileUrl(coords, options)
                 .replaceAll('https://', '')
                 .replaceAll('http://', '')

--- a/lib/src/layer/tile_provider/tile_provider.dart
+++ b/lib/src/layer/tile_provider/tile_provider.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+import 'package:network_to_file_image/network_to_file_image.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_image/network.dart';
@@ -93,6 +95,29 @@ class FileTileProvider extends TileProvider {
   @override
   ImageProvider getImage(Coords<num> coords, TileLayerOptions options) {
     return FileImage(File(getTileUrl(coords, options)));
+  }
+}
+
+class PersistentAdvancedCacheTileProvider extends TileProvider {
+  // Created by JaffaKetchup
+  @override
+  ImageProvider getImage(Coords<num> coords, TileLayerOptions options) {
+    final Directory _appDocDirFolder =
+        Directory(globals.saveDir.path + '/tiles/');
+    if (!_appDocDirFolder.existsSync()) {
+      _appDocDirFolder.createSync(recursive: true);
+    }
+    return NetworkToFileImage(
+      url: getTileUrl(coords, options),
+      file: File(
+        p.join(
+            globals.saveDir.path + '/tiles/',
+            getTileUrl(coords, options)
+                .replaceAll('https://', '')
+                .replaceAll('http://', '')
+                .replaceAll("/", "")),
+      ),
+    );
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,6 @@ dependencies:
   proj4dart: ^1.0.4
   meta: ^1.1.0
   network_to_file_image: ^2.3.6
-  path: ^1.7.0
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   vector_math: ^2.0.0
   proj4dart: ^1.0.4
   meta: ^1.1.0
+  network_to_file_image: ^2.3.6
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   proj4dart: ^1.0.4
   meta: ^1.1.0
   network_to_file_image: ^2.3.6
+  path: ^1.7.0
 
 dev_dependencies:
   pedantic: ^1.8.0


### PR DESCRIPTION
Hello,
As a follow up to issue #795, I have created this pull request. Please note the differentiation between existing caching solutions and this new solution: caches can be cleared without warning by the system, app storage can't.

I have added a new tile provider to be used as below:

> Use `PersistentAdvancedCacheTileProvider()` as the `TileLayerOptions > tileProvider` option, and set `TileLayerOptions > saveDir` to a variable containing (await) `getApplicationDocumentsDirectory()` from library [`path_provider`](https://pub.dev/packages/path_provider).
> 
> As the user scrolls around the map, tiles will be saved to `[saveDir]/tiles`. Then, when requested again, tiles will be taken from that directory if available, else a network tile request will be made. Thus, this is a file first solution.
> 
> This configuration should be used where offline functionality is required because cached tiles from other tile providers can be cleaned by the system without user notification at any point. With this setup, only the user (through App Settings > Storage > Clear Storage) or the app itself can clear the tiles. It is up to the app developer (you) to manage these tiles...
> 
> If your user wants to get the latest tiles from the server for tiles already loaded, you must clear the tiles folder. If the user wishes to remove tiles altogether, you must provide that functionality. This library will not handle that for you.
> 
> A recommended (however untested) integration is to use another tile provider (such as the default) whilst not in 'Offline Mode' so that the newest tiles are always loaded, then switch to this provider once the user enters 'Download & Offline Mode'. Then, when the user switches back out, clear the tiles folder.

This pull request adds one dependency. This PR has only been tested on an Android Pixel 3a emulator.

Thanks!
Luka S