### PR TITLE
Fix for Zoom-value outside min/maxZoom when changing BaseMap

### DIFF
--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -460,19 +460,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       reloadTiles = true;
     }
 
-    var maxTileZoomValue = 1.0;
-    var minTileZoomValue = 20.0;
-    for (var tile in _tiles.values) {
-      if (tile.level.zoom > maxTileZoomValue) {
-        maxTileZoomValue = tile.level.zoom;
-      }
-      if (tile.level.zoom < maxTileZoomValue) {
-        minTileZoomValue = tile.level.zoom;
-      }
-    }
-    if (maxTileZoomValue > options.maxZoom || minTileZoomValue < options.minZoom) {
-      reloadTiles=true;
-    }
+    reloadTiles |= _isZoomOutsideMinMax();
+
 
     if (oldWidget.options.updateInterval != options.updateInterval) {
       _throttleUpdate?.close();
@@ -506,6 +495,15 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       _resetView();
       _update(null);
     }
+  }
+
+  bool _isZoomOutsideMinMax() {
+    for (var tile in _tiles.values) {
+      if (tile.level.zoom > (options.maxZoom ?? 1.0) || tile.level.zoom < (options.minZoom ?? 20.0)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   void _initThrottleUpdate() {

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -460,6 +460,20 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       reloadTiles = true;
     }
 
+    var maxTileZoomValue = 1.0;
+    var minTileZoomValue = 20.0;
+    for (var tile in _tiles.values) {
+      if (tile.level.zoom > maxTileZoomValue) {
+        maxTileZoomValue = tile.level.zoom;
+      }
+      if (tile.level.zoom < maxTileZoomValue) {
+        minTileZoomValue = tile.level.zoom;
+      }
+    }
+    if (maxTileZoomValue > options.maxZoom || minTileZoomValue < options.minZoom) {
+      reloadTiles=true;
+    }
+
     if (oldWidget.options.updateInterval != options.updateInterval) {
       _throttleUpdate?.close();
       _initThrottleUpdate();


### PR DESCRIPTION
The fix will iterate through the current tiles and check if any of them are outside the minZoom and maxZoom-values of the new BaseMap-layer. If so, it will stop flutter_map from trying to replace old tiles with the corresponding tiles from the new BaseMap.