### PR TITLE
Add polygon label placement options

### DIFF
--- a/lib/src/layer/label.dart
+++ b/lib/src/layer/label.dart
@@ -1,26 +1,30 @@
-import 'dart:math';
+import 'dart:math' as math;
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_map/plugin_api.dart';
+import 'package:polylabel/polylabel.dart';
 
 class Label {
   static void paintText(
     Canvas canvas,
     List<Offset> points,
     String? labelText,
-    TextStyle? labelStyle,
-  ) {
-    var maxDx = 0.0;
-    var minDx = double.infinity;
-    var dx = points.map((e) => e.dx).toList().fold<double>(0.0,
-            (previousValue, element) {
-          maxDx = max(maxDx, element);
-          minDx = min(minDx, element);
-          return previousValue + element;
-        }) /
-        points.length;
-    var dy = points.map((e) => e.dy).toList().fold<double>(
-            0.0, (previousValue, element) => previousValue + element) /
-        points.length;
+    TextStyle? labelStyle, {
+    PolygonLabelPlacement labelPlacement = PolygonLabelPlacement.centroid,
+  }) {
+    late Offset placementPoint;
+    switch (labelPlacement) {
+      case PolygonLabelPlacement.centroid:
+        placementPoint = _computeCentroid(points);
+        break;
+      case PolygonLabelPlacement.polylabel:
+        placementPoint = _computePolylabel(points);
+        break;
+    }
+
+    var dx = placementPoint.dx;
+    var dy = placementPoint.dy;
 
     final textSpan = TextSpan(text: labelText, style: labelStyle);
     final textPainter = TextPainter(
@@ -31,8 +35,15 @@ class Label {
     );
     if (dx > 0) {
       textPainter.layout(minWidth: 0, maxWidth: double.infinity);
-      dx = dx - textPainter.width / 2;
-      dy = dy - textPainter.height / 2;
+      dx -= textPainter.width / 2;
+      dy -= textPainter.height / 2;
+
+      var maxDx = 0.0;
+      var minDx = double.infinity;
+      for (final point in points) {
+        maxDx = math.max(maxDx, point.dx);
+        minDx = math.min(minDx, point.dx);
+      }
 
       if (maxDx - minDx > textPainter.width) {
         textPainter.paint(
@@ -41,5 +52,22 @@ class Label {
         );
       }
     }
+  }
+
+  static Offset _computeCentroid(List<Offset> points) {
+    return Offset(
+      points.map((e) => e.dx).toList().average,
+      points.map((e) => e.dy).toList().average,
+    );
+  }
+
+  static Offset _computePolylabel(List<Offset> points) {
+    final labelPosition = polylabel([
+      points.map((p) => math.Point(p.dx, p.dy)).toList(),
+    ]);
+    return Offset(
+      labelPosition.point.x.toDouble(),
+      labelPosition.point.y.toDouble(),
+    );
   }
 }

--- a/lib/src/layer/label.dart
+++ b/lib/src/layer/label.dart
@@ -11,7 +11,7 @@ class Label {
     List<Offset> points,
     String? labelText,
     TextStyle? labelStyle, {
-    PolygonLabelPlacement labelPlacement = PolygonLabelPlacement.centroid,
+    PolygonLabelPlacement labelPlacement = PolygonLabelPlacement.polylabel,
   }) {
     late Offset placementPoint;
     switch (labelPlacement) {

--- a/lib/src/layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer.dart
@@ -26,6 +26,11 @@ class PolygonLayerOptions extends LayerOptions {
   }
 }
 
+enum PolygonLabelPlacement {
+  centroid,
+  polylabel,
+}
+
 class Polygon {
   final List<LatLng> points;
   final List<Offset> offsets = [];
@@ -40,6 +45,7 @@ class Polygon {
   late final LatLngBounds boundingBox;
   final String? label;
   final TextStyle labelStyle;
+  final PolygonLabelPlacement labelPlacement;
 
   Polygon({
     required this.points,
@@ -52,6 +58,7 @@ class Polygon {
     this.isFilled = false,
     this.label,
     this.labelStyle = const TextStyle(),
+    this.labelPlacement = PolygonLabelPlacement.centroid,
   }) : holeOffsetsList = null == holePointsList || holePointsList.isEmpty
             ? null
             : List.generate(holePointsList.length, (_) => []);
@@ -268,6 +275,7 @@ class PolygonPainter extends CustomPainter {
           polygonOpt.offsets,
           polygonOpt.label,
           polygonOpt.labelStyle,
+          labelPlacement: polygonOpt.labelPlacement,
         );
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   intl: ^0.17.0
   latlong2: ^0.8.0
   meta: ^1.3.0
+  polylabel: ^1.0.1
   positioned_tap_detector_2: ^1.0.4
   proj4dart: ^2.0.0
   transparent_image: ^2.0.0


### PR DESCRIPTION
Saw [this PR](https://github.com/fleaflet/flutter_map/pull/1220) about centered labels for polygons today.

I think it can be useful to add an option to place the label using [Dart polylabel](https://github.com/beroso/dart_polylabel). It works well on both convex and concave polygons.

Example:

| Centroid (current approach)  | Polylabel |
| ------------- | ------------- |
| <img width="234" alt="Screen Shot 2022-05-05 at 17 44 31" src="https://user-images.githubusercontent.com/7874200/167022894-1133b581-fc94-4de7-83d4-0fe45b9ef71a.png"> | <img width="224" alt="Screen Shot 2022-05-05 at 17 44 07" src="https://user-images.githubusercontent.com/7874200/167022958-ecc1703a-af4d-4de8-a2d1-b0711e305d0e.png"> |