### PR TITLE
Cancel animations on map controller move events

### DIFF
--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -758,10 +758,11 @@ abstract class MapGestureMixin extends State<FlutterMap>
   void _startListeningForAnimationInterruptions() {
     if (_mapControllerAnimationInterruption != null) return;
     // cancel map animation controllers on map controller move events
-    _mapControllerAnimationInterruption = mapController.mapEventStream.where(
-      (event) => event.source == MapEventSource.mapController &&
-                 event is MapEventMove
-    ).listen(_handleAnimationInterruptions);
+    _mapControllerAnimationInterruption = mapController.mapEventStream
+        .where((event) =>
+            event.source == MapEventSource.mapController &&
+            event is MapEventMove)
+        .listen(_handleAnimationInterruptions);
   }
 
   void _stopListeningForAnimationInterruptions() {

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -86,6 +86,8 @@ abstract class MapGestureMixin extends State<FlutterMap>
   late Animation _doubleTapZoomAnimation;
   late Animation _doubleTapCenterAnimation;
 
+  StreamSubscription<MapEvent>? _mapControllerAnimationInterruption;
+
   int _tapUpCounter = 0;
   Timer? _doubleTapHoldMaxDelay;
 
@@ -93,6 +95,8 @@ abstract class MapGestureMixin extends State<FlutterMap>
   FlutterMap get widget;
 
   MapState get mapState;
+
+  MapController get mapController;
 
   MapOptions get options;
 
@@ -225,6 +229,8 @@ abstract class MapGestureMixin extends State<FlutterMap>
     if (_flingController.isAnimating) {
       _flingController.stop();
 
+      _stopListeningForAnimationInterruptions();
+
       mapState.emitMapEvent(
         MapEventFlingAnimationEnd(
             center: mapState.center, zoom: mapState.zoom, source: source),
@@ -235,6 +241,8 @@ abstract class MapGestureMixin extends State<FlutterMap>
   void closeDoubleTapController(MapEventSource source) {
     if (_doubleTapController.isAnimating) {
       _doubleTapController.stop();
+
+      _stopListeningForAnimationInterruptions();
 
       mapState.emitMapEvent(
         MapEventDoubleTapZoomEnd(
@@ -652,7 +660,9 @@ abstract class MapGestureMixin extends State<FlutterMap>
             zoom: mapState.zoom,
             source: MapEventSource.doubleTapZoomAnimationController),
       );
+      _startListeningForAnimationInterruptions();
     } else if (status == AnimationStatus.completed) {
+      _stopListeningForAnimationInterruptions();
       mapState.emitMapEvent(
         MapEventDoubleTapZoomEnd(
             center: mapState.center,
@@ -711,6 +721,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
   void _flingAnimationStatusListener(AnimationStatus status) {
     if (status == AnimationStatus.completed) {
       _flingAnimationStarted = false;
+      _stopListeningForAnimationInterruptions();
       mapState.emitMapEvent(
         MapEventFlingAnimationEnd(
             center: mapState.center,
@@ -729,6 +740,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
             zoom: mapState.zoom,
             source: MapEventSource.flingAnimationController),
       );
+      _startListeningForAnimationInterruptions();
     }
 
     var newCenterPoint = mapState.project(_mapCenterStart) +
@@ -741,6 +753,25 @@ abstract class MapGestureMixin extends State<FlutterMap>
       hasGesture: true,
       source: MapEventSource.flingAnimationController,
     );
+  }
+
+  void _startListeningForAnimationInterruptions() {
+    if (_mapControllerAnimationInterruption != null) return;
+    // cancel map animation controllers on map controller move events
+    _mapControllerAnimationInterruption = mapController.mapEventStream.where(
+      (event) => event.source == MapEventSource.mapController &&
+                 event is MapEventMove
+    ).listen(_handleAnimationInterruptions);
+  }
+
+  void _stopListeningForAnimationInterruptions() {
+    _mapControllerAnimationInterruption?.cancel();
+    _mapControllerAnimationInterruption = null;
+  }
+
+  void _handleAnimationInterruptions(MapEvent event) {
+    closeDoubleTapController(event.source);
+    closeFlingAnimationController(event.source);
   }
 
   CustomPoint _offsetToPoint(Offset offset) {

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -12,6 +12,7 @@ import 'package:flutter_map/src/map/map_state_widget.dart';
 import 'package:positioned_tap_detector_2/positioned_tap_detector_2.dart';
 
 class FlutterMapState extends MapGestureMixin {
+  @override
   final MapControllerImpl mapController;
   final List<StreamGroup<Null>> groups = <StreamGroup<Null>>[];
   final _positionedTapController = PositionedTapController();


### PR DESCRIPTION
This fixes https://github.com/fleaflet/flutter_map/issues/946

Fling and double tap animations are already cancelled in multiple scenarios (like panning the map). This PR also cancels the animations whenever the `MapController` moves the camera. This is done to prevent interferences with animated camera moves.
