### PR TITLE
Added CachedTileProvider

### DIFF
--- a/lib/src/layer/tile_provider/tile_provider.dart
+++ b/lib/src/layer/tile_provider/tile_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
@@ -102,5 +103,17 @@ class CustomTileProvider extends TileProvider {
   @override
   ImageProvider getImage(Coords<num> coords, TileLayerOptions options) {
     return AssetImage(getTileUrl(coords, options));
+  }
+}
+
+///TileProvider that will cache the tile when the user visits. Thereby, when the user moves back to the same
+///tile, the cached instance will be used hence making it a smoother experience.
+class CachedTileProvider extends TileProvider {
+  const CachedTileProvider();
+  @override
+  ImageProvider getImage(Coords<num> coords, TileLayerOptions options) {
+    return CachedNetworkImageProvider(
+      getTileUrl(coords, options),
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   async: ^2.6.1
+  cached_network_image: ^3.2.0
   collection: ^1.15.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
**Issue Solved:** Using NetworkTileProvider, the experience isn't that much smoother. I have provided the definition for CachedTileProvider which uses cached_network_image to cache the tile image so that users can get a smoother experience.