### PR TITLE
Fix #856: Polyline border drawing

### DIFF
--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -174,7 +174,7 @@ class PolylinePainter extends CustomPainter {
     if (polylineOpt.isDotted) {
       var spacing = polylineOpt.strokeWidth * 1.5;
       canvas.saveLayer(rect, Paint());
-      if (borderPaint != null) {
+      if (borderPaint != null && filterPaint != null) {
         _paintDottedLine(
             canvas, polylineOpt.offsets, borderRadius, spacing, borderPaint);
         _paintDottedLine(
@@ -185,12 +185,10 @@ class PolylinePainter extends CustomPainter {
     } else {
       paint.style = PaintingStyle.stroke;
       canvas.saveLayer(rect, Paint());
-      if (borderPaint != null) {
-        if (filterPaint != null) {
-          filterPaint.style = PaintingStyle.stroke;
-          _paintLine(canvas, polylineOpt.offsets, borderPaint);
-        }
-        borderPaint?.style = PaintingStyle.stroke;
+      if (borderPaint != null && filterPaint != null) {
+        borderPaint.style = PaintingStyle.stroke;
+        _paintLine(canvas, polylineOpt.offsets, borderPaint);
+        filterPaint.style = PaintingStyle.stroke;
         _paintLine(canvas, polylineOpt.offsets, filterPaint);
       }
       _paintLine(canvas, polylineOpt.offsets, paint);


### PR DESCRIPTION
Fix for Issue #856 
This fix Polyline border drawing bug introduced in version 0.11.0 PR #766 .
Causing the bug was that `borderPaint.style = PaintingStyle.stroke` was set after the drawing line `_paintLine(...,borderPaint)`, which made the drawing use the default `PaintingStyle.fill` causing the border to create a filled shape.
https://github.com/fleaflet/flutter_map/blob/e8389e13083839a9f854bba2239d91f475940eaa/lib/src/layer/polyline_layer.dart#L188-L195
Reordering the style set statement before the `_paintLine(...)` statement fixed the bug.

![flutter_map](https://user-images.githubusercontent.com/29988012/112743352-e254b280-8f96-11eb-8936-e0e785f723b8.JPG)

