### PR TITLE
Use default values from MapOptions before MapController is ready

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - Flutter (1.0.0)
+  - location (0.0.1):
+    - Flutter
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - location (from `.symlinks/plugins/location/ios`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  location:
+    :path: ".symlinks/plugins/location/ios"
+
+SPEC CHECKSUMS:
+  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
+  location: 3a2eed4dd2fab25e7b7baf2a9efefe82b512d740
+
+PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
+
+COCOAPODS: 1.10.1

--- a/example/lib/pages/animated_map_controller.dart
+++ b/example/lib/pages/animated_map_controller.dart
@@ -34,7 +34,12 @@ class AnimatedMapControllerPageState extends State<AnimatedMapControllerPage>
   @override
   void initState() {
     super.initState();
-    mapController = MapController();
+    mapController = MapController(MapOptions(
+      center: LatLng(51.5, -0.09),
+      zoom: 5.0,
+      maxZoom: 10.0,
+      minZoom: 3.0,
+    ));
   }
 
   void _animatedMapMove(LatLng destLocation, double destZoom) {
@@ -162,11 +167,6 @@ class AnimatedMapControllerPageState extends State<AnimatedMapControllerPage>
             Flexible(
               child: FlutterMap(
                 mapController: mapController,
-                options: MapOptions(
-                    center: LatLng(51.5, -0.09),
-                    zoom: 5.0,
-                    maxZoom: 10.0,
-                    minZoom: 3.0),
                 layers: [
                   TileLayerOptions(
                       urlTemplate:

--- a/example/lib/pages/interactive_test_page.dart
+++ b/example/lib/pages/interactive_test_page.dart
@@ -26,7 +26,11 @@ class _InteractiveTestPageState extends State<InteractiveTestPage> {
   @override
   void initState() {
     super.initState();
-    mapController = MapController();
+    mapController = MapController(MapOptions(
+      center: LatLng(51.5, -0.09),
+      zoom: 11.0,
+      interactiveFlags: flags,
+    ));
 
     subscription = mapController.mapEventStream.listen(onMapEvent);
   }
@@ -168,7 +172,6 @@ class _InteractiveTestPageState extends State<InteractiveTestPage> {
             ),
             Flexible(
               child: FlutterMap(
-                mapController: mapController,
                 options: MapOptions(
                   center: LatLng(51.5, -0.09),
                   zoom: 11.0,
@@ -181,6 +184,7 @@ class _InteractiveTestPageState extends State<InteractiveTestPage> {
                     subdomains: ['a', 'b', 'c'],
                   ),
                 ],
+                mapController: mapController,
               ),
             ),
           ],

--- a/example/lib/pages/live_location.dart
+++ b/example/lib/pages/live_location.dart
@@ -29,7 +29,11 @@ class _LiveLocationPageState extends State<LiveLocationPage> {
   @override
   void initState() {
     super.initState();
-    _mapController = MapController();
+    _mapController = MapController(MapOptions(
+      center: LatLng(0, 0),
+      zoom: 5.0,
+      interactiveFlags: interActiveFlags,
+    ));
     initLocationService();
   }
 
@@ -134,12 +138,6 @@ class _LiveLocationPageState extends State<LiveLocationPage> {
             Flexible(
               child: FlutterMap(
                 mapController: _mapController,
-                options: MapOptions(
-                  center:
-                      LatLng(currentLatLng.latitude, currentLatLng.longitude),
-                  zoom: 5.0,
-                  interactiveFlags: interActiveFlags,
-                ),
                 layers: [
                   TileLayerOptions(
                     urlTemplate:

--- a/example/lib/pages/map_controller.dart
+++ b/example/lib/pages/map_controller.dart
@@ -27,7 +27,12 @@ class MapControllerPageState extends State<MapControllerPage> {
   @override
   void initState() {
     super.initState();
-    mapController = MapController();
+    mapController = MapController(MapOptions(
+      center: LatLng(51.5, -0.09),
+      zoom: 5.0,
+      maxZoom: 5.0,
+      minZoom: 3.0,
+    ));
   }
 
   @override
@@ -154,12 +159,6 @@ class MapControllerPageState extends State<MapControllerPage> {
             Flexible(
               child: FlutterMap(
                 mapController: mapController,
-                options: MapOptions(
-                  center: LatLng(51.5, -0.09),
-                  zoom: 5.0,
-                  maxZoom: 5.0,
-                  minZoom: 3.0,
-                ),
                 layers: [
                   TileLayerOptions(
                       urlTemplate:

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -63,21 +63,26 @@ class FlutterMap extends StatefulWidget {
   /// [MapOptions] to create a [MapState] with.
   ///
   /// This property must not be null.
-  final MapOptions options;
+  MapOptions get options => _mapController.options;
 
   /// A [MapController], used to control the map.
-  final MapControllerImpl? _mapController;
+  final MapControllerImpl _mapController;
 
   FlutterMap({
     Key? key,
-    required this.options,
+    MapOptions? options,
     this.layers = const [],
     this.nonRotatedLayers = const [],
     this.children = const [],
     this.nonRotatedChildren = const [],
     MapController? mapController,
-  })  : _mapController = mapController as MapControllerImpl?,
-        super(key: key);
+  })  : _mapController = mapController as MapControllerImpl? ??
+            MapController(options!) as MapControllerImpl,
+        super(key: key) {
+    if (options != null) {
+      _mapController.options = options;
+    }
+  }
 
   @override
   FlutterMapState createState() => FlutterMapState(_mapController);
@@ -134,7 +139,7 @@ abstract class MapController {
 
   Stream<MapEvent> get mapEventStream;
 
-  factory MapController() => MapControllerImpl();
+  factory MapController(MapOptions options) => MapControllerImpl(options);
 }
 
 typedef TapCallback = void Function(LatLng point);

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -21,9 +21,7 @@ class FlutterMapState extends MapGestureMixin {
   @override
   late final MapState mapState;
 
-  FlutterMapState(MapController? mapController)
-      : mapController = mapController as MapControllerImpl? ??
-            MapController() as MapControllerImpl;
+  FlutterMapState(this.mapController);
 
   @override
   void didUpdateWidget(FlutterMap oldWidget) {

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -10,10 +10,15 @@ import 'package:flutter_map/src/map/map_state_widget.dart';
 import 'package:latlong2/latlong.dart';
 
 class MapControllerImpl implements MapController {
+  MapOptions options;
   final Completer<Null> _readyCompleter = Completer<Null>();
   final StreamController<MapEvent> _mapEventSink = StreamController.broadcast();
+
+  MapControllerImpl(this.options);
   StreamSink<MapEvent> get mapEventSink => _mapEventSink.sink;
   late final MapState _state;
+
+  bool get isReady => _readyCompleter.isCompleted;
 
   @override
   Future<Null> get onReady => _readyCompleter.future;
@@ -52,16 +57,16 @@ class MapControllerImpl implements MapController {
   }
 
   @override
-  LatLng get center => _state.center;
+  LatLng get center => isReady ? _state.center : options.center;
 
   @override
-  LatLngBounds? get bounds => _state.bounds;
+  LatLngBounds? get bounds => isReady ? _state.bounds : options.bounds;
 
   @override
-  double get zoom => _state.zoom;
+  double get zoom => isReady ? _state.zoom : options.zoom;
 
   @override
-  double get rotation => _state.rotation;
+  double get rotation => isReady ? _state.rotation : options.rotation;
 
   @override
   bool rotate(double degree, {String? id}) {


### PR DESCRIPTION
This PR removes a class of LateInitializationErrors when passing MapController as argument to FlutterMap widget. See #986 for context. The change is breaking for clients that create their own MapController.

**flutter_map.dart** (breaking change)
```dart
factory MapController(MapOptions options) => MapControllerImpl(options);
```