### PR TITLE
Add deprecated flags to constructor parameters

### DIFF
--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -266,8 +266,8 @@ class MapOptions {
         MultiFingerGesture.pinchZoom | MultiFingerGesture.pinchMove,
     this.minZoom,
     this.maxZoom,
-    this.debug = false,
-    this.interactive,
+    @Deprecated('') this.debug = false,
+    @Deprecated('Use interactiveFlags instead') this.interactive,
     // TODO: Change when [interactive] is removed.
     // Change this to [this.interactiveFlags = InteractiveFlag.all] and remove
     // [interactiveFlags] from initializer list


### PR DESCRIPTION
Added two missing `@deprecated` flags to the `MapOptions` constructor (debug and interactive props) to warn the developers in their source code about the deprecation.