### PR TITLE
Add a key for markers to preserve state

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,6 +19,7 @@ import './pages/plugin_scalebar.dart';
 import './pages/plugin_zoombuttons.dart';
 import './pages/polyline.dart';
 import './pages/sliding_map.dart';
+import './pages/stateful_markers.dart';
 import './pages/tap_to_add.dart';
 import './pages/tile_builder_example.dart';
 import './pages/tile_loading_error_handle.dart';
@@ -64,6 +65,7 @@ class MyApp extends StatelessWidget {
         TileBuilderPage.route: (context) => TileBuilderPage(),
         InteractiveTestPage.route: (context) => InteractiveTestPage(),
         ManyMarkersPage.route: (context) => ManyMarkersPage(),
+        StatefulMarkersPage.route: (context) => StatefulMarkersPage(),
       },
     );
   }

--- a/example/lib/pages/stateful_markers.dart
+++ b/example/lib/pages/stateful_markers.dart
@@ -1,0 +1,130 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../widgets/drawer.dart';
+
+class StatefulMarkersPage extends StatefulWidget {
+  static const String route = '/stateful_markers';
+
+  @override
+  _StatefulMarkersPageState createState() => _StatefulMarkersPageState();
+}
+
+class _StatefulMarkersPageState extends State<StatefulMarkersPage> {
+  List<Marker> _markers;
+  final Random _random = Random();
+
+  @override
+  void initState() {
+    super.initState();
+    _markers = [];
+    _addMarker('key1');
+    _addMarker('key2');
+    _addMarker('key3');
+    _addMarker('key4');
+    _addMarker('key5');
+    _addMarker('key6');
+    _addMarker('key7');
+    _addMarker('key8');
+    _addMarker('key9');
+    _addMarker('key10');
+  }
+
+  void _addMarker(String key) {
+    _markers.add(Marker(
+        width: 40.0,
+        height: 40.0,
+        point: LatLng(
+            _random.nextDouble() * 10 + 48, _random.nextDouble() * 10 - 6),
+        builder: (ctx) => _ColorMarker(),
+        key: ValueKey(key)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Stateful Markers')),
+      drawer: buildDrawer(context, StatefulMarkersPage.route),
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Text('This is a map that is showing (51.5, -0.9).'),
+            ),
+            Flexible(
+              child: FlutterMap(
+                options: MapOptions(
+                  center: LatLng(51.5, -0.09),
+                  zoom: 5.0,
+                ),
+                layers: [
+                  TileLayerOptions(
+                    urlTemplate:
+                        'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    subdomains: ['a', 'b', 'c'],
+                    // For example purposes. It is recommended to use
+                    // TileProvider with a caching and retry strategy, like
+                    // NetworkTileProvider or CachedNetworkTileProvider
+                    tileProvider: NonCachingNetworkTileProvider(),
+                  ),
+                  MarkerLayerOptions(markers: _markers)
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ColorMarker extends StatefulWidget {
+  _ColorMarker({Key key}) : super(key: key);
+
+  @override
+  _ColorMarkerState createState() => _ColorMarkerState();
+}
+
+class _ColorMarkerState extends State<_ColorMarker> {
+  Color color;
+
+  @override
+  void initState() {
+    super.initState();
+    color = _ColorGenerator.getColor();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(color: color);
+  }
+}
+
+class _ColorGenerator {
+  static List colorOptions = [
+    Colors.blue,
+    Colors.red,
+    Colors.green,
+    Colors.yellow,
+    Colors.purple,
+    Colors.orange,
+    Colors.indigo,
+    Colors.amber,
+    Colors.black,
+    Colors.white,
+    Colors.brown,
+    Colors.pink,
+    Colors.cyan
+  ];
+
+  static final Random _random = Random();
+
+  static Color getColor() {
+    return colorOptions[_random.nextInt(colorOptions.length)];
+  }
+}

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -20,6 +20,7 @@ import '../pages/plugin_scalebar.dart';
 import '../pages/plugin_zoombuttons.dart';
 import '../pages/polyline.dart';
 import '../pages/sliding_map.dart';
+import '../pages/stateful_markers.dart';
 import '../pages/tap_to_add.dart';
 import '../pages/tile_builder_example.dart';
 import '../pages/tile_loading_error_handle.dart';
@@ -202,6 +203,12 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           onTap: () {
             Navigator.pushReplacementNamed(context, ManyMarkersPage.route);
           },
+        ),
+        _buildMenuItem(
+          context,
+          const Text('Stateful markers'),
+          StatefulMarkersPage.route,
+          currentRoute,
         )
       ],
     ),

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -105,6 +105,7 @@ enum AnchorAlign {
 class Marker {
   final LatLng point;
   final WidgetBuilder builder;
+  final Key key;
   final double width;
   final double height;
   final Anchor anchor;
@@ -136,6 +137,7 @@ class Marker {
   Marker({
     this.point,
     this.builder,
+    this.key,
     this.width = 30.0,
     this.height = 30.0,
     this.rotate,
@@ -239,6 +241,7 @@ class _MarkerLayerState extends State<MarkerLayer> {
 
           markers.add(
             Positioned(
+              key: marker.key,
               width: marker.width,
               height: marker.height,
               left: pos.x - width,


### PR DESCRIPTION
Fix issue https://github.com/fleaflet/flutter_map/issues/885 which prevent from preserving markers state.

A key was added to the `Marker` and used for the top level widget in the markers layer (the `Positioned`). This ensure that even if some markers are added / removed from the map, the `Stack` element is able to find the corresponding widget and then preserve its state instead of recreating a new one.