### PR TITLE
Refactor MapState Widgets

### DIFF
--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -154,39 +154,32 @@ class FlutterMapState extends MapGestureMixin {
   }
 
   Widget _buildMap(var size) {
-    return ClipRect(
-      child: Stack(
-        children: [
-          OverflowBox(
-            minWidth: size.x as double?,
-            maxWidth: size.x as double?,
-            minHeight: size.y as double?,
-            maxHeight: size.y as double?,
-            child: Transform.rotate(
-              angle: mapState.rotationRad,
-              child: Stack(
-                children: [
-                  if (widget.children.isNotEmpty) ...widget.children,
-                  if (widget.layers.isNotEmpty)
-                    ...widget.layers.map(
-                      (layer) => _createLayer(layer, options.plugins),
-                    )
-                ],
-              ),
-            ),
-          ),
-          Stack(
-            children: [
-              if (widget.nonRotatedChildren.isNotEmpty)
-                ...widget.nonRotatedChildren,
-              if (widget.nonRotatedLayers.isNotEmpty)
-                ...widget.nonRotatedLayers.map(
+    return Stack(
+      children: [
+        SizedBox(
+          width: size.x as double?,
+          height: size.x as double?,
+          child: Transform.rotate(
+            angle: mapState.rotationRad,
+            child: Stack(
+              children: [
+                ...widget.children,
+                ...widget.layers.map(
                   (layer) => _createLayer(layer, options.plugins),
                 )
-            ],
+              ],
+            ),
           ),
-        ],
-      ),
+        ),
+        Stack(
+          children: [
+            ...widget.nonRotatedChildren,
+            ...widget.nonRotatedLayers.map(
+              (layer) => _createLayer(layer, options.plugins),
+            )
+          ],
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
A minor PR

I *think* we weren't using the OverflowBox and after testing I could not see a difference compared using a SizedBox as the min and max took the same values.

The ClipRect *seemed* redundant too.

I have ran the changes on the example in the project and could not spot the difference but its not to say there isn't one.

EDIT - also noticed the IF checks were redundant when creating the stack children. If the lists are empty then the combined list will be too. Same for the map, mapping on the empty list will just exit with an empty output.