### PR TITLE
Added TapPosition to TapCallback

### DIFF
--- a/example/lib/pages/custom_crs/custom_crs.dart
+++ b/example/lib/pages/custom_crs/custom_crs.dart
@@ -132,7 +132,7 @@ class _CustomCrsPageState extends State<CustomCrsPage> {
                   // Set maxZoom usually scales.length - 1 OR resolutions.length - 1
                   // but not greater
                   maxZoom: maxZoom,
-                  onTap: (p) => setState(() {
+                  onTap: (tapPosition, p) => setState(() {
                     initText = 'You clicked at';
                     point = proj4.Point(x: p.latitude, y: p.longitude);
                   }),

--- a/example/lib/pages/tap_to_add.dart
+++ b/example/lib/pages/tap_to_add.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:positioned_tap_detector_2/positioned_tap_detector_2.dart';
 
 import '../widgets/drawer.dart';
 
@@ -61,7 +62,7 @@ class TapToAddPageState extends State<TapToAddPage> {
     );
   }
 
-  void _handleTap(LatLng latlng) {
+  void _handleTap(TapPosition tapPosition, LatLng latlng) {
     setState(() {
       tappedPoints.add(latlng);
     });

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -138,8 +138,8 @@ abstract class MapController {
   factory MapController() => MapControllerImpl();
 }
 
-typedef TapCallback = void Function(TapPosition position, LatLng point);
-typedef LongPressCallback = void Function(TapPosition position, LatLng point);
+typedef TapCallback = void Function(TapPosition tapPosition, LatLng point);
+typedef LongPressCallback = void Function(TapPosition tapPosition, LatLng point);
 typedef PositionCallback = void Function(MapPosition position, bool hasGesture);
 typedef MapCreatedCallback = void Function(MapController mapController);
 

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -139,7 +139,8 @@ abstract class MapController {
 }
 
 typedef TapCallback = void Function(TapPosition tapPosition, LatLng point);
-typedef LongPressCallback = void Function(TapPosition tapPosition, LatLng point);
+typedef LongPressCallback = void Function(
+    TapPosition tapPosition, LatLng point);
 typedef PositionCallback = void Function(MapPosition position, bool hasGesture);
 typedef MapCreatedCallback = void Function(MapController mapController);
 

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -13,6 +13,7 @@ import 'package:flutter_map/src/map/flutter_map_state.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:flutter_map/src/plugins/plugin.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:positioned_tap_detector_2/positioned_tap_detector_2.dart';
 
 export 'package:flutter_map/src/core/point.dart';
 export 'package:flutter_map/src/geo/crs/crs.dart';
@@ -137,8 +138,8 @@ abstract class MapController {
   factory MapController() => MapControllerImpl();
 }
 
-typedef TapCallback = void Function(LatLng point);
-typedef LongPressCallback = void Function(LatLng point);
+typedef TapCallback = void Function(TapPosition position, LatLng point);
+typedef LongPressCallback = void Function(TapPosition position, LatLng point);
 typedef PositionCallback = void Function(MapPosition position, bool hasGesture);
 typedef MapCreatedCallback = void Function(MapController mapController);
 

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -510,7 +510,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
     final latlng = _offsetToCrs(position.relative!);
     if (options.onTap != null) {
       // emit the event
-      options.onTap!(latlng);
+      options.onTap!(position, latlng);
     }
 
     mapState.emitMapEvent(
@@ -532,7 +532,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
     final latlng = _offsetToCrs(position.relative!);
     if (options.onLongPress != null) {
       // emit the event
-      options.onLongPress!(latlng);
+      options.onLongPress!(position, latlng);
     }
 
     mapState.emitMapEvent(


### PR DESCRIPTION
This PR added the Screens TapPosition to the onTap Callback. 

When using an interactive WFS Service that handles Click/Touch Inputs you need to pass the Screen Position to Pressed to the Service, not the LatLong point.
If you use a separate GestureDetector stacked on top of FlutterMap it interferes with its Gestures (like Pan oder Pinch). This PR exposes the TapPosition from FlutterMaps own GestureDetector.

Related to https://github.com/fleaflet/flutter_map/issues/706