### PR TITLE
Corrected equals type for Coords

### DIFF
--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -1439,7 +1439,7 @@ class Coords<T extends num> extends CustomPoint<T> {
   String toString() => 'Coords($x, $y, $z)';
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (other is Coords) {
       return x == other.x && y == other.y && z == other.z;
     }


### PR DESCRIPTION
Small but nasty type-problem, that won't let apply generic ==-overrides when extended.

https://api.flutter.dev/flutter/dart-core/Object/operator_equals.html