### PR TITLE
Added support for custom templates in URL

### DIFF
--- a/lib/src/core/util.dart
+++ b/lib/src/core/util.dart
@@ -7,13 +7,13 @@ var _templateRe = RegExp(r'\{ *([\w_-]+) *\}');
 /// Replaces the templating placeholders with the provided data map.
 ///
 /// Throws an [Exception] if any placeholder remains unresolved.
-String template(String str, Map<String, String> data) {
+String template(String str, Map<String, dynamic> data) {
   return str.replaceAllMapped(_templateRe, (Match match) {
     var value = data[match.group(1)];
     if (value == null) {
       throw Exception('No value provided for variable ${match.group(1)}');
     } else {
-      return value;
+      return value.toString();
     }
   });
 }

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -16,7 +16,7 @@ import 'package:tuple/tuple.dart';
 import 'layer.dart';
 
 typedef TemplateFunction = String Function(
-    String str, Map<String, String> data);
+    String str, Map<String, dynamic> data);
 typedef ErrorTileCallBack = void Function(Tile tile, dynamic error);
 
 /// Describes the needed properties to create a tile-based layer. A tile is an
@@ -148,7 +148,7 @@ class TileLayerOptions extends LayerOptions {
   /// ),
   /// ```
   ///
-  final Map<String, String> additionalOptions;
+  final Map<String, dynamic> additionalOptions;
 
   /// Tiles will not update more than once every `updateInterval` (default 200
   /// milliseconds) when panning. It can be null (but it will calculating for
@@ -209,7 +209,7 @@ class TileLayerOptions extends LayerOptions {
     this.maxNativeZoom,
     this.zoomReverse = false,
     double zoomOffset = 0.0,
-    Map<String, String> additionalOptions,
+    Map<String, dynamic> additionalOptions,
     this.subdomains = const <String>[],
     this.keepBuffer = 2,
     this.backgroundColor = const Color(0xFFE0E0E0),
@@ -263,7 +263,7 @@ class TileLayerOptions extends LayerOptions {
         // copy additionalOptions Map if not null, so we can safely compare old
         // and new Map inside didUpdateWidget with MapEquality.
         additionalOptions = additionalOptions == null
-            ? const <String, String>{}
+            ? const <String, dynamic>{}
             : Map.from(additionalOptions),
         super(key: key, rebuild: rebuild);
 }

--- a/lib/src/layer/tile_provider/tile_provider.dart
+++ b/lib/src/layer/tile_provider/tile_provider.dart
@@ -17,19 +17,18 @@ abstract class TileProvider {
             .getUrl(coords, options.tileSize.toInt(), options.retinaMode)
         : options.urlTemplate;
 
-    var z = _getZoomForUrl(coords, options);
+    final x = coords.x.round();
+    final y = coords.y.round();
+    final z = _getZoomForUrl(coords, options).round();
 
-    var data = <String, String>{
-      'x': coords.x.round().toString(),
-      'y': coords.y.round().toString(),
-      'z': z.round().toString(),
+    var data = <String, dynamic>{
+      'x': x,
+      'y': options.tms ? invertY(y, z) : y,
+      'z': z,
       's': getSubdomain(coords, options),
       'r': '@2x',
     };
-    if (options.tms) {
-      data['y'] = invertY(coords.y.round(), z.round()).toString();
-    }
-    var allOpts = Map<String, String>.from(data)
+    var allOpts = Map<String, dynamic>.from(data)
       ..addAll(options.additionalOptions);
     return options.templateFunction(urlTemplate, allOpts);
   }


### PR DESCRIPTION
I added support for sprintf templates inside urls. For example, you can use templates like this:
`http://example.com/{x:%08i}/{y:%08i}/{z:%02i} `
When replacing the number 1,2,3, the sample will be parsed as:
`http://example.com/00000001/00000002/03`
I need functionality to work with our corporate tile server, but I think it might be useful for someone else as well.
