### PR TITLE
Add Caching Implementations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,45 @@ child: FlutterMap(
 
 For more details visit [Custom CRS demo page](./example/lib/pages/custom_crs/Readme.md).
 
+### How to Cache Tiles (Custom TileProvider)
+
+1. Using Flutter's NetworkImage:
+Flutter has a built in ImageProvider (NetworkImage) that caches images in memory until an app restart.
+```dart
+class CachedTileProvider extends TileProvider {
+  const CachedTileProvider();
+  @override
+  ImageProvider getImage(Coords<num> coords, TileLayerOptions options) {
+    return NetworkImage(getTileUrl(coords, options));
+  }
+}
+```
+
+2. Using the `cached_network_image` dependency:
+This dependency has an ImageProvider that caches to disk which means the cache persists through an app restart.
+```dart
+import 'package:cached_network_image/cached_network_image.dart';
+
+class CachedTileProvider extends TileProvider {
+  const CachedTileProvider();
+  @override
+  ImageProvider getImage(Coords<num> coords, TileLayerOptions options) {
+    return CachedNetworkImageProvider(
+      getTileUrl(coords, options),
+      //Now you can set options that determine how the image gets cached via whichever plugin you use.
+    );
+  }
+}
+```
+
+Lastly we need to add the CachedTileProvider TileProvider to TileLayerOptions
+```dart
+TileLayerOptions(
+  urlTemplate: 'https://example.com/{x}/{y}/{z}',
+  tileProvider: const CachedTileProvider()
+)
+```
+
 ## Run the example
 
 See the `example/` folder for a working example app.


### PR DESCRIPTION
Added recommended caching implementations for developers to use in readme (since flutter_map does not natively provide caching to reduce dependency requirements and since caching is such a use-case specific thing); **however** caching can be easily implemented with flutter_map using any Flutter ImageProvider that caches. This gives the app developer more control and reduces flutter_map maintainer load. Adding this to the readme will also lower the amount of Issues and PRs that add caching in many different ways when it should be handled by the developer.

Issues that this should close:
Fixes #832
Fixes #649
Fixes #576 (This issue will not be relevant to this repo and might still exist depending on ImageProvider)
Fixes #752 
Fixes #748 (Issue will not be relevant to this repo and still might exist depending on ImageProvider)
Fixes #614 (I think they just did not set up their URL correctly; but this should be closed)
Fixes #402 (Not relevant anymore)

Issues that this could close:
#631 (The issue should be modified or closed)

Here are PRs: that should close:
Fixes #564 (PR adds sqlite dependency and attempts to add caching TileProvider. This should be done as a plugin or developers should use an existing caching image provider)
