### PR TITLE
Fix initial fit bounds

### DIFF
--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -77,14 +77,25 @@ class FlutterMapState extends MapGestureMixin {
   Widget build(BuildContext context) {
     _disposeStreamGroups();
     return LayoutBuilder(
-        builder: (BuildContext context, BoxConstraints constraints) {
-      mapState.setOriginalSize(constraints.maxWidth, constraints.maxHeight);
-      var size = mapState.size;
+      builder: (BuildContext context, BoxConstraints constraints) {
 
-      var scaleGestureTeam = GestureArenaTeam();
+        var hasLateSize = mapState.hasLateSize(constraints);
 
-      var scaleGestureDetector = ({required Widget child}) =>
-          RawGestureDetector(
+        mapState.setOriginalSize(constraints.maxWidth, constraints.maxHeight);
+
+        // It's possible on first call to LayoutBuilder, it may not know a size
+        // which will cause methods like fitBounds to break. These methods
+        // could be called in initIfLateSize()
+        if(hasLateSize) {
+          mapState.initIfLateSize();
+        }
+        var size = mapState.size;
+
+        var scaleGestureTeam = GestureArenaTeam();
+
+        var scaleGestureDetector = ({required Widget child}) =>
+
+        RawGestureDetector(
             gestures: <Type, GestureRecognizerFactory>{
               ScaleGestureRecognizer:
                   GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -77,25 +77,23 @@ class FlutterMapState extends MapGestureMixin {
   Widget build(BuildContext context) {
     _disposeStreamGroups();
     return LayoutBuilder(
-      builder: (BuildContext context, BoxConstraints constraints) {
+        builder: (BuildContext context, BoxConstraints constraints) {
+      var hasLateSize = mapState.hasLateSize(constraints);
 
-        var hasLateSize = mapState.hasLateSize(constraints);
+      mapState.setOriginalSize(constraints.maxWidth, constraints.maxHeight);
 
-        mapState.setOriginalSize(constraints.maxWidth, constraints.maxHeight);
+      // It's possible on first call to LayoutBuilder, it may not know a size
+      // which will cause methods like fitBounds to break. These methods
+      // could be called in initIfLateSize()
+      if (hasLateSize) {
+        mapState.initIfLateSize();
+      }
+      var size = mapState.size;
 
-        // It's possible on first call to LayoutBuilder, it may not know a size
-        // which will cause methods like fitBounds to break. These methods
-        // could be called in initIfLateSize()
-        if(hasLateSize) {
-          mapState.initIfLateSize();
-        }
-        var size = mapState.size;
+      var scaleGestureTeam = GestureArenaTeam();
 
-        var scaleGestureTeam = GestureArenaTeam();
-
-        var scaleGestureDetector = ({required Widget child}) =>
-
-        RawGestureDetector(
+      var scaleGestureDetector = ({required Widget child}) =>
+          RawGestureDetector(
             gestures: <Type, GestureRecognizerFactory>{
               ScaleGestureRecognizer:
                   GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -181,8 +181,10 @@ class MapState {
   // Check if we've just got a new size constraints. Initially a layoutBuilder
   // May not be able to calculate a size, and end up with 0,0
   bool hasLateSize(constraints) {
-    if(options.bounds != null && originalSize != null &&
-        originalSize!.x == 0.0 && constraints.maxWidth != 0.0) {
+    if (options.bounds != null &&
+        originalSize != null &&
+        originalSize!.x == 0.0 &&
+        constraints.maxWidth != 0.0) {
       return true;
     }
     return false;
@@ -191,7 +193,7 @@ class MapState {
   // If we've just calculated a size, we may want to call some methods that
   // rely on it, like fitBounds. Add any others here.
   void initIfLateSize() {
-    if(options.bounds != null) {
+    if (options.bounds != null) {
       fitBounds(options.bounds!, options.boundsOptions);
     }
   }

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -178,6 +178,24 @@ class MapState {
     }
   }
 
+  // Check if we've just got a new size constraints. Initially a layoutBuilder
+  // May not be able to calculate a size, and end up with 0,0
+  bool hasLateSize(constraints) {
+    if(options.bounds != null && originalSize != null &&
+        originalSize!.x == 0.0 && constraints.maxWidth != 0.0) {
+      return true;
+    }
+    return false;
+  }
+
+  // If we've just calculated a size, we may want to call some methods that
+  // rely on it, like fitBounds. Add any others here.
+  void initIfLateSize() {
+    if(options.bounds != null) {
+      fitBounds(options.bounds!, options.boundsOptions);
+    }
+  }
+
   void _handleMoveEmit(LatLng targetCenter, double targetZoom, hasGesture,
       MapEventSource source, String? id) {
     if (source == MapEventSource.flingAnimationController) {


### PR DESCRIPTION
Fix for problem where bounds sometimes breaks on an initial layoutBuilder that doesn't have a valid constraints size, and causes fixBounds to break. (sorry created a branch here, but didn't mean to!)