### PR TITLE
Added option to use pxCache and also length check on Markers to avoid crash

### DIFF
--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -8,6 +8,10 @@ import 'package:latlong2/latlong.dart';
 class MarkerLayerOptions extends LayerOptions {
   final List<Marker> markers;
 
+  /// Do we want to cache projections for performance, caching can
+  /// introduce inaccuracies if the cache is out of date
+  final bool usePxCache;
+
   /// If true markers will be counter rotated to the map rotation
   final bool? rotate;
 
@@ -38,6 +42,7 @@ class MarkerLayerOptions extends LayerOptions {
     this.rotate = false,
     this.rotateOrigin,
     this.rotateAlignment = Alignment.center,
+    this.usePxCache = true,
     Stream<Null>? rebuild,
   }) : super(key: key, rebuild: rebuild);
 }
@@ -191,10 +196,30 @@ class _MarkerLayerState extends State<MarkerLayer> {
   var _pxCache = <CustomPoint>[];
 
   // Calling this every time markerOpts change should guarantee proper length
-  List<CustomPoint> generatePxCache() => List.generate(
+  List<CustomPoint> generatePxCache() {
+    if (widget.markerLayerOptions.usePxCache) {
+      return List.generate(
         widget.markerLayerOptions.markers.length,
-        (i) => widget.map.project(widget.markerLayerOptions.markers[i].point),
+            (i) =>
+            widget.map.project(widget.markerLayerOptions.markers[i].point),
       );
+    }
+    return [];
+  }
+
+  bool updatePxCacheIfNeeded() {
+    var didUpdate = false;
+    /// markers may be modified, so update cache. Note, someone may
+    /// have not added to a cache, but modified, so this won't catch
+    /// this case. Parent widget setState should be called to call
+    /// didUpdateWidget to force a cache reload
+
+    if(widget.markerLayerOptions.markers.length != _pxCache.length) {
+      _pxCache = generatePxCache();
+      didUpdate = true;
+    }
+    return didUpdate;
+  }
 
   @override
   void initState() {
@@ -211,18 +236,28 @@ class _MarkerLayerState extends State<MarkerLayer> {
 
   @override
   Widget build(BuildContext context) {
+    
     return StreamBuilder<int?>(
       stream: widget.stream, // a Stream<int> or null
       builder: (BuildContext context, AsyncSnapshot<int?> snapshot) {
+
+
+        var layerOptions = widget.markerLayerOptions;
+        var map = widget.map;
+        var usePxCache = layerOptions.usePxCache;
         var markers = <Widget>[];
-        final sameZoom = widget.map.zoom == lastZoom;
-        for (var i = 0; i < widget.markerLayerOptions.markers.length; i++) {
-          var marker = widget.markerLayerOptions.markers[i];
+        final sameZoom = map.zoom == lastZoom;
+
+        var cacheUpdated = updatePxCacheIfNeeded();
+
+        for (var i = 0; i < layerOptions.markers.length; i++) {
+          var marker = layerOptions.markers[i];
 
           // Decide whether to use cached point or calculate it
           var pxPoint =
-              sameZoom ? _pxCache[i] : widget.map.project(marker.point);
-          if (!sameZoom) {
+            usePxCache && (sameZoom || cacheUpdated) ?
+              _pxCache[i] : map.project(marker.point);
+          if (!sameZoom && usePxCache) {
             _pxCache[i] = pxPoint;
           }
 
@@ -231,23 +266,23 @@ class _MarkerLayerState extends State<MarkerLayer> {
           var sw = CustomPoint(pxPoint.x + width, pxPoint.y - height);
           var ne = CustomPoint(pxPoint.x - width, pxPoint.y + height);
 
-          if (!widget.map.pixelBounds.containsPartialBounds(Bounds(sw, ne))) {
+          if (!map.pixelBounds.containsPartialBounds(Bounds(sw, ne))) {
             continue;
           }
 
-          final pos = pxPoint - widget.map.getPixelOrigin();
+          final pos = pxPoint - map.getPixelOrigin();
           final markerWidget =
-              (marker.rotate ?? widget.markerLayerOptions.rotate ?? false)
-                  // Counter rotated marker to the map rotation
-                  ? Transform.rotate(
-                      angle: -widget.map.rotationRad,
-                      origin: marker.rotateOrigin ??
-                          widget.markerLayerOptions.rotateOrigin,
-                      alignment: marker.rotateAlignment ??
-                          widget.markerLayerOptions.rotateAlignment,
-                      child: marker.builder(context),
-                    )
-                  : marker.builder(context);
+          (marker.rotate ?? layerOptions.rotate ?? false)
+          // Counter rotated marker to the map rotation
+              ? Transform.rotate(
+            angle: -map.rotationRad,
+            origin: marker.rotateOrigin ??
+                layerOptions.rotateOrigin,
+            alignment: marker.rotateAlignment ??
+                layerOptions.rotateAlignment,
+            child: marker.builder(context),
+          )
+              : marker.builder(context);
 
           markers.add(
             Positioned(
@@ -260,7 +295,7 @@ class _MarkerLayerState extends State<MarkerLayer> {
             ),
           );
         }
-        lastZoom = widget.map.zoom;
+        lastZoom = map.zoom;
         return Container(
           child: Stack(
             children: markers,
@@ -270,3 +305,4 @@ class _MarkerLayerState extends State<MarkerLayer> {
     );
   }
 }
+

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -8,8 +8,8 @@ import 'package:latlong2/latlong.dart';
 class MarkerLayerOptions extends LayerOptions {
   final List<Marker> markers;
 
-  /// Do we want to cache projections for performance, caching can
-  /// introduce inaccuracies if the cache is out of date
+  /// Toggle marker position caching. Enabling will improve performance, but may introducen
+  /// errors when adding/removing markers. Default is enabled (`true`).
   final bool usePxCache;
 
   /// If true markers will be counter rotated to the map rotation
@@ -195,13 +195,12 @@ class _MarkerLayerState extends State<MarkerLayer> {
   // https://stackoverflow.com/questions/15943890/is-there-a-performance-benefit-in-using-fixed-length-lists-in-dart
   var _pxCache = <CustomPoint>[];
 
-  // Calling this every time markerOpts change should guarantee proper length
+  /// Calling this every time markerOpts change should guarantee proper length
   List<CustomPoint> generatePxCache() {
     if (widget.markerLayerOptions.usePxCache) {
       return List.generate(
         widget.markerLayerOptions.markers.length,
-            (i) =>
-            widget.map.project(widget.markerLayerOptions.markers[i].point),
+        (i) => widget.map.project(widget.markerLayerOptions.markers[i].point),
       );
     }
     return [];
@@ -209,12 +208,13 @@ class _MarkerLayerState extends State<MarkerLayer> {
 
   bool updatePxCacheIfNeeded() {
     var didUpdate = false;
+
     /// markers may be modified, so update cache. Note, someone may
     /// have not added to a cache, but modified, so this won't catch
     /// this case. Parent widget setState should be called to call
     /// didUpdateWidget to force a cache reload
 
-    if(widget.markerLayerOptions.markers.length != _pxCache.length) {
+    if (widget.markerLayerOptions.markers.length != _pxCache.length) {
       _pxCache = generatePxCache();
       didUpdate = true;
     }
@@ -236,12 +236,9 @@ class _MarkerLayerState extends State<MarkerLayer> {
 
   @override
   Widget build(BuildContext context) {
-    
     return StreamBuilder<int?>(
       stream: widget.stream, // a Stream<int> or null
       builder: (BuildContext context, AsyncSnapshot<int?> snapshot) {
-
-
         var layerOptions = widget.markerLayerOptions;
         var map = widget.map;
         var usePxCache = layerOptions.usePxCache;
@@ -254,9 +251,9 @@ class _MarkerLayerState extends State<MarkerLayer> {
           var marker = layerOptions.markers[i];
 
           // Decide whether to use cached point or calculate it
-          var pxPoint =
-            usePxCache && (sameZoom || cacheUpdated) ?
-              _pxCache[i] : map.project(marker.point);
+          var pxPoint = usePxCache && (sameZoom || cacheUpdated)
+              ? _pxCache[i]
+              : map.project(marker.point);
           if (!sameZoom && usePxCache) {
             _pxCache[i] = pxPoint;
           }
@@ -271,17 +268,15 @@ class _MarkerLayerState extends State<MarkerLayer> {
           }
 
           final pos = pxPoint - map.getPixelOrigin();
-          final markerWidget =
-          (marker.rotate ?? layerOptions.rotate ?? false)
-          // Counter rotated marker to the map rotation
+          final markerWidget = (marker.rotate ?? layerOptions.rotate ?? false)
+              // Counter rotated marker to the map rotation
               ? Transform.rotate(
-            angle: -map.rotationRad,
-            origin: marker.rotateOrigin ??
-                layerOptions.rotateOrigin,
-            alignment: marker.rotateAlignment ??
-                layerOptions.rotateAlignment,
-            child: marker.builder(context),
-          )
+                  angle: -map.rotationRad,
+                  origin: marker.rotateOrigin ?? layerOptions.rotateOrigin,
+                  alignment:
+                      marker.rotateAlignment ?? layerOptions.rotateAlignment,
+                  child: marker.builder(context),
+                )
               : marker.builder(context);
 
           markers.add(
@@ -305,4 +300,3 @@ class _MarkerLayerState extends State<MarkerLayer> {
     );
   }
 }
-


### PR DESCRIPTION
Don't merge this without testing/checking. I'd like some thoughts first on whether we want an option to turn caching off, and if using map.var rather than widget.map.var is preferred or not. 

There's recently been a crash on MarkerLayer where the pxCache and the Markers didn't match up, after adding a marker after a tap.
This is a suggestion that looks to prevent the crash from happening, making sure we update if the lengths mismatch. Also added the option to turn off pxCaching as it "could" get out of date I think. Default is on.

There may be a better solution.
