### PR TITLE
fix screen width and height to degrees conversion when crs is CrsSimple and add double tap callback

### DIFF
--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -240,6 +240,7 @@ class MapOptions {
   final bool allowPanningOnScrollingParent;
 
   final TapCallback? onTap;
+  final TapCallback? onDoubleTap;
   final LongPressCallback? onLongPress;
   final PositionCallback? onPositionChanged;
   final MapCreatedCallback? onMapCreated;
@@ -281,6 +282,7 @@ class MapOptions {
     this.interactiveFlags = InteractiveFlag.all,
     this.allowPanning = true,
     this.onTap,
+    this.onDoubleTap,
     this.onLongPress,
     this.onPositionChanged,
     this.onMapCreated,

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -360,13 +360,23 @@ class MapOptions {
   }
 
   double _calculateScreenWidthInDegrees() {
-    final zoom = _getControllerZoom();
-    final degreesPerPixel = 360 / pow(2, zoom + 8);
+
+    if(crs.code == 'CRS.SIMPLE') {
+      return screenSize!.width / pow(2, _getControllerZoom() + 8);
+    }
+
+    final degreesPerPixel = 360 / pow(2, _getControllerZoom() + 8);
     return screenSize!.width * degreesPerPixel;
   }
 
-  double _calculateScreenHeightInDegrees() =>
-      screenSize!.height * 170.102258 / pow(2, _getControllerZoom() + 8);
+  double _calculateScreenHeightInDegrees() {
+
+    if(crs.code == 'CRS.SIMPLE') {
+      return screenSize!.height / pow(2, _getControllerZoom() + 8);
+    }
+
+    return screenSize!.height * 170.102258 / pow(2, _getControllerZoom() + 8);
+  }
 
   double _getControllerZoom() => controller!.zoom;
 }

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -605,16 +605,16 @@ abstract class MapGestureMixin extends State<FlutterMap>
     if (options.onDoubleTap != null) {
       final latlng = _offsetToCrs(tapPosition.relative!);
       options.onDoubleTap!(tapPosition, latlng);
-    } else {
-      if (InteractiveFlag.hasFlag(
-          options.interactiveFlags, InteractiveFlag.doubleTapZoom)) {
-        final centerPos = _pointToOffset(mapState.originalSize!) / 2.0;
-        final newZoom = _getZoomForScale(mapState.zoom, 2.0);
-        final focalDelta = _getDoubleTapFocalDelta(
-            centerPos, tapPosition.relative!, newZoom - mapState.zoom);
-        final newCenter = _offsetToCrs(centerPos + focalDelta);
-        _startDoubleTapAnimation(newZoom, newCenter);
-      }
+    }
+
+    if (InteractiveFlag.hasFlag(
+        options.interactiveFlags, InteractiveFlag.doubleTapZoom)) {
+      final centerPos = _pointToOffset(mapState.originalSize!) / 2.0;
+      final newZoom = _getZoomForScale(mapState.zoom, 2.0);
+      final focalDelta = _getDoubleTapFocalDelta(
+          centerPos, tapPosition.relative!, newZoom - mapState.zoom);
+      final newCenter = _offsetToCrs(centerPos + focalDelta);
+      _startDoubleTapAnimation(newZoom, newCenter);
     }
   }
 

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -295,6 +295,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
               center: mapState.center,
               zoom: mapState.zoom,
               source: eventSource,
+              localFocalPoint: details.localFocalPoint,
             ),
           );
         }
@@ -381,6 +382,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
                         center: mapState.center,
                         zoom: mapState.zoom,
                         source: eventSource,
+                        localFocalPoint: details.localFocalPoint,
                       ),
                     );
                   }
@@ -402,6 +404,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
                       center: mapState.center,
                       zoom: mapState.zoom,
                       source: eventSource,
+                      localFocalPoint: details.localFocalPoint,
                     ),
                   );
                 }
@@ -496,6 +499,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
           center: mapState.center,
           zoom: mapState.zoom,
           source: eventSource,
+          localFocalPoint: _lastFocalLocal,
         ),
       );
     }

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -602,14 +602,19 @@ abstract class MapGestureMixin extends State<FlutterMap>
     closeFlingAnimationController(MapEventSource.doubleTap);
     closeDoubleTapController(MapEventSource.doubleTap);
 
-    if (InteractiveFlag.hasFlag(
-        options.interactiveFlags, InteractiveFlag.doubleTapZoom)) {
-      final centerPos = _pointToOffset(mapState.originalSize!) / 2.0;
-      final newZoom = _getZoomForScale(mapState.zoom, 2.0);
-      final focalDelta = _getDoubleTapFocalDelta(
-          centerPos, tapPosition.relative!, newZoom - mapState.zoom);
-      final newCenter = _offsetToCrs(centerPos + focalDelta);
-      _startDoubleTapAnimation(newZoom, newCenter);
+    if (options.onDoubleTap != null) {
+      final latlng = _offsetToCrs(tapPosition.relative!);
+      options.onDoubleTap!(tapPosition, latlng);
+    } else {
+      if (InteractiveFlag.hasFlag(
+          options.interactiveFlags, InteractiveFlag.doubleTapZoom)) {
+        final centerPos = _pointToOffset(mapState.originalSize!) / 2.0;
+        final newZoom = _getZoomForScale(mapState.zoom, 2.0);
+        final focalDelta = _getDoubleTapFocalDelta(
+            centerPos, tapPosition.relative!, newZoom - mapState.zoom);
+        final newCenter = _offsetToCrs(centerPos + focalDelta);
+        _startDoubleTapAnimation(newZoom, newCenter);
+      }
     }
   }
 

--- a/lib/src/gestures/map_events.dart
+++ b/lib/src/gestures/map_events.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:latlong2/latlong.dart';
 
 enum MapEventSource {
@@ -86,18 +87,24 @@ class MapEventMove extends MapEventWithMove {
 }
 
 class MapEventMoveStart extends MapEvent {
+  final Offset localFocalPoint;
+
   MapEventMoveStart(
       {required MapEventSource source,
       required LatLng center,
-      required double zoom})
+      required double zoom,
+      required this.localFocalPoint})
       : super(source: source, center: center, zoom: zoom);
 }
 
 class MapEventMoveEnd extends MapEvent {
+  final Offset localFocalPoint;
+
   MapEventMoveEnd(
       {required MapEventSource source,
       required LatLng center,
-      required double zoom})
+      required double zoom,
+      required this.localFocalPoint})
       : super(source: source, center: center, zoom: zoom);
 }
 


### PR DESCRIPTION
Crs.pointToLatLng divide pixels by scale and adaptiveBoundaries does not work with CrsSimple.