### PR TITLE
feat(LatLngBounds): Center LatLng getter

### DIFF
--- a/example/lib/pages/scale_layer_plugin_option.dart
+++ b/example/lib/pages/scale_layer_plugin_option.dart
@@ -28,7 +28,7 @@ class ScaleLayerPlugin implements MapPlugin {
   Widget createLayer(
       LayerOptions options, MapState mapState, Stream<Null> stream) {
     if (options is ScaleLayerPluginOption) {
-      return ScaleLayer(options, mapState, stream);
+      return ScaleLayerWidget(options, mapState);
     }
     throw Exception('Unknown options type for ScaleLayerPlugin: $options');
   }
@@ -39,10 +39,25 @@ class ScaleLayerPlugin implements MapPlugin {
   }
 }
 
+class ScaleLayerWidget extends StatelessWidget {
+  final ScaleLayerPluginOption scaleLayerOpts;
+  final MapState map;
+  ScaleLayerWidget(this.scaleLayerOpts, this.map)
+      : super(key: scaleLayerOpts.key);
+  @override
+  Widget build(BuildContext context) {
+    final mapState = MapState.maybeOf(context);
+    return StreamBuilder<void>(
+        stream: mapState?.onMoved,
+        builder: (BuildContext context, _) {
+          return ScaleLayer(scaleLayerOpts, map);
+        });
+  }
+}
+
 class ScaleLayer extends StatelessWidget {
   final ScaleLayerPluginOption scaleLayerOpts;
   final MapState map;
-  final Stream<Null> stream;
   final scale = [
     25000000,
     15000000,
@@ -69,8 +84,7 @@ class ScaleLayer extends StatelessWidget {
     5
   ];
 
-  ScaleLayer(this.scaleLayerOpts, this.map, this.stream)
-      : super(key: scaleLayerOpts.key);
+  ScaleLayer(this.scaleLayerOpts, this.map) : super(key: scaleLayerOpts.key);
 
   @override
   Widget build(BuildContext context) {
@@ -86,15 +100,19 @@ class ScaleLayer extends StatelessWidget {
         : '${distance.toStringAsFixed(0)} m';
     var width = (end.x - (start.x as double));
 
-    return CustomPaint(
-      painter: ScalePainter(
-        width,
-        displayDistance,
-        lineColor: scaleLayerOpts.lineColor,
-        lineWidth: scaleLayerOpts.lineWidth,
-        padding: scaleLayerOpts.padding,
-        textStyle: scaleLayerOpts.textStyle,
-      ),
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints bc) {
+        return CustomPaint(
+          painter: ScalePainter(
+            width,
+            displayDistance,
+            lineColor: scaleLayerOpts.lineColor,
+            lineWidth: scaleLayerOpts.lineWidth,
+            padding: scaleLayerOpts.padding,
+            textStyle: scaleLayerOpts.textStyle,
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -77,6 +77,33 @@ class LatLngBounds {
   LatLng get northWest => LatLng(north, west);
   LatLng get southEast => LatLng(south, east);
 
+  LatLng get center {
+    /// https://stackoverflow.com/a/4656937
+    /// http://www.movable-type.co.uk/scripts/latlong.html
+    ///
+    /// coord 1: southWest
+    /// coord 2: northEast
+    ///
+    /// phi: lat
+    /// lambda: lng
+
+    var phi1 = southWest!.latitudeInRad;
+    var lambda1 = southWest!.longitudeInRad;
+    var phi2 = northEast!.latitudeInRad;
+
+    var dLambda = degToRadian(northEast!.longitude -
+        southWest!.longitude); // delta lambda = lambda2-lambda1
+
+    var Bx = math.cos(phi2) * math.cos(dLambda);
+    var By = math.cos(phi2) * math.sin(dLambda);
+    var phi3 = math.atan2(math.sin(phi1) + math.sin(phi2),
+        math.sqrt((math.cos(phi1) + Bx) * (math.cos(phi1) + Bx) + By * By));
+    var lambda3 = lambda1 + math.atan2(By, math.cos(phi1) + Bx);
+
+    //phi3 and lambda3 are actually in radians and LatLng wants degrees
+    return LatLng(radianToDeg(phi3), radianToDeg(lambda3));
+  }
+
   bool get isValid {
     return _sw != null && _ne != null;
   }

--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -94,11 +94,11 @@ class LatLngBounds {
     var dLambda = degToRadian(northEast!.longitude -
         southWest!.longitude); // delta lambda = lambda2-lambda1
 
-    var Bx = math.cos(phi2) * math.cos(dLambda);
-    var By = math.cos(phi2) * math.sin(dLambda);
+    var bx = math.cos(phi2) * math.cos(dLambda);
+    var by = math.cos(phi2) * math.sin(dLambda);
     var phi3 = math.atan2(math.sin(phi1) + math.sin(phi2),
-        math.sqrt((math.cos(phi1) + Bx) * (math.cos(phi1) + Bx) + By * By));
-    var lambda3 = lambda1 + math.atan2(By, math.cos(phi1) + Bx);
+        math.sqrt((math.cos(phi1) + bx) * (math.cos(phi1) + bx) + by * by));
+    var lambda3 = lambda1 + math.atan2(by, math.cos(phi1) + bx);
 
     //phi3 and lambda3 are actually in radians and LatLng wants degrees
     return LatLng(radianToDeg(phi3), radianToDeg(lambda3));


### PR DESCRIPTION
A `LatLngBounds` object can now return its center midpoint.

Example usage:
```dart
var bounds = LatLngBounds.fromPoints([LatLng(1, 1), LatLng(0, -1)]);
print(bounds.center);
// LatLng(latitude:0.500076, longitude:-0.000076)
```

[The resource used for the maths](http://www.movable-type.co.uk/scripts/latlong.html)