### PR TITLE
Treat layers as internal plugins and refactor code

### DIFF
--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/map/flutter_map_state.dart';
 import 'package:flutter_map/src/map/map.dart';
+import 'package:flutter_map/src/plugins/internal/internal_plugins.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:positioned_tap_detector_2/positioned_tap_detector_2.dart';
 
@@ -17,16 +18,16 @@ export 'package:flutter_map/src/geo/latlng_bounds.dart';
 export 'package:flutter_map/src/gestures/interactive_flag.dart';
 export 'package:flutter_map/src/gestures/map_events.dart';
 export 'package:flutter_map/src/gestures/multi_finger_gesture.dart';
-export 'package:flutter_map/src/layer/circle_layer.dart';
-export 'package:flutter_map/src/layer/group_layer.dart';
 export 'package:flutter_map/src/layer/layer.dart';
-export 'package:flutter_map/src/layer/marker_layer.dart';
-export 'package:flutter_map/src/layer/overlay_image_layer.dart';
-export 'package:flutter_map/src/layer/polygon_layer.dart';
-export 'package:flutter_map/src/layer/polyline_layer.dart';
 export 'package:flutter_map/src/layer/tile_builder/tile_builder.dart';
-export 'package:flutter_map/src/layer/tile_layer.dart';
 export 'package:flutter_map/src/layer/tile_provider/tile_provider.dart';
+export 'package:flutter_map/src/plugins/internal/circle_layer.dart';
+export 'package:flutter_map/src/plugins/internal/group_layer.dart';
+export 'package:flutter_map/src/plugins/internal/marker_layer.dart';
+export 'package:flutter_map/src/plugins/internal/overlay_image_layer.dart';
+export 'package:flutter_map/src/plugins/internal/polygon_layer.dart';
+export 'package:flutter_map/src/plugins/internal/polyline_layer.dart';
+export 'package:flutter_map/src/plugins/internal/tile_layer.dart';
 export 'package:flutter_map/src/plugins/plugin.dart';
 
 /// Renders a map composed of a list of layers powered by [LayerOptions].
@@ -279,7 +280,7 @@ class MapOptions {
     this.onLongPress,
     this.onPositionChanged,
     this.onMapCreated,
-    this.plugins = const [],
+    List<MapPlugin> plugins = const [],
     this.slideOnBoundaries = false,
     this.adaptiveBoundaries = false,
     this.screenSize,
@@ -287,6 +288,8 @@ class MapOptions {
     this.swPanBoundary,
     this.nePanBoundary,
   })  : center = center ?? LatLng(50.5, 30.51),
+        plugins = List.unmodifiable(
+            [...InternalPlugins.internalPlugins, ...(plugins)]),
         assert(rotationThreshold >= 0.0),
         assert(pinchZoomThreshold >= 0.0),
         assert(pinchMoveThreshold >= 0.0) {

--- a/lib/src/layer/tile_builder/tile_builder.dart
+++ b/lib/src/layer/tile_builder/tile_builder.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_map/src/layer/tile_layer.dart';
+import 'package:flutter_map/src/plugins/internal/tile_layer.dart';
 
 typedef TileBuilder = Widget Function(
     BuildContext context, Widget tileWidget, Tile tile);

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -196,28 +196,6 @@ class FlutterMapState extends MapGestureMixin {
         return plugin.createLayer(options, mapState, _merge(options));
       }
     }
-    if (options is TileLayerOptions) {
-      return TileLayer(
-          options: options, mapState: mapState, stream: _merge(options));
-    }
-    if (options is MarkerLayerOptions) {
-      return MarkerLayer(options, mapState, _merge(options));
-    }
-    if (options is PolylineLayerOptions) {
-      return PolylineLayer(options, mapState, _merge(options));
-    }
-    if (options is PolygonLayerOptions) {
-      return PolygonLayer(options, mapState, _merge(options));
-    }
-    if (options is CircleLayerOptions) {
-      return CircleLayer(options, mapState, _merge(options));
-    }
-    if (options is GroupLayerOptions) {
-      return GroupLayer(options, mapState, _merge(options));
-    }
-    if (options is OverlayImageLayerOptions) {
-      return OverlayImageLayer(options, mapState, _merge(options));
-    }
     throw (StateError("""
 Can't find correct layer for $options. Perhaps when you create your FlutterMap you need something like this:
 

--- a/lib/src/plugins/internal/circle_layer.dart
+++ b/lib/src/plugins/internal/circle_layer.dart
@@ -3,6 +3,17 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong2/latlong.dart' hide Path;
 
+class CircleLayerPlugin extends MapPlugin {
+  @override
+  Widget createLayer(
+      LayerOptions options, MapState mapState, Stream<Null> stream) {
+    return CircleLayer(options as CircleLayerOptions, mapState, stream);
+  }
+
+  @override
+  bool supportsLayer(LayerOptions options) => options is CircleLayerOptions;
+}
+
 class CircleLayerOptions extends LayerOptions {
   final List<CircleMarker> circles;
   CircleLayerOptions({

--- a/lib/src/plugins/internal/internal_plugins.dart
+++ b/lib/src/plugins/internal/internal_plugins.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_map/flutter_map.dart';
+
+class InternalPlugins {
+  static List<MapPlugin> internalPlugins = [
+    CircleLayerPlugin(),
+    GroupLayerPlugin(),
+    MarkerLayerPlugin(),
+    OverlayImageLayerPlugin(),
+    PolygonLayerPlugin(),
+    PolylineLayerPlugin(),
+    TileLayerPlugin(),
+  ];
+}

--- a/lib/src/plugins/internal/marker_layer.dart
+++ b/lib/src/plugins/internal/marker_layer.dart
@@ -4,6 +4,17 @@ import 'package:flutter_map/src/core/bounds.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong2/latlong.dart';
 
+class MarkerLayerPlugin extends MapPlugin {
+  @override
+  Widget createLayer(
+      LayerOptions options, MapState mapState, Stream<Null> stream) {
+    return MarkerLayer(options as MarkerLayerOptions, mapState, stream);
+  }
+
+  @override
+  bool supportsLayer(LayerOptions options) => options is MarkerLayerOptions;
+}
+
 /// Configuration for marker layer
 class MarkerLayerOptions extends LayerOptions {
   final List<Marker> markers;

--- a/lib/src/plugins/internal/overlay_image_layer.dart
+++ b/lib/src/plugins/internal/overlay_image_layer.dart
@@ -4,6 +4,19 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/map/map.dart';
 
+class OverlayImageLayerPlugin extends MapPlugin {
+  @override
+  Widget createLayer(
+      LayerOptions options, MapState mapState, Stream<Null> stream) {
+    return OverlayImageLayer(
+        options as OverlayImageLayerOptions, mapState, stream);
+  }
+
+  @override
+  bool supportsLayer(LayerOptions options) =>
+      options is OverlayImageLayerOptions;
+}
+
 class OverlayImageLayerOptions extends LayerOptions {
   final List<OverlayImage> overlayImages;
 

--- a/lib/src/plugins/internal/polygon_layer.dart
+++ b/lib/src/plugins/internal/polygon_layer.dart
@@ -6,6 +6,17 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong2/latlong.dart' hide Path; // conflict with Path from UI
 
+class PolygonLayerPlugin extends MapPlugin {
+  @override
+  Widget createLayer(
+      LayerOptions options, MapState mapState, Stream<Null> stream) {
+    return PolygonLayer(options as PolygonLayerOptions, mapState, stream);
+  }
+
+  @override
+  bool supportsLayer(LayerOptions options) => options is PolygonLayerOptions;
+}
+
 class PolygonLayerOptions extends LayerOptions {
   final List<Polygon> polygons;
   final bool polygonCulling;

--- a/lib/src/plugins/internal/polyline_layer.dart
+++ b/lib/src/plugins/internal/polyline_layer.dart
@@ -6,6 +6,17 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong2/latlong.dart';
 
+class PolylineLayerPlugin extends MapPlugin {
+  @override
+  Widget createLayer(
+      LayerOptions options, MapState mapState, Stream<Null> stream) {
+    return PolylineLayer(options as PolylineLayerOptions, mapState, stream);
+  }
+
+  @override
+  bool supportsLayer(LayerOptions options) => options is PolylineLayerOptions;
+}
+
 class PolylineLayerOptions extends LayerOptions {
   final List<Polyline> polylines;
   final bool polylineCulling;

--- a/lib/src/plugins/internal/tile_layer.dart
+++ b/lib/src/plugins/internal/tile_layer.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 import 'package:collection/collection.dart' show MapEquality;
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/core/bounds.dart';
 import 'package:flutter_map/src/core/point.dart';
 import 'package:flutter_map/src/core/util.dart' as util;
@@ -14,7 +15,7 @@ import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:tuple/tuple.dart';
 
-import 'layer.dart';
+import '../../layer/layer.dart';
 
 typedef TemplateFunction = String Function(
     String str, Map<String, String> data);
@@ -33,6 +34,20 @@ enum EvictErrorTileStrategy {
 }
 
 typedef ErrorTileCallBack = void Function(Tile tile, dynamic error);
+
+class TileLayerPlugin extends MapPlugin {
+  @override
+  Widget createLayer(
+      LayerOptions options, MapState mapState, Stream<Null> stream) {
+    return TileLayer(
+        options: options as TileLayerOptions,
+        mapState: mapState,
+        stream: stream);
+  }
+
+  @override
+  bool supportsLayer(LayerOptions options) => options is TileLayer;
+}
 
 /// Describes the needed properties to create a tile-based layer. A tile is an
 /// image bound to a specific geographical position.

--- a/lib/src/plugins/plugin.dart
+++ b/lib/src/plugins/plugin.dart
@@ -5,5 +5,8 @@ import 'package:flutter_map/src/map/map.dart';
 abstract class MapPlugin {
   bool supportsLayer(LayerOptions options);
   Widget createLayer(
-      LayerOptions options, MapState mapState, Stream<Null> stream);
+    LayerOptions options,
+    MapState mapState,
+    Stream<Null> stream,
+  );
 }


### PR DESCRIPTION
This PR moves the implementation of layers e.g. TileLayer, CircleLayer to be treated as plugins. The internal original implementation remains unchanged.

Benefits
- "Dog fooding" the Plugin implementation
- Removes lots of IF's when dealing with layers, now we just iterate over them
- 3rd party plugins should work with group layers

I have kept the same API in MapPlugin however it would have been good if it took a generic of `<T extends LayerOptions>` to avoid later casting... but doing so would mean if this was accepted then all plugins would need to perform an update, which seems a lot of overhead. This change can still be made but would need some community coordination etc.