### PR TITLE
possible fix for opacity widget causing hairlines and possible flicker

### DIFF
--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -1381,14 +1381,11 @@ class _AnimatedTileState extends State<AnimatedTile> {
         : RawImage(
             image: widget.tile.imageInfo?.image,
             fit: BoxFit.fill,
-          );
+            opacity: widget.tile.animationController);
 
-    return Opacity(
-      opacity: widget.tile.opacity,
-      child: widget.tileBuilder == null
-          ? tileWidget
-          : widget.tileBuilder!(context, tileWidget, widget.tile),
-    );
+    return widget.tileBuilder == null
+        ? tileWidget
+        : widget.tileBuilder!(context, tileWidget, widget.tile);
   }
 
   @override


### PR DESCRIPTION
This is a possible workaround for the flicker and hairline issues https://github.com/fleaflet/flutter_map/issues/1126 & https://github.com/fleaflet/flutter_map/issues/1156

It removes the Opacity widget (I'm not sure this is going to get fixed easily by Flutter, so think we will have to create our own), and introduces the opacity to the RawImage instead.

This feels possibly logical, however, I'm not confident on the Animated Tile stuff, so this may not be exactly the same.... I assume the opacity at this position is for fading in new tilesets/zooms ? If anyone knows this part of the code, it would be useful to give some thoughts, as I'm a little unsure how to test it properly.

It would also be useful for those with the initial problems to see if it helps.

Rotation needs to be disabled for the original hairline type issues to appear, i.e interactiveFlags: ~InteractiveFlag.rotate in MapOptions