### PR TITLE
bugfix: Prevent parent ListView widgets from snatching scrolling gestures

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map_example/pages/map_inside_listview.dart';
 import 'package:flutter_map_example/pages/network_tile_provider.dart';
 
 import './pages/animated_map_controller.dart';
@@ -68,6 +69,7 @@ class MyApp extends StatelessWidget {
         InteractiveTestPage.route: (context) => InteractiveTestPage(),
         ManyMarkersPage.route: (context) => ManyMarkersPage(),
         StatefulMarkersPage.route: (context) => StatefulMarkersPage(),
+        MapInsideListViewPage.route: (context) => MapInsideListViewPage(),
       },
     );
   }

--- a/example/lib/pages/map_inside_listview.dart
+++ b/example/lib/pages/map_inside_listview.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/plugin_api.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../pages/zoombuttons_plugin_option.dart';
+import '../widgets/drawer.dart';
+
+class MapInsideListViewPage extends StatelessWidget {
+  static const String route = 'map_inside_listview';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Map inside ListView')),
+      drawer: buildDrawer(context, MapInsideListViewPage.route),
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: ListView(
+          scrollDirection: Axis.vertical,
+          children: [
+            Container(
+              height: 300,
+              child: FlutterMap(
+                options: MapOptions(
+                  center: LatLng(51.5, -0.09),
+                  zoom: 5.0,
+                  plugins: [
+                    ZoomButtonsPlugin(),
+                  ],
+                ),
+                layers: [
+                  ZoomButtonsPluginOption(
+                    minZoom: 4,
+                    maxZoom: 19,
+                    mini: true,
+                    padding: 10,
+                    alignment: Alignment.bottomLeft,
+                  )
+                ],
+                children: <Widget>[
+                  TileLayerWidget(
+                    options: TileLayerOptions(
+                      urlTemplate:
+                      'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                      subdomains: ['a', 'b', 'c'],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Card(
+              child: ListTile(
+                  title: Text(
+                      'Scrolling inside the map does not scroll the ListView')),
+            ),
+            SizedBox(height: 500),
+            Card(child: ListTile(title: Text('look at that scrolling')))
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/pages/map_inside_listview.dart
+++ b/example/lib/pages/map_inside_listview.dart
@@ -41,7 +41,7 @@ class MapInsideListViewPage extends StatelessWidget {
                   TileLayerWidget(
                     options: TileLayerOptions(
                       urlTemplate:
-                      'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                       subdomains: ['a', 'b', 'c'],
                     ),
                   ),

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -218,12 +218,8 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           StatefulMarkersPage.route,
           currentRoute,
         ),
-        _buildMenuItem(
-            context,
-            const Text('Map inside listview'),
-            MapInsideListViewPage.route,
-            currentRoute
-        ),
+        _buildMenuItem(context, const Text('Map inside listview'),
+            MapInsideListViewPage.route, currentRoute),
       ],
     ),
   );

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map_example/pages/map_inside_listview.dart';
 import 'package:flutter_map_example/pages/marker_rotate.dart';
 import 'package:flutter_map_example/pages/network_tile_provider.dart';
 
@@ -216,7 +217,13 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           const Text('Stateful markers'),
           StatefulMarkersPage.route,
           currentRoute,
-        )
+        ),
+        _buildMenuItem(
+            context,
+            const Text('Map inside listview'),
+            MapInsideListViewPage.route,
+            currentRoute
+        ),
       ],
     ),
   );

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -224,6 +224,7 @@ class MapOptions {
   final int interactiveFlags;
 
   final bool allowPanning;
+  final bool allowPanningOnScrollingParent;
 
   final TapCallback? onTap;
   final LongPressCallback? onLongPress;
@@ -244,6 +245,7 @@ class MapOptions {
   double? _safeAreaZoom;
 
   MapOptions({
+    this.allowPanningOnScrollingParent = true,
     this.crs = const Epsg3857(),
     LatLng? center,
     this.bounds,

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -137,43 +137,7 @@ class FlutterMapState extends MapGestureMixin {
                     onTapDown: _positionedTapController.onTapDown,
                     onTapUp: handleOnTapUp,
                     child: scaleGestureDetector(
-                      child: ClipRect(
-                        child: Stack(
-                          children: [
-                            OverflowBox(
-                              minWidth: size.x as double?,
-                              maxWidth: size.x as double?,
-                              minHeight: size.y as double?,
-                              maxHeight: size.y as double?,
-                              child: Transform.rotate(
-                                angle: mapState.rotationRad,
-                                child: Stack(
-                                  children: [
-                                    if (widget.children.isNotEmpty)
-                                      ...widget.children,
-                                    if (widget.layers.isNotEmpty)
-                                      ...widget.layers.map(
-                                        (layer) => _createLayer(
-                                            layer, options.plugins),
-                                      )
-                                  ],
-                                ),
-                              ),
-                            ),
-                            Stack(
-                              children: [
-                                if (widget.nonRotatedChildren.isNotEmpty)
-                                  ...widget.nonRotatedChildren,
-                                if (widget.nonRotatedLayers.isNotEmpty)
-                                  ...widget.nonRotatedLayers.map(
-                                    (layer) =>
-                                        _createLayer(layer, options.plugins),
-                                  )
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
+                      child: _buildMap(size)
                     ),
                   )
                 : GestureDetector(
@@ -184,43 +148,7 @@ class FlutterMapState extends MapGestureMixin {
                     onLongPress: _positionedTapController.onLongPress,
                     onTapDown: _positionedTapController.onTapDown,
                     onTapUp: handleOnTapUp,
-                    child: ClipRect(
-                      child: Stack(
-                        children: [
-                          OverflowBox(
-                            minWidth: size.x as double?,
-                            maxWidth: size.x as double?,
-                            minHeight: size.y as double?,
-                            maxHeight: size.y as double?,
-                            child: Transform.rotate(
-                              angle: mapState.rotationRad,
-                              child: Stack(
-                                children: [
-                                  if (widget.children.isNotEmpty)
-                                    ...widget.children,
-                                  if (widget.layers.isNotEmpty)
-                                    ...widget.layers.map(
-                                      (layer) =>
-                                          _createLayer(layer, options.plugins),
-                                    )
-                                ],
-                              ),
-                            ),
-                          ),
-                          Stack(
-                            children: [
-                              if (widget.nonRotatedChildren.isNotEmpty)
-                                ...widget.nonRotatedChildren,
-                              if (widget.nonRotatedLayers.isNotEmpty)
-                                ...widget.nonRotatedLayers.map(
-                                  (layer) =>
-                                      _createLayer(layer, options.plugins),
-                                )
-                            ],
-                          ),
-                        ],
-                      ),
-                    ),
+                    child: _buildMap(size)
                   ),
           ),
         ),
@@ -228,6 +156,45 @@ class FlutterMapState extends MapGestureMixin {
     });
   }
 
+  Widget _buildMap(var size){
+    return ClipRect(
+      child: Stack(
+        children: [
+          OverflowBox(
+            minWidth: size.x as double?,
+            maxWidth: size.x as double?,
+            minHeight: size.y as double?,
+            maxHeight: size.y as double?,
+            child: Transform.rotate(
+              angle: mapState.rotationRad,
+              child: Stack(
+                children: [
+                  if (widget.children.isNotEmpty)
+                    ...widget.children,
+                  if (widget.layers.isNotEmpty)
+                    ...widget.layers.map(
+                          (layer) =>
+                          _createLayer(layer, options.plugins),
+                    )
+                ],
+              ),
+            ),
+          ),
+          Stack(
+            children: [
+              if (widget.nonRotatedChildren.isNotEmpty)
+                ...widget.nonRotatedChildren,
+              if (widget.nonRotatedLayers.isNotEmpty)
+                ...widget.nonRotatedLayers.map(
+                      (layer) =>
+                      _createLayer(layer, options.plugins),
+                )
+            ],
+          ),
+        ],
+      ),
+    );
+  }
   Widget _createLayer(LayerOptions options, List<MapPlugin> plugins) {
     for (var plugin in plugins) {
       if (plugin.supportsLayer(options)) {

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -136,9 +136,7 @@ class FlutterMapState extends MapGestureMixin {
                     onLongPress: _positionedTapController.onLongPress,
                     onTapDown: _positionedTapController.onTapDown,
                     onTapUp: handleOnTapUp,
-                    child: scaleGestureDetector(
-                      child: _buildMap(size)
-                    ),
+                    child: scaleGestureDetector(child: _buildMap(size)),
                   )
                 : GestureDetector(
                     onScaleStart: handleScaleStart,
@@ -148,15 +146,14 @@ class FlutterMapState extends MapGestureMixin {
                     onLongPress: _positionedTapController.onLongPress,
                     onTapDown: _positionedTapController.onTapDown,
                     onTapUp: handleOnTapUp,
-                    child: _buildMap(size)
-                  ),
+                    child: _buildMap(size)),
           ),
         ),
       );
     });
   }
 
-  Widget _buildMap(var size){
+  Widget _buildMap(var size) {
     return ClipRect(
       child: Stack(
         children: [
@@ -169,12 +166,10 @@ class FlutterMapState extends MapGestureMixin {
               angle: mapState.rotationRad,
               child: Stack(
                 children: [
-                  if (widget.children.isNotEmpty)
-                    ...widget.children,
+                  if (widget.children.isNotEmpty) ...widget.children,
                   if (widget.layers.isNotEmpty)
                     ...widget.layers.map(
-                          (layer) =>
-                          _createLayer(layer, options.plugins),
+                      (layer) => _createLayer(layer, options.plugins),
                     )
                 ],
               ),
@@ -186,8 +181,7 @@ class FlutterMapState extends MapGestureMixin {
                 ...widget.nonRotatedChildren,
               if (widget.nonRotatedLayers.isNotEmpty)
                 ...widget.nonRotatedLayers.map(
-                      (layer) =>
-                      _createLayer(layer, options.plugins),
+                  (layer) => _createLayer(layer, options.plugins),
                 )
             ],
           ),
@@ -195,6 +189,7 @@ class FlutterMapState extends MapGestureMixin {
       ),
     );
   }
+
   Widget _createLayer(LayerOptions options, List<MapPlugin> plugins) {
     for (var plugin in plugins) {
       if (plugin.supportsLayer(options)) {

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -84,12 +84,13 @@ class FlutterMapState extends MapGestureMixin {
 
       var scaleGestureTeam = GestureArenaTeam();
 
-      var scaleGestureDetector = ({required Widget child}) => RawGestureDetector(
-        gestures: <Type, GestureRecognizerFactory>{
-          ScaleGestureRecognizer:
-          GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(
-                  () => ScaleGestureRecognizer(),
-                  (ScaleGestureRecognizer instance) {
+      var scaleGestureDetector = ({required Widget child}) =>
+          RawGestureDetector(
+            gestures: <Type, GestureRecognizerFactory>{
+              ScaleGestureRecognizer:
+                  GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(
+                      () => ScaleGestureRecognizer(),
+                      (ScaleGestureRecognizer instance) {
                 scaleGestureTeam.captain = instance;
                 instance.team ??= scaleGestureTeam;
                 instance
@@ -97,26 +98,26 @@ class FlutterMapState extends MapGestureMixin {
                   ..onUpdate = handleScaleUpdate
                   ..onEnd = handleScaleEnd;
               }),
-          VerticalDragGestureRecognizer:
-          GestureRecognizerFactoryWithHandlers<
-              VerticalDragGestureRecognizer>(
-                  () => VerticalDragGestureRecognizer(),
-                  (VerticalDragGestureRecognizer instance) {
+              VerticalDragGestureRecognizer:
+                  GestureRecognizerFactoryWithHandlers<
+                          VerticalDragGestureRecognizer>(
+                      () => VerticalDragGestureRecognizer(),
+                      (VerticalDragGestureRecognizer instance) {
                 instance.team ??= scaleGestureTeam;
                 // these empty lambdas are necessary to activate this gesture recognizer
                 instance.onUpdate = (_) {};
               }),
-          HorizontalDragGestureRecognizer:
-          GestureRecognizerFactoryWithHandlers<
-              HorizontalDragGestureRecognizer>(
-                  () => HorizontalDragGestureRecognizer(),
-                  (HorizontalDragGestureRecognizer instance) {
+              HorizontalDragGestureRecognizer:
+                  GestureRecognizerFactoryWithHandlers<
+                          HorizontalDragGestureRecognizer>(
+                      () => HorizontalDragGestureRecognizer(),
+                      (HorizontalDragGestureRecognizer instance) {
                 instance.team ??= scaleGestureTeam;
                 instance.onUpdate = (_) {};
               })
-        },
-        child: child,
-      );
+            },
+            child: child,
+          );
 
       return MapStateInheritedWidget(
         mapState: mapState,
@@ -129,90 +130,98 @@ class FlutterMapState extends MapGestureMixin {
             onTap: handleTap,
             onLongPress: handleLongPress,
             onDoubleTap: handleDoubleTap,
-            child: options.allowPanningOnScrollingParent ? GestureDetector(
-              onTap: _positionedTapController.onTap,
-              onLongPress: _positionedTapController.onLongPress,
-              onTapDown: _positionedTapController.onTapDown,
-              onTapUp: handleOnTapUp,
-              child: scaleGestureDetector(
-                child: ClipRect(
-                  child: Stack(
-                    children: [
-                      OverflowBox(
-                        minWidth: size.x as double?,
-                        maxWidth: size.x as double?,
-                        minHeight: size.y as double?,
-                        maxHeight: size.y as double?,
-                        child: Transform.rotate(
-                          angle: mapState.rotationRad,
-                          child: Stack(
-                            children: [
-                              if (widget.children.isNotEmpty) ...widget.children,
-                              if (widget.layers.isNotEmpty)
-                                ...widget.layers.map(
-                                  (layer) => _createLayer(layer, options.plugins),
-                                )
-                            ],
-                          ),
-                        ),
-                      ),
-                      Stack(
-                        children: [
-                          if (widget.nonRotatedChildren.isNotEmpty)
-                            ...widget.nonRotatedChildren,
-                          if (widget.nonRotatedLayers.isNotEmpty)
-                            ...widget.nonRotatedLayers.map(
-                              (layer) => _createLayer(layer, options.plugins),
-                            )
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ) : GestureDetector(
-              onScaleStart: handleScaleStart,
-              onScaleUpdate: handleScaleUpdate,
-              onScaleEnd: handleScaleEnd,
-              onTap: _positionedTapController.onTap,
-              onLongPress: _positionedTapController.onLongPress,
-              onTapDown: _positionedTapController.onTapDown,
-              onTapUp: handleOnTapUp,
-              child: ClipRect(
-                child: Stack(
-                  children: [
-                    OverflowBox(
-                      minWidth: size.x as double?,
-                      maxWidth: size.x as double?,
-                      minHeight: size.y as double?,
-                      maxHeight: size.y as double?,
-                      child: Transform.rotate(
-                        angle: mapState.rotationRad,
+            child: options.allowPanningOnScrollingParent
+                ? GestureDetector(
+                    onTap: _positionedTapController.onTap,
+                    onLongPress: _positionedTapController.onLongPress,
+                    onTapDown: _positionedTapController.onTapDown,
+                    onTapUp: handleOnTapUp,
+                    child: scaleGestureDetector(
+                      child: ClipRect(
                         child: Stack(
                           children: [
-                            if (widget.children.isNotEmpty) ...widget.children,
-                            if (widget.layers.isNotEmpty)
-                              ...widget.layers.map(
-                                    (layer) => _createLayer(layer, options.plugins),
-                              )
+                            OverflowBox(
+                              minWidth: size.x as double?,
+                              maxWidth: size.x as double?,
+                              minHeight: size.y as double?,
+                              maxHeight: size.y as double?,
+                              child: Transform.rotate(
+                                angle: mapState.rotationRad,
+                                child: Stack(
+                                  children: [
+                                    if (widget.children.isNotEmpty)
+                                      ...widget.children,
+                                    if (widget.layers.isNotEmpty)
+                                      ...widget.layers.map(
+                                        (layer) => _createLayer(
+                                            layer, options.plugins),
+                                      )
+                                  ],
+                                ),
+                              ),
+                            ),
+                            Stack(
+                              children: [
+                                if (widget.nonRotatedChildren.isNotEmpty)
+                                  ...widget.nonRotatedChildren,
+                                if (widget.nonRotatedLayers.isNotEmpty)
+                                  ...widget.nonRotatedLayers.map(
+                                    (layer) =>
+                                        _createLayer(layer, options.plugins),
+                                  )
+                              ],
+                            ),
                           ],
                         ),
                       ),
                     ),
-                    Stack(
-                      children: [
-                        if (widget.nonRotatedChildren.isNotEmpty)
-                          ...widget.nonRotatedChildren,
-                        if (widget.nonRotatedLayers.isNotEmpty)
-                          ...widget.nonRotatedLayers.map(
-                                (layer) => _createLayer(layer, options.plugins),
-                          )
-                      ],
+                  )
+                : GestureDetector(
+                    onScaleStart: handleScaleStart,
+                    onScaleUpdate: handleScaleUpdate,
+                    onScaleEnd: handleScaleEnd,
+                    onTap: _positionedTapController.onTap,
+                    onLongPress: _positionedTapController.onLongPress,
+                    onTapDown: _positionedTapController.onTapDown,
+                    onTapUp: handleOnTapUp,
+                    child: ClipRect(
+                      child: Stack(
+                        children: [
+                          OverflowBox(
+                            minWidth: size.x as double?,
+                            maxWidth: size.x as double?,
+                            minHeight: size.y as double?,
+                            maxHeight: size.y as double?,
+                            child: Transform.rotate(
+                              angle: mapState.rotationRad,
+                              child: Stack(
+                                children: [
+                                  if (widget.children.isNotEmpty)
+                                    ...widget.children,
+                                  if (widget.layers.isNotEmpty)
+                                    ...widget.layers.map(
+                                      (layer) =>
+                                          _createLayer(layer, options.plugins),
+                                    )
+                                ],
+                              ),
+                            ),
+                          ),
+                          Stack(
+                            children: [
+                              if (widget.nonRotatedChildren.isNotEmpty)
+                                ...widget.nonRotatedChildren,
+                              if (widget.nonRotatedLayers.isNotEmpty)
+                                ...widget.nonRotatedLayers.map(
+                                  (layer) =>
+                                      _createLayer(layer, options.plugins),
+                                )
+                            ],
+                          ),
+                        ],
+                      ),
                     ),
-                  ],
-                ),
-              ),
-            ) ,
+                  ),
           ),
         ),
       );

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/gestures/gestures.dart';
@@ -81,6 +82,42 @@ class FlutterMapState extends MapGestureMixin {
       mapState.setOriginalSize(constraints.maxWidth, constraints.maxHeight);
       var size = mapState.size;
 
+      var scaleGestureTeam = GestureArenaTeam();
+
+      var scaleGestureDetector = ({required Widget child}) => RawGestureDetector(
+        gestures: <Type, GestureRecognizerFactory>{
+          ScaleGestureRecognizer:
+          GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(
+                  () => ScaleGestureRecognizer(),
+                  (ScaleGestureRecognizer instance) {
+                scaleGestureTeam.captain = instance;
+                instance.team ??= scaleGestureTeam;
+                instance
+                  ..onStart = handleScaleStart
+                  ..onUpdate = handleScaleUpdate
+                  ..onEnd = handleScaleEnd;
+              }),
+          VerticalDragGestureRecognizer:
+          GestureRecognizerFactoryWithHandlers<
+              VerticalDragGestureRecognizer>(
+                  () => VerticalDragGestureRecognizer(),
+                  (VerticalDragGestureRecognizer instance) {
+                instance.team ??= scaleGestureTeam;
+                // these empty lambdas are necessary to activate this gesture recognizer
+                instance.onUpdate = (_) {};
+              }),
+          HorizontalDragGestureRecognizer:
+          GestureRecognizerFactoryWithHandlers<
+              HorizontalDragGestureRecognizer>(
+                  () => HorizontalDragGestureRecognizer(),
+                  (HorizontalDragGestureRecognizer instance) {
+                instance.team ??= scaleGestureTeam;
+                instance.onUpdate = (_) {};
+              })
+        },
+        child: child,
+      );
+
       return MapStateInheritedWidget(
         mapState: mapState,
         child: Listener(
@@ -92,7 +129,48 @@ class FlutterMapState extends MapGestureMixin {
             onTap: handleTap,
             onLongPress: handleLongPress,
             onDoubleTap: handleDoubleTap,
-            child: GestureDetector(
+            child: options.allowPanningOnScrollingParent ? GestureDetector(
+              onTap: _positionedTapController.onTap,
+              onLongPress: _positionedTapController.onLongPress,
+              onTapDown: _positionedTapController.onTapDown,
+              onTapUp: handleOnTapUp,
+              child: scaleGestureDetector(
+                child: ClipRect(
+                  child: Stack(
+                    children: [
+                      OverflowBox(
+                        minWidth: size.x as double?,
+                        maxWidth: size.x as double?,
+                        minHeight: size.y as double?,
+                        maxHeight: size.y as double?,
+                        child: Transform.rotate(
+                          angle: mapState.rotationRad,
+                          child: Stack(
+                            children: [
+                              if (widget.children.isNotEmpty) ...widget.children,
+                              if (widget.layers.isNotEmpty)
+                                ...widget.layers.map(
+                                  (layer) => _createLayer(layer, options.plugins),
+                                )
+                            ],
+                          ),
+                        ),
+                      ),
+                      Stack(
+                        children: [
+                          if (widget.nonRotatedChildren.isNotEmpty)
+                            ...widget.nonRotatedChildren,
+                          if (widget.nonRotatedLayers.isNotEmpty)
+                            ...widget.nonRotatedLayers.map(
+                              (layer) => _createLayer(layer, options.plugins),
+                            )
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ) : GestureDetector(
               onScaleStart: handleScaleStart,
               onScaleUpdate: handleScaleUpdate,
               onScaleEnd: handleScaleEnd,
@@ -115,7 +193,7 @@ class FlutterMapState extends MapGestureMixin {
                             if (widget.children.isNotEmpty) ...widget.children,
                             if (widget.layers.isNotEmpty)
                               ...widget.layers.map(
-                                (layer) => _createLayer(layer, options.plugins),
+                                    (layer) => _createLayer(layer, options.plugins),
                               )
                           ],
                         ),
@@ -127,14 +205,14 @@ class FlutterMapState extends MapGestureMixin {
                           ...widget.nonRotatedChildren,
                         if (widget.nonRotatedLayers.isNotEmpty)
                           ...widget.nonRotatedLayers.map(
-                            (layer) => _createLayer(layer, options.plugins),
+                                (layer) => _createLayer(layer, options.plugins),
                           )
                       ],
                     ),
                   ],
                 ),
               ),
-            ),
+            ) ,
           ),
         ),
       );


### PR DESCRIPTION
This is basically copy of https://github.com/fleaflet/flutter_map/pull/717 (since the PR creator does not seem intrested in implementing the commented option and PR is now stale). I saw that the PR is not  being merged because there is no option to developer if they want previous behavior. I have tried to add a bool in mapoptions to determine the type of behavior in the map.

Let me know if anything else is required. I want this feature to be implemented.
Thank You!