### PR TITLE
Upgraded dependencies and accordingly migrated code

### DIFF
--- a/example/lib/pages/custom_crs/custom_crs.dart
+++ b/example/lib/pages/custom_crs/custom_crs.dart
@@ -32,12 +32,12 @@ class _CustomCrsPageState extends State<CustomCrsPage> {
     super.initState();
 
     // EPSG:4326 is a predefined projection ships with proj4dart
-    epsg4326 = proj4.Projection('EPSG:4326');
+    epsg4326 = proj4.Projection.get('EPSG:4326');
 
     // EPSG:3413 is a user-defined projection from a valid Proj4 definition string
     // From: http://epsg.io/3413, proj definition: http://epsg.io/3413.proj4
     // Find Projection by name or define it if not exists
-    epsg3413 = proj4.Projection('EPSG:3413') ??
+    epsg3413 = proj4.Projection.get('EPSG:3413') ??
         proj4.Projection.add('EPSG:3413',
             '+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs');
 

--- a/example/lib/pages/live_location.dart
+++ b/example/lib/pages/live_location.dart
@@ -35,7 +35,7 @@ class _LiveLocationPageState extends State<LiveLocationPage> {
 
   void initLocationService() async {
     await _locationService.changeSettings(
-      accuracy: LocationAccuracy.HIGH,
+      accuracy: LocationAccuracy.high,
       interval: 1000,
     );
 
@@ -48,13 +48,12 @@ class _LiveLocationPageState extends State<LiveLocationPage> {
 
       if (serviceEnabled) {
         var permission = await _locationService.requestPermission();
-        _permission = permission == PermissionStatus.GRANTED;
+        _permission = permission == PermissionStatus.granted;
 
         if (_permission) {
           location = await _locationService.getLocation();
           _currentLocation = location;
-          _locationService
-              .onLocationChanged()
+          _locationService.onLocationChanged
               .listen((LocationData result) async {
             if (mounted) {
               setState(() {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter_map:
     path: ../
-  location: ^2.5.0
+  location: ^4.1.1
 
 dev_dependencies:
   pedantic: ^1.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,21 +10,21 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tuple: ^1.0.2
+  tuple: ^2.0.0
   latlong2: ^0.8.0
   positioned_tap_detector_2: ^1.0.0
-  transparent_image: ^1.0.0
-  async: ^2.1.0
+  transparent_image: ^2.0.0
+  async: ^2.5.0
   flutter_image: ^3.0.0
-  vector_math: ^2.0.0
-  proj4dart: ^1.0.4
-  meta: ^1.1.0
-  collection: ^1.14.0
+  vector_math: ^2.1.0
+  proj4dart: ^2.0.0
+  meta: ^1.3.0
+  collection: ^1.15.0
 
 dev_dependencies:
   pedantic: ^1.11.0
-  location: ^2.5.0
+  location: ^4.1.1
   flutter_test:
     sdk: flutter
-  test: ^1.9.0
-  mockito: ^4.1.4
+  test: ^1.16.0 # due to recent dependency updates, an older version is used here
+  mockito: ^5.0.5


### PR DESCRIPTION
Updated some dependencies to their current versions as some dependencies were referring to outdated major versions.

Major versions updated and working:
- [x] `tuple` - not breaking
- [x] `trasparent_image` - not breaking
- [x] `proj4dart` - migrated
- [x] `location` - migrated
- [x] `mockito` - not breaking

Minor dependencies updated:
- `async`
- `vector_math`
- `meta`
- `collection`
- `test` - not updated to most recent version as this would break other dependencies