### PR TITLE
Update map fling spring physics parameters to reduce initial acceleration

### DIFF
--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -491,7 +491,13 @@ abstract class MapGestureMixin extends State<FlutterMap>
 
     _flingController
       ..value = 0.0
-      ..fling(velocity: magnitude / 1000.0);
+      ..fling(
+          velocity: magnitude / 1000.0,
+          springDescription: SpringDescription.withDampingRatio(
+            mass: 1.0,
+            stiffness: 1000.0,
+            ratio: 5.0,
+          ));
   }
 
   void handleTap(TapPosition position) {

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -8,6 +8,7 @@ import 'package:flutter_map/src/gestures/latlng_tween.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:positioned_tap_detector_2/positioned_tap_detector_2.dart';
+import 'package:flutter/physics.dart';
 
 abstract class MapGestureMixin extends State<FlutterMap>
     with TickerProviderStateMixin {


### PR DESCRIPTION
This change fixes the fling acceleration issue reported in #271.

The initial rapid acceleration appears to be due to the spring physics being critically dampened. I changed the default to be over damped and tweaked it by manually comparing it to google and apple maps and now it's smoother.

Reference: [SpringDescription.withDampingRatio constructor
](https://api.flutter.dev/flutter/physics/SpringDescription/SpringDescription.withDampingRatio.html)