### PR TITLE
update dependency of tuple package from ^1.0.2 to ^2.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tuple: ^1.0.2
+  tuple: ^2.0.0
   latlong2: ^0.8.0
   positioned_tap_detector_2: ^1.0.0
   transparent_image: ^1.0.0


### PR DESCRIPTION
```tuple: ^1.0.2``` is causing dependency conflicts in my application which can be solved by updating to ```tuple: ^2.0.0```.
The [changelogs](https://pub.dev/packages/tuple/changelog) of the tuple package suggest that there were no breaking changes, so I decided to updated the package in ```flutter_map``` to ```tuple: ^2.0.0```. 
