### PR TITLE
Pinchzoom regarding gesture center

### DIFF
--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -400,15 +400,16 @@ abstract class MapGestureMixin extends State<FlutterMap>
 
               if (_pinchMoveStarted) {
                 final oldCenterPt = mapState.project(mapState.center, newZoom);
-                final newFocalLatLong  = _offsetToCrs(_focalStartLocal,newZoom);
+                final newFocalLatLong = _offsetToCrs(_focalStartLocal, newZoom);
                 final newFocalPt = mapState.project(newFocalLatLong, newZoom);
                 final oldFocalPt = mapState.project(_focalStartLatLng, newZoom);
                 final zoomDifference = oldFocalPt - newFocalPt;
                 final moveDifference =
-                _rotateOffset(_focalStartLocal - _lastFocalLocal);
+                    _rotateOffset(_focalStartLocal - _lastFocalLocal);
 
-                final newCenterPt = oldCenterPt
-                    + zoomDifference + _offsetToPoint(moveDifference);
+                final newCenterPt = oldCenterPt +
+                    zoomDifference +
+                    _offsetToPoint(moveDifference);
                 newCenter = mapState.unproject(newCenterPt, newZoom);
               } else {
                 newCenter = mapState.center;
@@ -579,7 +580,8 @@ abstract class MapGestureMixin extends State<FlutterMap>
   }
 
   LatLng _offsetToCrs(Offset offset, [double? zoom]) {
-    final focalStartPt = mapState.project(mapState.center, zoom ?? mapState.zoom);
+    final focalStartPt =
+        mapState.project(mapState.center, zoom ?? mapState.zoom);
     final point = (_offsetToPoint(offset) - (mapState.originalSize! / 2.0))
         .rotate(mapState.rotationRad);
 

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -5,16 +5,12 @@ import 'dart:math';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
-import '../../flutter_map.dart';
-import '../core/point.dart';
-import 'interactive_flag.dart';
-import 'latlng_tween.dart';
-import 'multi_finger_gesture.dart';
-import '../map/map.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/gestures/interactive_flag.dart';
+import 'package:flutter_map/src/gestures/latlng_tween.dart';
+import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:positioned_tap_detector_2/positioned_tap_detector_2.dart';
-
-import 'map_events.dart';
 
 abstract class MapGestureMixin extends State<FlutterMap>
     with TickerProviderStateMixin {
@@ -108,9 +104,9 @@ abstract class MapGestureMixin extends State<FlutterMap>
       ..addListener(_handleFlingAnimation)
       ..addStatusListener(_flingAnimationStatusListener);
     _doubleTapController =
-    AnimationController(vsync: this, duration: Duration(milliseconds: 200))
-      ..addListener(_handleDoubleTapZoomAnimation)
-      ..addStatusListener(_doubleTapZoomStatusListener);
+        AnimationController(vsync: this, duration: Duration(milliseconds: 200))
+          ..addListener(_handleDoubleTapZoomAnimation)
+          ..addStatusListener(_doubleTapZoomStatusListener);
   }
 
   @override
@@ -121,7 +117,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
     final flags = options.interactiveFlags;
 
     final oldGestures =
-    _getMultiFingerGestureFlags(mapOptions: oldWidget.options);
+        _getMultiFingerGestureFlags(mapOptions: oldWidget.options);
     final gestures = _getMultiFingerGestureFlags();
 
     if (flags != oldFlags || gestures != oldGestures) {
@@ -281,7 +277,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
     }
 
     final eventSource =
-    _dragMode ? MapEventSource.onDrag : MapEventSource.onMultiFinger;
+        _dragMode ? MapEventSource.onDrag : MapEventSource.onMultiFinger;
 
     final flags = options.interactiveFlags;
     final focalOffset = details.localFocalPoint;
@@ -320,11 +316,11 @@ abstract class MapGestureMixin extends State<FlutterMap>
       }
     } else {
       final hasIntPinchMove =
-      InteractiveFlag.hasFlag(flags, InteractiveFlag.pinchMove);
+          InteractiveFlag.hasFlag(flags, InteractiveFlag.pinchMove);
       final hasIntPinchZoom =
-      InteractiveFlag.hasFlag(flags, InteractiveFlag.pinchZoom);
+          InteractiveFlag.hasFlag(flags, InteractiveFlag.pinchZoom);
       final hasIntRotate =
-      InteractiveFlag.hasFlag(flags, InteractiveFlag.rotate);
+          InteractiveFlag.hasFlag(flags, InteractiveFlag.rotate);
 
       if (hasIntPinchMove || hasIntPinchZoom || hasIntRotate) {
         final hasGestureRace = options.enableMultiFingerGestureRace;
@@ -332,7 +328,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
         if (hasGestureRace && _gestureWinner == MultiFingerGesture.none) {
           if (hasIntPinchZoom &&
               (_getZoomForScale(_mapZoomStart, details.scale) - _mapZoomStart)
-                  .abs() >=
+                      .abs() >=
                   options.pinchZoomThreshold) {
             if (options.debugMultiFingerGestureWinner) {
               print('Multi Finger Gesture winner: Pinch Zoom');
@@ -362,7 +358,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
           final hasGesturePinchZoom = MultiFingerGesture.hasFlag(
               gestures, MultiFingerGesture.pinchZoom);
           final hasGestureRotate =
-          MultiFingerGesture.hasFlag(gestures, MultiFingerGesture.rotate);
+              MultiFingerGesture.hasFlag(gestures, MultiFingerGesture.rotate);
 
           final hasMove = hasIntPinchMove && hasGesturePinchMove;
           final hasZoom = hasIntPinchZoom && hasGesturePinchZoom;
@@ -419,9 +415,11 @@ abstract class MapGestureMixin extends State<FlutterMap>
                 final newFocalPt = mapState.project(newFocalLatLong, newZoom);
                 final oldFocalPt = mapState.project(_focalStartLatLng, newZoom);
                 final zoomDifference = oldFocalPt - newFocalPt;
-                final moveDifference = _rotateOffset(_focalStartLocal - _lastFocalLocal);
+                final moveDifference =
+                _rotateOffset(_focalStartLocal - _lastFocalLocal);
 
-                final newCenterPt = oldCenterPt + zoomDifference + _offsetToPoint(moveDifference);
+                final newCenterPt = oldCenterPt
+                    + zoomDifference + _offsetToPoint(moveDifference);
                 newCenter = mapState.unproject(newCenterPt, newZoom);
               } else {
                 newCenter = mapState.center;
@@ -484,7 +482,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
     }
 
     final eventSource =
-    _dragMode ? MapEventSource.dragEnd : MapEventSource.multiFingerEnd;
+        _dragMode ? MapEventSource.dragEnd : MapEventSource.multiFingerEnd;
 
     if (_rotationStarted) {
       _rotationStarted = false;
@@ -528,8 +526,8 @@ abstract class MapGestureMixin extends State<FlutterMap>
 
     var direction = details.velocity.pixelsPerSecond / magnitude;
     var distance = (Offset.zero &
-    Size(mapState.originalSize!.x as double,
-        mapState.originalSize!.y as double))
+            Size(mapState.originalSize!.x as double,
+                mapState.originalSize!.y as double))
         .shortestSide;
 
     var _flingOffset = _focalStartLocal - _lastFocalLocal;
@@ -761,7 +759,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
 
   double _getZoomForScale(double startZoom, double scale) {
     var resultZoom =
-    scale == 1.0 ? startZoom : startZoom + math.log(scale) / math.ln2;
+        scale == 1.0 ? startZoom : startZoom + math.log(scale) / math.ln2;
     return mapState.fitZoomToBounds(resultZoom);
   }
 


### PR DESCRIPTION
old behaviour on pinchzoom was to zoom in regarding the map center. now it zooms in regarding the center of the pinch gesture like in google maps for example. I didn't add an option to change between the two as i cant imagine anyone would want to zoom into the center of the map when using pinchzoom. 