### PR TITLE
refacto: added saveLayers parameter

### DIFF
--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -14,8 +14,12 @@ class PolylineLayerOptions extends LayerOptions {
 
   /// {@macro newPolylinePainter.saveLayers}
   ///
-  /// By default, this is value is set to `false` to improve performance on
+  /// By default, this value is set to `false` to improve performance on
   /// layers containing a lot of polylines.
+  ///
+  /// You might want to set this to `true` if you get unwanted darker lines
+  /// where they overlap but, keep in mind that this might reduce the
+  /// performance of the layer.
   final bool saveLayers;
 
   PolylineLayerOptions({


### PR DESCRIPTION
Solve #1217 

- Added saveLayers parameter to PolylineLayerOptions & PolylinePainter to enable or disable calls to canvas.saveLayer & canvas.restore (by default at `false` as advised in [ibrierley's comment](https://github.com/fleaflet/flutter_map/issues/1217#issuecomment-1101791862))
- Replaced calls to path.lineTo by path.addPolygon in PolylinePainter._paintLine (recommended here: https://github.com/fleaflet/flutter_map/issues/1165#issuecomment-1055342364)