### PR TITLE
fix Group Layer Options constructor wrong nullability

### DIFF
--- a/lib/src/layer/group_layer.dart
+++ b/lib/src/layer/group_layer.dart
@@ -7,9 +7,9 @@ class GroupLayerOptions extends LayerOptions {
   List<LayerOptions> group = <LayerOptions>[];
 
   GroupLayerOptions({
-    required Key key,
-    required this.group,
-    required Stream<Null> rebuild,
+    Key? key,
+    this.group = const [],
+    Stream<Null>? rebuild,
   }) : super(key: key, rebuild: rebuild);
 }
 


### PR DESCRIPTION
All other `LayerOptions` constructor accept null key and null rebuild, `GroupLayerOptions` should also accept.