### PR TITLE
Listing flutter_map_floating_marker_titles under Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Note that there is also `FileTileProvider()`, which you can use to load tiles fr
 - [lat_lon_grid_plugin](https://github.com/mat8854/lat_lon_grid_plugin): Adds a latitude / longitude grid as plugin to the FlutterMap
 - [flutter_map_marker_popup](https://github.com/rorystephenson/flutter_map_marker_popup): A plugin to show customisable popups for markers.
 - [map_elevation](https://github.com/OwnWeb/map_elevation): A widget to display elevation of a track (polyline) like Leaflet.Elevation
+- [flutter_map_floating_marker_titles](https://github.com/androidseb/flutter_map_floating_marker_titles): Displaying floating marker titles on the map view
 
 ## Roadmap
 


### PR DESCRIPTION
Hello,

Thanks for the great project! I have built this floating marker titles library for flutter, and flutter_map's code helped me a lot with that.

I'm hoping to give back by bringing value to your library by adding this feature, and I thought the best way to introduce this was with this PR, please let me know if there is a better way.

I hope this helps :-)