### PR TITLE
Prevent crash when move() is called before FlutterMap has been built

### DIFF
--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -133,7 +133,7 @@ class MapState {
   // Extended size of the map where rotation is calculated
   CustomPoint _size;
 
-  CustomPoint get size => _size;
+  CustomPoint get size => _size ?? CustomPoint(0.0, 0.0);
 
   void _updateSizeByOriginalSizeAndRotation() {
     final originalWidth = _originalSize.x;


### PR DESCRIPTION
If size has never been computed before `move()` is called on a `MapController` instance, there is a crash:

```
E/flutter (20522): [ERROR:flutter/lib/ui/ui_dart_state.cc(177)] Unhandled Exception: NoSuchMethodError: The method &#039;/&#039; was called on null.
E/flutter (20522): Receiver: null
E/flutter (20522): Tried calling: /(2.0)
E/flutter (20522): #0      Object.noSuchMethod (dart:core-patch/object_patch.dart:51:5)
E/flutter (20522): #1      MapState.getPixelBounds (package:flutter_map/src/map/map.dart:464:25)
package:flutter_map/…/map/map.dart:464
E/flutter (16529): #2      MapState.move
package:flutter_map/…/map/map.dart:307
E/flutter (16529): #3      MapControllerImpl.move
package:flutter_map/…/map/map.dart:41
E/flutter (16529): #4      MapAltState.initState.<anonymous closure>
```

`MapController` has a `ready` state, but it can be ready and the map not built yet. 