### PR TITLE
Added centerZoomFitBounds to MapController

### DIFF
--- a/example/lib/pages/animated_map_controller.dart
+++ b/example/lib/pages/animated_map_controller.dart
@@ -156,6 +156,19 @@ class AnimatedMapControllerPageState extends State<AnimatedMapControllerPage>
                     },
                     child: Text('Fit Bounds'),
                   ),
+                  MaterialButton(
+                    onPressed: () {
+                      var bounds = LatLngBounds();
+                      bounds.extend(dublin);
+                      bounds.extend(paris);
+                      bounds.extend(london);
+
+                      var centerZoom =
+                          mapController.centerZoomFitBounds(bounds);
+                      _animatedMapMove(centerZoom.center, centerZoom.zoom);
+                    },
+                    child: Text('Fit Bounds animated'),
+                  ),
                 ],
               ),
             ),

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -14,6 +14,7 @@ import 'package:flutter_map/src/map/map.dart';
 import 'package:flutter_map/src/plugins/plugin.dart';
 import 'package:latlong2/latlong.dart';
 
+export 'package:flutter_map/src/core/center_zoom.dart';
 export 'package:flutter_map/src/core/point.dart';
 export 'package:flutter_map/src/geo/crs/crs.dart';
 export 'package:flutter_map/src/geo/latlng_bounds.dart';
@@ -121,6 +122,11 @@ abstract class MapController {
   /// Fits the map bounds. Optional constraints can be defined
   /// through the [options] parameter.
   void fitBounds(LatLngBounds bounds, {FitBoundsOptions? options});
+
+  /// Calcs the new center and zoom for the map bounds. Optional constraints can be defined
+  /// through the [options] parameter.
+  CenterZoom centerZoomFitBounds(LatLngBounds bounds,
+      {FitBoundsOptions? options});
 
   Future<Null> get onReady;
 

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -52,6 +52,15 @@ class MapControllerImpl implements MapController {
   }
 
   @override
+  CenterZoom centerZoomFitBounds(
+    LatLngBounds bounds, {
+    FitBoundsOptions? options =
+        const FitBoundsOptions(padding: EdgeInsets.all(12.0)),
+  }) {
+    return _state.centerZoomFitBounds(bounds, options!);
+  }
+
+  @override
   LatLng get center => _state.center;
 
   @override
@@ -338,6 +347,14 @@ class MapState {
     }
     var target = getBoundsCenterZoom(bounds, options);
     move(target.center, target.zoom, source: MapEventSource.fitBounds);
+  }
+
+  CenterZoom centerZoomFitBounds(
+      LatLngBounds bounds, FitBoundsOptions options) {
+    if (!bounds.isValid) {
+      throw Exception('Bounds are not valid.');
+    }
+    return getBoundsCenterZoom(bounds, options);
   }
 
   LatLng getCenter() {


### PR DESCRIPTION
This PR adds a method to calculate the center of a given map bound.
Which is needed for animated camera transitions from one bound to the next.

This should help with #965 