### PR TITLE
fix : mapController.moveAndRotate with null id

### DIFF
--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -33,7 +33,7 @@ class MapControllerImpl implements MapController {
   MoveAndRotateResult moveAndRotate(LatLng center, double zoom, double degree,
       {String? id}) {
     return _state.moveAndRotate(center, zoom, degree,
-        source: MapEventSource.mapController, id: id!);
+        source: MapEventSource.mapController, id: id as String);
   }
 
   @override


### PR DESCRIPTION
The id variable in the mapController moveAndRotate function is declared as nullable, but a null check is applied. This causes the function to not work if it is called without the optional id field.

Suggest casting the String? to a String type to allow the null id value to be used.