### PR TITLE
Added beta documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Join the Discord server: <https://discord.gg/egEGeByf4q>!
 
 Talk about 'flutter_map', get and give help, and receive notifications about new 'flutter_map' updates! More additions planned in the future.
 
-## [Beta Documentation](https://deploy-preview-10--fleaflet-docs.netlify.app)
+## [Beta Documentation](https://fleaflet-docs.netlify.app)
 
-View the beta documentation: <https://deploy-preview-10--fleaflet-docs.netlify.app/>!  
+View the beta documentation: <https://fleaflet-docs.netlify.app>!  
 Link liable to break and/or change. Most contents should be correct (but not yet verified), but some documentation may be missing/misleading.
 
 Any feedback is appreciated! Please comment or leave a code review on [pull request #992](/pull/992).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,22 @@ A versatile mapping package for Flutter, based off of ['leaflet.js'](https://lea
 [![Pub.dev](https://img.shields.io/pub/v/flutter_map.svg?label=Latest+Version)](https://pub.dev/packages/flutter_map) [![Checks & Tests](https://badgen.net/github/checks/fleaflet/flutter_map?label=Checks+%26+Tests&color=orange)](https://github.com/fleaflet/flutter_map/actions?query=branch%3Amaster) [![points](https://badges.bar/flutter_map/pub%20points)](https://pub.dev/packages/flutter_map/score)  
 [![stars](https://badgen.net/github/stars/fleaflet/flutter_map?label=stars&color=green&icon=github)](https://github.com/fleaflet/flutter_map/stargazers) [![likes](https://badges.bar/flutter_map/likes)](https://pub.dev/packages/flutter_map/score)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[![Open Issues](https://badgen.net/github/open-issues/fleaflet/flutter_map?label=Open+Issues&color=green)](https://GitHub.com/fleaflet/flutter_map/issues) [![Open PRs](https://badgen.net/github/open-prs/fleaflet/flutter_map?label=Open+PRs&color=green)](https://GitHub.com/fleaflet/flutter_map/pulls)
 
-Join the Discord server: https://discord.gg/egEGeByf4q
+---
+
+## [Discord Server](https://discord.gg/egEGeByf4q)
+
+Join the Discord server: <https://discord.gg/egEGeByf4q>!
+
+Talk about 'flutter_map', get and give help, and receive notifications about new 'flutter_map' updates! More additions planned in the future.
+
+## [Beta Documentation](https://deploy-preview-10--fleaflet-docs.netlify.app)
+
+View the beta documentation: <https://deploy-preview-10--fleaflet-docs.netlify.app/>!  
+Link liable to break and/or change. Most contents should be correct (but not yet verified), but some documentation may be missing/misleading.
+
+Any feedback is appreciated! Please comment or leave a code review on [pull request #992](/pull/992).
+
+---
 
 ## Installation & Configuration
 


### PR DESCRIPTION
Added link to <https://fleaflet-docs.netlify.app>, and link to #992 to leave feedback.
Made Discord link more prominent, along with beta documentation section.

No other changes.