### PR TITLE
[BUG] Emit move event even when source is custom #1231

### DIFF
--- a/example/lib/pages/tile_loading_error_handle.dart
+++ b/example/lib/pages/tile_loading_error_handle.dart
@@ -50,7 +50,7 @@ class _TileLoadingErrorHandleState extends State<TileLoadingErrorHandle> {
                       tileProvider: const NonCachingNetworkTileProvider(),
                       errorTileCallback: (Tile tile, error) {
                         if (_needLoadingError) {
-                          WidgetsBinding.instance?.addPostFrameCallback((_) {
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
                             ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                               duration: const Duration(seconds: 1),
                               content: Text(

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -255,6 +255,23 @@ class MapState {
           source: source,
         ),
       );
+    } else if (source == MapEventSource.custom) {
+      // for custom source, emit move event if zoom or center has changed
+      if (targetZoom != _zoom ||
+          _lastCenter == null ||
+          targetCenter.latitude != _lastCenter!.latitude ||
+          targetCenter.longitude != _lastCenter!.longitude) {
+        emitMapEvent(
+          MapEventMove(
+            id: id,
+            center: _lastCenter!,
+            zoom: _zoom,
+            targetCenter: targetCenter,
+            targetZoom: targetZoom,
+            source: source,
+          ),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
As outlined in #1231, and discussed in Discord on 2022-05-11, certain zoom changes do not cause a move event to be emitted. This appears to be a bug, as probably everything changing the bounds should cause such an event. I am using flutter_map together with the flutter_map_marker_cluster plugin which e.g. zooms in if you tap on a cluster and thus changes the bounds, and I need to be able to react to that.

Therefore, I propose the following change to MapState._handleMoveEmit():

If source is custom, and targetZoom or targetCenter are different than before, a move event is emitted.

Thank you for your time and for flutter_map in general 😃 