### PR TITLE
Enable stricter linter rules.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,18 @@
 include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+  errors:
+    close_sinks: ignore
+    missing_required_param: error
+    missing_return: error
+
 linter:
   rules:
     prefer_final_locals: true
     prefer_final_in_for_each: true
     avoid_dynamic_calls: true
     always_use_package_imports: true
+    type_annotate_public_apis: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,6 @@
 include: package:flutter_lints/flutter.yaml
 linter:
   rules:
+    prefer_final_locals: true
+    prefer_final_in_for_each: true
+    avoid_dynamic_calls: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,3 +4,4 @@ linter:
     prefer_final_locals: true
     prefer_final_in_for_each: true
     avoid_dynamic_calls: true
+    always_use_package_imports: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,3 +16,5 @@ linter:
     avoid_dynamic_calls: true
     always_use_package_imports: true
     type_annotate_public_apis: true
+    prefer_int_literals: true
+    use_named_constants: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,3 @@
 include: package:flutter_lints/flutter.yaml
 linter:
   rules:
-    library_private_types_in_public_api: false

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -428,7 +428,7 @@ class _SafeArea {
         isLatitudeBlocked = southWest.latitude > northEast.latitude,
         isLongitudeBlocked = southWest.longitude > northEast.longitude;
 
-  bool contains(point) =>
+  bool contains(LatLng? point) =>
       isLatitudeBlocked || isLongitudeBlocked ? false : bounds.contains(point);
 
   LatLng containPoint(LatLng point, LatLng fallback) => LatLng(

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -4,9 +4,16 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/core/center_zoom.dart';
+import 'package:flutter_map/src/geo/crs/crs.dart';
+import 'package:flutter_map/src/geo/latlng_bounds.dart';
+import 'package:flutter_map/src/gestures/interactive_flag.dart';
+import 'package:flutter_map/src/gestures/map_events.dart';
+import 'package:flutter_map/src/gestures/multi_finger_gesture.dart';
+import 'package:flutter_map/src/layer/layer.dart';
 import 'package:flutter_map/src/map/flutter_map_state.dart';
 import 'package:flutter_map/src/map/map.dart';
+import 'package:flutter_map/src/plugins/plugin.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:positioned_tap_detector_2/positioned_tap_detector_2.dart';
 

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -391,7 +391,7 @@ class FitBoundsOptions {
   final bool inside;
 
   const FitBoundsOptions({
-    this.padding = const EdgeInsets.all(0.0),
+    this.padding = EdgeInsets.zero,
     this.maxZoom = 17.0,
     this.zoom,
     this.inside = false,

--- a/lib/src/core/bounds.dart
+++ b/lib/src/core/bounds.dart
@@ -9,8 +9,8 @@ class Bounds<T extends num> {
   final CustomPoint<T> max;
 
   factory Bounds(CustomPoint<T> a, CustomPoint<T> b) {
-    var bounds1 = Bounds._(a, b);
-    var bounds2 = bounds1.extend(a);
+    final bounds1 = Bounds._(a, b);
+    final bounds2 = bounds1.extend(a);
     return bounds2.extend(b);
   }
 
@@ -55,8 +55,8 @@ class Bounds<T extends num> {
   }
 
   bool contains(CustomPoint<T> point) {
-    var min = point;
-    var max = point;
+    final min = point;
+    final max = point;
     return containsBounds(Bounds(min, max));
   }
 

--- a/lib/src/core/util.dart
+++ b/lib/src/core/util.dart
@@ -11,11 +11,11 @@ var _templateRe = RegExp(r'\{ *([\w_-]+) *\}');
 /// Throws an [Exception] if any placeholder remains unresolved.
 String template(String str, Map<String, String> data) {
   return str.replaceAllMapped(_templateRe, (Match match) {
-    var firstMatch = match.group(1);
+    final firstMatch = match.group(1);
     if (firstMatch == null) {
       throw Exception('incorrect URL template: $str');
     }
-    var value = data[firstMatch];
+    final value = data[firstMatch];
     if (value == null) {
       throw Exception('No value provided for variable ${match.group(1)}');
     } else {
@@ -25,9 +25,9 @@ String template(String str, Map<String, String> data) {
 }
 
 double wrapNum(double x, Tuple2<double, double> range, [bool? includeMax]) {
-  var max = range.item2;
-  var min = range.item1;
-  var d = max - min;
+  final max = range.item2;
+  final min = range.item1;
+  final d = max - min;
   return x == max && includeMax != null ? x : ((x - min) % d + d) % d + min;
 }
 

--- a/lib/src/geo/crs/crs.dart
+++ b/lib/src/geo/crs/crs.dart
@@ -104,7 +104,7 @@ abstract class Earth extends Crs {
   bool get infinite => false;
 
   @override
-  final Tuple2<double, double> wrapLng = const Tuple2(-180.0, 180.0);
+  final Tuple2<double, double> wrapLng = const Tuple2(-180, 180);
 
   @override
   final Tuple2<double, double>? wrapLat = null;

--- a/lib/src/geo/crs/crs.dart
+++ b/lib/src/geo/crs/crs.dart
@@ -25,8 +25,8 @@ abstract class Crs {
   /// map point.
   CustomPoint latLngToPoint(LatLng latlng, double zoom) {
     try {
-      var projectedPoint = projection.project(latlng);
-      var scale = this.scale(zoom);
+      final projectedPoint = projection.project(latlng);
+      final scale = this.scale(zoom);
       return transformation.transform(projectedPoint, scale.toDouble());
     } catch (e) {
       return const CustomPoint(0.0, 0.0);
@@ -35,8 +35,8 @@ abstract class Crs {
 
   /// Converts a map point to the sphere coordinate (at a certain zoom).
   LatLng? pointToLatLng(CustomPoint point, double zoom) {
-    var scale = this.scale(zoom);
-    var untransformedPoint =
+    final scale = this.scale(zoom);
+    final untransformedPoint =
         transformation.untransform(point, scale.toDouble());
     try {
       return projection.unproject(untransformedPoint);
@@ -59,10 +59,10 @@ abstract class Crs {
   Bounds? getProjectedBounds(double zoom) {
     if (infinite) return null;
 
-    var b = projection.bounds!;
-    var s = scale(zoom);
-    var min = transformation.transform(b.min, s.toDouble());
-    var max = transformation.transform(b.max, s.toDouble());
+    final b = projection.bounds!;
+    final s = scale(zoom);
+    final min = transformation.transform(b.min, s.toDouble());
+    final max = transformation.transform(b.max, s.toDouble());
     return Bounds(min, max);
   }
 
@@ -198,7 +198,7 @@ class Proj4Crs extends Crs {
     final projection =
         _Proj4Projection(proj4Projection: proj4Projection, bounds: bounds);
     List<Transformation>? transformations;
-    var infinite = null == bounds;
+    final infinite = null == bounds;
     List<double> finalScales;
 
     if (null != scales && scales.isNotEmpty) {
@@ -214,7 +214,7 @@ class Proj4Crs extends Crs {
       transformation ??= const Transformation(1, 0, -1, 0);
     } else {
       if (origins.length == 1) {
-        var origin = origins[0];
+        final origin = origins[0];
         transformation = Transformation(1, -origin.x, -1, origin.y);
       } else {
         transformations =
@@ -238,9 +238,9 @@ class Proj4Crs extends Crs {
   @override
   CustomPoint latLngToPoint(LatLng latlng, double zoom) {
     try {
-      var projectedPoint = projection.project(latlng);
-      var scale = this.scale(zoom);
-      var transformation = _getTransformationByZoom(zoom);
+      final projectedPoint = projection.project(latlng);
+      final scale = this.scale(zoom);
+      final transformation = _getTransformationByZoom(zoom);
 
       return transformation.transform(projectedPoint, scale.toDouble());
     } catch (e) {
@@ -251,10 +251,10 @@ class Proj4Crs extends Crs {
   /// Converts a map point to the sphere coordinate (at a certain zoom).
   @override
   LatLng? pointToLatLng(CustomPoint point, double zoom) {
-    var scale = this.scale(zoom);
-    var transformation = _getTransformationByZoom(zoom);
+    final scale = this.scale(zoom);
+    final transformation = _getTransformationByZoom(zoom);
 
-    var untransformedPoint =
+    final untransformedPoint =
         transformation.untransform(point, scale.toDouble());
     try {
       return projection.unproject(untransformedPoint);
@@ -268,28 +268,28 @@ class Proj4Crs extends Crs {
   Bounds? getProjectedBounds(double zoom) {
     if (infinite) return null;
 
-    var b = projection.bounds!;
-    var s = scale(zoom);
+    final b = projection.bounds!;
+    final s = scale(zoom);
 
-    var transformation = _getTransformationByZoom(zoom);
+    final transformation = _getTransformationByZoom(zoom);
 
-    var min = transformation.transform(b.min, s.toDouble());
-    var max = transformation.transform(b.max, s.toDouble());
+    final min = transformation.transform(b.min, s.toDouble());
+    final max = transformation.transform(b.max, s.toDouble());
     return Bounds(min, max);
   }
 
   /// Zoom to Scale function.
   @override
   num scale(double zoom) {
-    var iZoom = zoom.floor();
+    final iZoom = zoom.floor();
     if (zoom == iZoom) {
       return _scales[iZoom];
     } else {
       // Non-integer zoom, interpolate
-      var baseScale = _scales[iZoom];
-      var nextScale = _scales[iZoom + 1];
-      var scaleDiff = nextScale - baseScale;
-      var zDiff = (zoom - iZoom);
+      final baseScale = _scales[iZoom];
+      final nextScale = _scales[iZoom + 1];
+      final scaleDiff = nextScale - baseScale;
+      final zDiff = (zoom - iZoom);
       return baseScale + scaleDiff * zDiff;
     }
   }
@@ -298,20 +298,20 @@ class Proj4Crs extends Crs {
   @override
   num zoom(double scale) {
     // Find closest number in _scales, down
-    var downScale = _closestElement(_scales, scale);
+    final downScale = _closestElement(_scales, scale);
     if (downScale == null) {
       return double.negativeInfinity;
     }
-    var downZoom = _scales.indexOf(downScale);
+    final downZoom = _scales.indexOf(downScale);
     // Check if scale is downScale => return array index
     if (scale == downScale) {
       return downZoom;
     }
     // Interpolate
-    var nextZoom = downZoom + 1;
-    var nextScale = _scales[nextZoom];
+    final nextZoom = downZoom + 1;
+    final nextScale = _scales[nextZoom];
 
-    var scaleDiff = nextScale - downScale;
+    final scaleDiff = nextScale - downScale;
     return (scale - downScale) / scaleDiff + downZoom;
   }
 
@@ -319,7 +319,7 @@ class Proj4Crs extends Crs {
   double? _closestElement(List<double> array, double element) {
     double? low;
     for (var i = array.length - 1; i >= 0; i--) {
-      var curr = array[i];
+      final curr = array[i];
 
       if (curr <= element && (null == low || low < curr)) {
         low = curr;
@@ -334,8 +334,8 @@ class Proj4Crs extends Crs {
       return transformation;
     }
 
-    var iZoom = zoom.round();
-    var lastIdx = _transformations!.length - 1;
+    final iZoom = zoom.round();
+    final lastIdx = _transformations!.length - 1;
 
     return _transformations![iZoom > lastIdx ? lastIdx : iZoom];
   }
@@ -406,10 +406,10 @@ class SphericalMercator extends Projection {
 
   @override
   CustomPoint project(LatLng latlng) {
-    var d = math.pi / 180;
-    var max = maxLatitude;
-    var lat = math.max(math.min(max, latlng.latitude), -max);
-    var sin = math.sin(lat * d);
+    const d = math.pi / 180;
+    const max = maxLatitude;
+    final lat = math.max(math.min(max, latlng.latitude), -max);
+    final sin = math.sin(lat * d);
 
     return CustomPoint(
         r * latlng.longitude * d, r * math.log((1 + sin) / (1 - sin)) / 2);
@@ -417,7 +417,7 @@ class SphericalMercator extends Projection {
 
   @override
   LatLng unproject(CustomPoint point) {
-    var d = 180 / math.pi;
+    const d = 180 / math.pi;
     return LatLng(
         inclusiveLat(
             (2 * math.atan(math.exp(point.y / r)) - (math.pi / 2)) * d),
@@ -440,7 +440,7 @@ class _Proj4Projection extends Projection {
 
   @override
   CustomPoint project(LatLng latlng) {
-    var point = epsg4326.transform(
+    final point = epsg4326.transform(
         proj4Projection, proj4.Point(x: latlng.longitude, y: latlng.latitude));
 
     return CustomPoint(point.x, point.y);
@@ -448,7 +448,7 @@ class _Proj4Projection extends Projection {
 
   @override
   LatLng unproject(CustomPoint point) {
-    var point2 = proj4Projection.transform(
+    final point2 = proj4Projection.transform(
         epsg4326, proj4.Point(x: point.x as double, y: point.y as double));
 
     return LatLng(inclusiveLat(point2.y), inclusiveLng(point2.x));
@@ -465,15 +465,15 @@ class Transformation {
 
   CustomPoint transform(CustomPoint<num> point, double? scale) {
     scale ??= 1.0;
-    var x = scale * (a * point.x + b);
-    var y = scale * (c * point.y + d);
+    final x = scale * (a * point.x + b);
+    final y = scale * (c * point.y + d);
     return CustomPoint(x, y);
   }
 
   CustomPoint untransform(CustomPoint point, double? scale) {
     scale ??= 1.0;
-    var x = (point.x / scale - b) / a;
-    var y = (point.y / scale - d) / c;
+    final x = (point.x / scale - b) / a;
+    final y = (point.y / scale - d) / c;
     return CustomPoint(x, y);
   }
 }

--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -20,9 +20,9 @@ class LatLngBounds {
       num? minY;
       num? maxY;
 
-      for (var point in points) {
-        num x = point.longitudeInRad;
-        num y = point.latitudeInRad;
+      for (final point in points) {
+        final num x = point.longitudeInRad;
+        final num y = point.latitudeInRad;
 
         if (minX == null || minX > x) {
           minX = x;
@@ -110,18 +110,18 @@ class LatLngBounds {
        lambda: lng
     */
 
-    var phi1 = southWest!.latitudeInRad;
-    var lambda1 = southWest!.longitudeInRad;
-    var phi2 = northEast!.latitudeInRad;
+    final phi1 = southWest!.latitudeInRad;
+    final lambda1 = southWest!.longitudeInRad;
+    final phi2 = northEast!.latitudeInRad;
 
-    var dLambda = degToRadian(northEast!.longitude -
+    final dLambda = degToRadian(northEast!.longitude -
         southWest!.longitude); // delta lambda = lambda2-lambda1
 
-    var bx = math.cos(phi2) * math.cos(dLambda);
-    var by = math.cos(phi2) * math.sin(dLambda);
-    var phi3 = math.atan2(math.sin(phi1) + math.sin(phi2),
+    final bx = math.cos(phi2) * math.cos(dLambda);
+    final by = math.cos(phi2) * math.sin(dLambda);
+    final phi3 = math.atan2(math.sin(phi1) + math.sin(phi2),
         math.sqrt((math.cos(phi1) + bx) * (math.cos(phi1) + bx) + by * by));
-    var lambda3 = lambda1 + math.atan2(by, math.cos(phi1) + bx);
+    final lambda3 = lambda1 + math.atan2(by, math.cos(phi1) + bx);
 
     // phi3 and lambda3 are actually in radians and LatLng wants degrees
     return LatLng(radianToDeg(phi3), radianToDeg(lambda3));
@@ -137,15 +137,15 @@ class LatLngBounds {
     if (!isValid) {
       return false;
     }
-    var sw2 = point;
-    var ne2 = point;
+    final sw2 = point;
+    final ne2 = point;
     return containsBounds(LatLngBounds(sw2, ne2));
   }
 
   /// Checks whether [bounds] is contained inside bounds
   bool containsBounds(LatLngBounds bounds) {
-    var sw2 = bounds._sw!;
-    var ne2 = bounds._ne;
+    final sw2 = bounds._sw!;
+    final ne2 = bounds._ne;
     return (sw2.latitude >= _sw!.latitude) &&
         (ne2!.latitude <= _ne!.latitude) &&
         (sw2.longitude >= _sw!.longitude) &&
@@ -172,8 +172,8 @@ class LatLngBounds {
 
   /// Expands bounds by decimal degrees unlike [extend] or [extendBounds]
   void pad(double bufferRatio) {
-    var heightBuffer = (_sw!.latitude - _ne!.latitude).abs() * bufferRatio;
-    var widthBuffer = (_sw!.longitude - _ne!.longitude).abs() * bufferRatio;
+    final heightBuffer = (_sw!.latitude - _ne!.latitude).abs() * bufferRatio;
+    final widthBuffer = (_sw!.longitude - _ne!.longitude).abs() * bufferRatio;
 
     _sw = LatLng(_sw!.latitude - heightBuffer, _sw!.longitude - widthBuffer);
     _ne = LatLng(_ne!.latitude + heightBuffer, _ne!.longitude + widthBuffer);

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -71,8 +71,8 @@ abstract class MapGestureMixin extends State<FlutterMap>
   late Animation<Offset> _flingAnimation;
 
   late final AnimationController _doubleTapController;
-  late Animation _doubleTapZoomAnimation;
-  late Animation _doubleTapCenterAnimation;
+  late Animation<double> _doubleTapZoomAnimation;
+  late Animation<LatLng> _doubleTapCenterAnimation;
 
   StreamSubscription<MapEvent>? _mapControllerAnimationInterruption;
 

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -12,7 +12,7 @@ import 'package:positioned_tap_detector_2/positioned_tap_detector_2.dart';
 
 abstract class MapGestureMixin extends State<FlutterMap>
     with TickerProviderStateMixin {
-  static const double _kMinFlingVelocity = 800.0;
+  static const double _kMinFlingVelocity = 800;
 
   var _dragMode = false;
   var _gestureWinner = MultiFingerGesture.none;
@@ -538,9 +538,9 @@ abstract class MapGestureMixin extends State<FlutterMap>
       ..fling(
           velocity: magnitude / 1000.0,
           springDescription: SpringDescription.withDampingRatio(
-            mass: 1.0,
-            stiffness: 1000.0,
-            ratio: 5.0,
+            mass: 1,
+            stiffness: 1000,
+            ratio: 5,
           ));
   }
 
@@ -609,7 +609,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
     if (InteractiveFlag.hasFlag(
         options.interactiveFlags, InteractiveFlag.doubleTapZoom)) {
       final centerPos = _pointToOffset(mapState.originalSize!) / 2.0;
-      final newZoom = _getZoomForScale(mapState.zoom, 2.0);
+      final newZoom = _getZoomForScale(mapState.zoom, 2);
       final focalDelta = _getDoubleTapFocalDelta(
           centerPos, tapPosition.relative!, newZoom - mapState.zoom);
       final newCenter = _offsetToCrs(centerPos + focalDelta);
@@ -645,7 +645,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
         LatLngTween(begin: mapState.center, end: newCenter)
             .chain(CurveTween(curve: Curves.fastOutSlowIn))
             .animate(_doubleTapController);
-    _doubleTapController.forward(from: 0.0);
+    _doubleTapController.forward(from: 0);
   }
 
   void _doubleTapZoomStatusListener(AnimationStatus status) {

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -12,7 +12,7 @@ import 'package:positioned_tap_detector_2/positioned_tap_detector_2.dart';
 
 abstract class MapGestureMixin extends State<FlutterMap>
     with TickerProviderStateMixin {
-  static const double _kMinFlingVelocity = 800;
+  static const int _kMinFlingVelocity = 800;
 
   var _dragMode = false;
   var _gestureWinner = MultiFingerGesture.none;

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -297,7 +297,8 @@ abstract class MapGestureMixin extends State<FlutterMap>
         }
 
         final oldCenterPt = mapState.project(mapState.center, mapState.zoom);
-        var localDistanceOffset = _rotateOffset(_lastFocalLocal - focalOffset);
+        final localDistanceOffset =
+            _rotateOffset(_lastFocalLocal - focalOffset);
 
         final newCenterPt = oldCenterPt + _offsetToPoint(localDistanceOffset);
         final newCenter = mapState.unproject(newCenterPt, mapState.zoom);
@@ -502,10 +503,10 @@ abstract class MapGestureMixin extends State<FlutterMap>
       );
     }
 
-    var hasFling = InteractiveFlag.hasFlag(
+    final hasFling = InteractiveFlag.hasFlag(
         options.interactiveFlags, InteractiveFlag.flingAnimation);
 
-    var magnitude = details.velocity.pixelsPerSecond.distance;
+    final magnitude = details.velocity.pixelsPerSecond.distance;
     if (magnitude < _kMinFlingVelocity || !hasFling) {
       if (hasFling) {
         mapState.emitMapEvent(
@@ -520,13 +521,13 @@ abstract class MapGestureMixin extends State<FlutterMap>
       return;
     }
 
-    var direction = details.velocity.pixelsPerSecond / magnitude;
-    var distance = (Offset.zero &
+    final direction = details.velocity.pixelsPerSecond / magnitude;
+    final distance = (Offset.zero &
             Size(mapState.originalSize!.x as double,
                 mapState.originalSize!.y as double))
         .shortestSide;
 
-    var flingOffset = _focalStartLocal - _lastFocalLocal;
+    final flingOffset = _focalStartLocal - _lastFocalLocal;
     _flingAnimation = Tween<Offset>(
       begin: flingOffset,
       end: flingOffset - direction * distance,
@@ -591,7 +592,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
     final point = (_offsetToPoint(offset) - (mapState.originalSize! / 2.0))
         .rotate(mapState.rotationRad);
 
-    var newCenterPt = focalStartPt + point;
+    final newCenterPt = focalStartPt + point;
     return mapState.unproject(newCenterPt, zoom ?? mapState.zoom);
   }
 
@@ -688,7 +689,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
   void _handleDoubleTapHold(ScaleUpdateDetails details) {
     _doubleTapHoldMaxDelay?.cancel();
 
-    var flags = options.interactiveFlags;
+    final flags = options.interactiveFlags;
     // TODO: is this pinchZoom? never seen this fired
     if (InteractiveFlag.hasFlag(flags, InteractiveFlag.pinchZoom)) {
       final zoom = mapState.zoom;
@@ -738,9 +739,9 @@ abstract class MapGestureMixin extends State<FlutterMap>
       _startListeningForAnimationInterruptions();
     }
 
-    var newCenterPoint = mapState.project(_mapCenterStart) +
+    final newCenterPoint = mapState.project(_mapCenterStart) +
         _offsetToPoint(_flingAnimation.value).rotate(mapState.rotationRad);
-    var newCenter = mapState.unproject(newCenterPoint);
+    final newCenter = mapState.unproject(newCenterPoint);
 
     mapState.move(
       newCenter,
@@ -779,7 +780,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
   }
 
   double _getZoomForScale(double startZoom, double scale) {
-    var resultZoom =
+    final resultZoom =
         scale == 1.0 ? startZoom : startZoom + math.log(scale) / math.ln2;
     return mapState.fitZoomToBounds(resultZoom);
   }

--- a/lib/src/layer/circle_layer.dart
+++ b/lib/src/layer/circle_layer.dart
@@ -64,15 +64,15 @@ class CircleLayer extends StatelessWidget {
     return StreamBuilder<void>(
       stream: stream, // a Stream<void> or null
       builder: (BuildContext context, _) {
-        var circleWidgets = <Widget>[];
-        for (var circle in circleOpts.circles) {
+        final circleWidgets = <Widget>[];
+        for (final circle in circleOpts.circles) {
           var pos = map.project(circle.point);
           pos = pos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
               map.getPixelOrigin();
           circle.offset = Offset(pos.x.toDouble(), pos.y.toDouble());
 
           if (circle.useRadiusInMeter) {
-            var r = const Distance().offset(circle.point, circle.radius, 180);
+            final r = const Distance().offset(circle.point, circle.radius, 180);
             var rpos = map.project(r);
             rpos = rpos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
                 map.getPixelOrigin();

--- a/lib/src/layer/group_layer.dart
+++ b/lib/src/layer/group_layer.dart
@@ -37,7 +37,7 @@ class GroupLayer extends StatelessWidget {
     return StreamBuilder(
       stream: stream,
       builder: (BuildContext context, _) {
-        var layers = <Widget>[
+        final layers = <Widget>[
           for (var options in groupOpts.group) _createLayer(options)
         ];
 

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -60,7 +60,7 @@ class Anchor {
   static double _leftOffset(double width, AnchorAlign alignOpt) {
     switch (alignOpt) {
       case AnchorAlign.left:
-        return 0.0;
+        return 0;
       case AnchorAlign.right:
         return width;
       case AnchorAlign.top:
@@ -74,7 +74,7 @@ class Anchor {
   static double _topOffset(double height, AnchorAlign alignOpt) {
     switch (alignOpt) {
       case AnchorAlign.top:
-        return 0.0;
+        return 0;
       case AnchorAlign.bottom:
         return height;
       case AnchorAlign.left:
@@ -190,7 +190,7 @@ class MarkerLayer extends StatefulWidget {
 }
 
 class _MarkerLayerState extends State<MarkerLayer> {
-  double lastZoom = -1.0;
+  double lastZoom = -1;
 
   /// List containing cached pixel positions of markers
   /// Should be discarded when zoom changes

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -239,19 +239,19 @@ class _MarkerLayerState extends State<MarkerLayer> {
     return StreamBuilder<void>(
       stream: widget.stream,
       builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
-        var layerOptions = widget.markerLayerOptions;
-        var map = widget.map;
-        var usePxCache = layerOptions.usePxCache;
-        var markers = <Widget>[];
+        final layerOptions = widget.markerLayerOptions;
+        final map = widget.map;
+        final usePxCache = layerOptions.usePxCache;
+        final markers = <Widget>[];
         final sameZoom = map.zoom == lastZoom;
 
-        var cacheUpdated = updatePxCacheIfNeeded();
+        final cacheUpdated = updatePxCacheIfNeeded();
 
         for (var i = 0; i < layerOptions.markers.length; i++) {
-          var marker = layerOptions.markers[i];
+          final marker = layerOptions.markers[i];
 
           // Decide whether to use cached point or calculate it
-          var pxPoint = usePxCache && (sameZoom || cacheUpdated)
+          final pxPoint = usePxCache && (sameZoom || cacheUpdated)
               ? _pxCache[i]
               : map.project(marker.point);
           if (!sameZoom && usePxCache) {
@@ -260,8 +260,8 @@ class _MarkerLayerState extends State<MarkerLayer> {
 
           final width = marker.width - marker.anchor.left;
           final height = marker.height - marker.anchor.top;
-          var sw = CustomPoint(pxPoint.x + width, pxPoint.y - height);
-          var ne = CustomPoint(pxPoint.x - width, pxPoint.y + height);
+          final sw = CustomPoint(pxPoint.x + width, pxPoint.y - height);
+          final ne = CustomPoint(pxPoint.x - width, pxPoint.y + height);
 
           if (!map.pixelBounds.containsPartialBounds(Bounds(sw, ne))) {
             continue;

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -87,8 +87,10 @@ class Anchor {
 
   factory Anchor.forPos(AnchorPos? pos, double width, double height) {
     if (pos == null) return Anchor._(width, height, AnchorAlign.none);
-    if (pos.value is AnchorAlign) return Anchor._(width, height, pos.value);
-    if (pos.value is Anchor) return pos.value;
+    if (pos.value is AnchorAlign) {
+      return Anchor._(width, height, pos.value as AnchorAlign);
+    }
+    if (pos.value is Anchor) return pos.value as Anchor;
     throw Exception('Unsupported AnchorPos value type: ${pos.runtimeType}.');
   }
 }
@@ -96,8 +98,9 @@ class Anchor {
 class AnchorPos<T> {
   AnchorPos._(this.value);
   T value;
-  static AnchorPos exactly(Anchor anchor) => AnchorPos._(anchor);
-  static AnchorPos align(AnchorAlign alignOpt) => AnchorPos._(alignOpt);
+  static AnchorPos exactly(Anchor anchor) => AnchorPos<Anchor>._(anchor);
+  static AnchorPos align(AnchorAlign alignOpt) =>
+      AnchorPos<AnchorAlign>._(alignOpt);
 }
 
 enum AnchorAlign {
@@ -187,7 +190,7 @@ class MarkerLayer extends StatefulWidget {
 }
 
 class _MarkerLayerState extends State<MarkerLayer> {
-  var lastZoom = -1.0;
+  double lastZoom = -1.0;
 
   /// List containing cached pixel positions of markers
   /// Should be discarded when zoom changes

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -183,7 +183,7 @@ class MarkerLayer extends StatefulWidget {
       : super(key: markerLayerOptions.key);
 
   @override
-  _MarkerLayerState createState() => _MarkerLayerState();
+  State<MarkerLayer> createState() => _MarkerLayerState();
 }
 
 class _MarkerLayerState extends State<MarkerLayer> {

--- a/lib/src/layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer.dart
@@ -19,7 +19,7 @@ class PolygonLayerOptions extends LayerOptions {
     Stream<void>? rebuild,
   }) : super(key: key, rebuild: rebuild) {
     if (polygonCulling) {
-      for (var polygon in polygons) {
+      for (final polygon in polygons) {
         polygon.boundingBox = LatLngBounds.fromPoints(polygon.points);
       }
     }
@@ -97,13 +97,13 @@ class PolygonLayer extends StatelessWidget {
     return StreamBuilder(
       stream: stream, // a Stream<void> or null
       builder: (BuildContext context, _) {
-        var polygons = <Widget>[];
+        final polygons = <Widget>[];
 
-        for (var polygon in polygonOpts.polygons) {
+        for (final polygon in polygonOpts.polygons) {
           polygon.offsets.clear();
 
           if (null != polygon.holeOffsetsList) {
-            for (var offsets in polygon.holeOffsetsList!) {
+            for (final offsets in polygon.holeOffsetsList!) {
               offsets.clear();
             }
           }
@@ -117,9 +117,8 @@ class PolygonLayer extends StatelessWidget {
           _fillOffsets(polygon.offsets, polygon.points);
 
           if (null != polygon.holePointsList) {
-            for (var i = 0, len = polygon.holePointsList!.length;
-                i < len;
-                ++i) {
+            final len = polygon.holePointsList!.length;
+            for (var i = 0; i < len; ++i) {
               _fillOffsets(
                   polygon.holeOffsetsList![i], polygon.holePointsList![i]);
             }
@@ -141,8 +140,9 @@ class PolygonLayer extends StatelessWidget {
   }
 
   void _fillOffsets(final List<Offset> offsets, final List<LatLng> points) {
-    for (var i = 0, len = points.length; i < len; ++i) {
-      var point = points[i];
+    final len = points.length;
+    for (var i = 0; i < len; ++i) {
+      final point = points[i];
 
       var pos = map.project(point);
       pos = pos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
@@ -171,20 +171,20 @@ class PolygonPainter extends CustomPainter {
 
   void _paintBorder(Canvas canvas) {
     if (polygonOpt.borderStrokeWidth > 0.0) {
-      var borderRadius = (polygonOpt.borderStrokeWidth / 2);
+      final borderRadius = (polygonOpt.borderStrokeWidth / 2);
 
       final borderPaint = Paint()
         ..color = polygonOpt.borderColor
         ..strokeWidth = polygonOpt.borderStrokeWidth;
 
       if (polygonOpt.isDotted) {
-        var spacing = polygonOpt.borderStrokeWidth * 1.5;
+        final spacing = polygonOpt.borderStrokeWidth * 1.5;
         _paintDottedLine(
             canvas, polygonOpt.offsets, borderRadius, spacing, borderPaint);
 
         if (!polygonOpt.disableHolesBorder &&
             null != polygonOpt.holeOffsetsList) {
-          for (var offsets in polygonOpt.holeOffsetsList!) {
+          for (final offsets in polygonOpt.holeOffsetsList!) {
             _paintDottedLine(
                 canvas, offsets, borderRadius, spacing, borderPaint);
           }
@@ -194,7 +194,7 @@ class PolygonPainter extends CustomPainter {
 
         if (!polygonOpt.disableHolesBorder &&
             null != polygonOpt.holeOffsetsList) {
-          for (var offsets in polygonOpt.holeOffsetsList!) {
+          for (final offsets in polygonOpt.holeOffsetsList!) {
             _paintLine(canvas, offsets, borderRadius, borderPaint);
           }
         }
@@ -206,14 +206,14 @@ class PolygonPainter extends CustomPainter {
       double stepLength, Paint paint) {
     var startDistance = 0.0;
     for (var i = 0; i < offsets.length; i++) {
-      var o0 = offsets[i % offsets.length];
-      var o1 = offsets[(i + 1) % offsets.length];
-      var totalDistance = _dist(o0, o1);
+      final o0 = offsets[i % offsets.length];
+      final o1 = offsets[(i + 1) % offsets.length];
+      final totalDistance = _dist(o0, o1);
       var distance = startDistance;
       while (distance < totalDistance) {
-        var f1 = distance / totalDistance;
-        var f0 = 1.0 - f1;
-        var offset = Offset(o0.dx * f0 + o1.dx * f1, o0.dy * f0 + o1.dy * f1);
+        final f1 = distance / totalDistance;
+        final f0 = 1.0 - f1;
+        final offset = Offset(o0.dx * f0 + o1.dx * f1, o0.dy * f0 + o1.dy * f1);
         canvas.drawCircle(offset, radius, paint);
         distance += stepLength;
       }
@@ -227,7 +227,7 @@ class PolygonPainter extends CustomPainter {
   void _paintLine(
       Canvas canvas, List<Offset> offsets, double radius, Paint paint) {
     canvas.drawPoints(PointMode.lines, [...offsets, offsets[0]], paint);
-    for (var offset in offsets) {
+    for (final offset in offsets) {
       canvas.drawCircle(offset, radius, paint);
     }
   }
@@ -239,8 +239,8 @@ class PolygonPainter extends CustomPainter {
       canvas.saveLayer(rect, paint);
       paint.style = PaintingStyle.fill;
 
-      for (var offsets in polygonOpt.holeOffsetsList!) {
-        var path = Path();
+      for (final offsets in polygonOpt.holeOffsetsList!) {
+        final path = Path();
         path.addPolygon(offsets, true);
         canvas.drawPath(path, paint);
       }
@@ -249,7 +249,7 @@ class PolygonPainter extends CustomPainter {
         ..color = polygonOpt.color
         ..blendMode = BlendMode.srcOut;
 
-      var path = Path();
+      final path = Path();
       path.addPolygon(polygonOpt.offsets, true);
       canvas.drawPath(path, paint);
 
@@ -263,7 +263,7 @@ class PolygonPainter extends CustomPainter {
             polygonOpt.isFilled ? PaintingStyle.fill : PaintingStyle.stroke
         ..color = polygonOpt.color;
 
-      var path = Path();
+      final path = Path();
       path.addPolygon(polygonOpt.offsets, true);
       canvas.drawPath(path, paint);
 

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -30,7 +30,7 @@ class PolylineLayerOptions extends LayerOptions {
     this.saveLayers = false,
   }) : super(key: key, rebuild: rebuild) {
     if (polylineCulling) {
-      for (var polyline in polylines) {
+      for (final polyline in polylines) {
         polyline.boundingBox = LatLngBounds.fromPoints(polyline.points);
       }
     }
@@ -100,9 +100,9 @@ class PolylineLayer extends StatelessWidget {
     return StreamBuilder<void>(
       stream: stream, // a Stream<void> or null
       builder: (BuildContext context, _) {
-        var polylines = <Widget>[];
+        final polylines = <Widget>[];
 
-        for (var polylineOpt in polylineOpts.polylines) {
+        for (final polylineOpt in polylineOpts.polylines) {
           polylineOpt.offsets.clear();
 
           if (polylineOpts.polylineCulling &&
@@ -127,8 +127,9 @@ class PolylineLayer extends StatelessWidget {
   }
 
   void _fillOffsets(final List<Offset> offsets, final List<LatLng> points) {
-    for (var i = 0, len = points.length; i < len; ++i) {
-      var point = points[i];
+    final len = points.length;
+    for (var i = 0; i < len; ++i) {
+      final point = points[i];
 
       var pos = map.project(point);
       pos = pos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
@@ -192,10 +193,10 @@ class PolylinePainter extends CustomPainter {
           ..strokeJoin = polylineOpt.strokeJoin
           ..blendMode = BlendMode.srcOver)
         : null;
-    var radius = paint.strokeWidth / 2;
-    var borderRadius = (borderPaint?.strokeWidth ?? 0) / 2;
+    final radius = paint.strokeWidth / 2;
+    final borderRadius = (borderPaint?.strokeWidth ?? 0) / 2;
     if (polylineOpt.isDotted) {
-      var spacing = polylineOpt.strokeWidth * 1.5;
+      final spacing = polylineOpt.strokeWidth * 1.5;
       if (saveLayers) canvas.saveLayer(rect, Paint());
       if (borderPaint != null && filterPaint != null) {
         _paintDottedLine(
@@ -224,14 +225,14 @@ class PolylinePainter extends CustomPainter {
     final path = ui.Path();
     var startDistance = 0.0;
     for (var i = 0; i < offsets.length - 1; i++) {
-      var o0 = offsets[i];
-      var o1 = offsets[i + 1];
-      var totalDistance = _dist(o0, o1);
+      final o0 = offsets[i];
+      final o1 = offsets[i + 1];
+      final totalDistance = _dist(o0, o1);
       var distance = startDistance;
       while (distance < totalDistance) {
-        var f1 = distance / totalDistance;
-        var f0 = 1.0 - f1;
-        var offset = Offset(o0.dx * f0 + o1.dx * f1, o0.dy * f0 + o1.dy * f1);
+        final f1 = distance / totalDistance;
+        final f0 = 1.0 - f1;
+        final offset = Offset(o0.dx * f0 + o1.dx * f1, o0.dy * f0 + o1.dy * f1);
         path.addOval(Rect.fromCircle(center: offset, radius: radius));
         distance += stepLength;
       }

--- a/lib/src/layer/tile_builder/tile_builder.dart
+++ b/lib/src/layer/tile_builder/tile_builder.dart
@@ -109,8 +109,8 @@ Widget loadingTimeDebugTileBuilder(
   Widget tileWidget,
   Tile tile,
 ) {
-  var loadStarted = tile.loadStarted;
-  var loaded = tile.loaded;
+  final loadStarted = tile.loadStarted;
+  final loaded = tile.loaded;
 
   final time = loaded == null
       ? 'Loading'

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -309,7 +309,7 @@ class TileLayerOptions extends LayerOptions {
                 : maxZoom,
         minZoom =
             wmsOptions == null && retinaMode && maxZoom > 0.0 && zoomReverse
-                ? math.max(minZoom + 1.0, 0.0)
+                ? math.max(minZoom + 1.0, 0)
                 : minZoom,
         zoomOffset = wmsOptions == null && retinaMode && maxZoom > 0.0
             ? (zoomReverse ? zoomOffset - 1.0 : zoomOffset + 1.0)
@@ -890,23 +890,23 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     // wrapping
     _wrapX = crs.wrapLng;
     if (_wrapX != null) {
-      final first = (map.project(LatLng(0.0, crs.wrapLng!.item1), tileZoom).x /
-              tileSize.x)
-          .floorToDouble();
-      final second = (map.project(LatLng(0.0, crs.wrapLng!.item2), tileZoom).x /
-              tileSize.y)
-          .ceilToDouble();
+      final first =
+          (map.project(LatLng(0, crs.wrapLng!.item1), tileZoom).x / tileSize.x)
+              .floorToDouble();
+      final second =
+          (map.project(LatLng(0, crs.wrapLng!.item2), tileZoom).x / tileSize.y)
+              .ceilToDouble();
       _wrapX = Tuple2(first, second);
     }
 
     _wrapY = crs.wrapLat;
     if (_wrapY != null) {
-      final first = (map.project(LatLng(crs.wrapLat!.item1, 0.0), tileZoom).y /
-              tileSize.x)
-          .floorToDouble();
-      final second = (map.project(LatLng(crs.wrapLat!.item2, 0.0), tileZoom).y /
-              tileSize.y)
-          .ceilToDouble();
+      final first =
+          (map.project(LatLng(crs.wrapLat!.item1, 0), tileZoom).y / tileSize.x)
+              .floorToDouble();
+      final second =
+          (map.project(LatLng(crs.wrapLat!.item2, 0), tileZoom).y / tileSize.y)
+              .ceilToDouble();
       _wrapY = Tuple2(first, second);
     }
   }
@@ -1293,7 +1293,7 @@ class Tile implements Comparable<Tile> {
 
     try {
       final oldImageStream = _imageStream;
-      _imageStream = imageProvider.resolve(const ImageConfiguration());
+      _imageStream = imageProvider.resolve(ImageConfiguration.empty);
 
       if (_imageStream!.key != oldImageStream?.key) {
         oldImageStream?.removeListener(_listener);

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -1390,7 +1390,7 @@ class AnimatedTile extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _AnimatedTileState createState() => _AnimatedTileState();
+  State<AnimatedTile> createState() => _AnimatedTileState();
 }
 
 class _AnimatedTileState extends State<AnimatedTile> {

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -516,7 +516,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       if (oldUrl != newUrl ||
           !(const MapEquality()).equals(oldOptions, newOptions)) {
         if (options.overrideTilesWhenUrlChanges) {
-          for (var tile in _tiles.values) {
+          for (final tile in _tiles.values) {
             tile.imageProvider = options.tileProvider
                 .getImage(_wrapCoords(tile.coords), options);
             tile.loadTileImage();
@@ -535,7 +535,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   bool _isZoomOutsideMinMax() {
-    for (var tile in _tiles.values) {
+    for (final tile in _tiles.values) {
       if (tile.level.zoom > (options.maxZoom) ||
           tile.level.zoom < (options.minZoom)) {
         return true;
@@ -573,13 +573,13 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
-    var tilesToRender = _tiles.values.toList()..sort();
+    final tilesToRender = _tiles.values.toList()..sort();
 
-    var tileWidgets = <Widget>[
+    final tileWidgets = <Widget>[
       for (var tile in tilesToRender) _createTileWidget(tile)
     ];
 
-    var tilesContainer = Stack(
+    final tilesContainer = Stack(
       children: tileWidgets,
     );
 
@@ -609,12 +609,12 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   Widget _createTileWidget(Tile tile) {
-    var tilePos = tile.tilePos;
-    var level = tile.level;
-    var tileSize = getTileSize();
-    var pos = (tilePos).multiplyBy(level.scale) + level.translatePoint;
-    num width = tileSize.x * level.scale;
-    num height = tileSize.y * level.scale;
+    final tilePos = tile.tilePos;
+    final level = tile.level;
+    final tileSize = getTileSize();
+    final pos = (tilePos).multiplyBy(level.scale) + level.translatePoint;
+    final num width = tileSize.x * level.scale;
+    final num height = tileSize.y * level.scale;
 
     final Widget content = AnimatedTile(
       tile: tile,
@@ -633,9 +633,9 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   void _abortLoading() {
-    var toRemove = <String>[];
-    for (var entry in _tiles.entries) {
-      var tile = entry.value;
+    final toRemove = <String>[];
+    for (final entry in _tiles.entries) {
+      final tile = entry.value;
 
       if (tile.coords.z != _tileZoom) {
         if (tile.loaded == null) {
@@ -644,8 +644,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       }
     }
 
-    for (var key in toRemove) {
-      var tile = _tiles[key]!;
+    for (final key in toRemove) {
+      final tile = _tiles[key]!;
 
       tile.tileReady = null;
       tile.dispose(tile.loadError &&
@@ -659,7 +659,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   bool _hasLevelChildren(double lvl) {
-    for (var tile in _tiles.values) {
+    for (final tile in _tiles.values) {
       if (tile.coords.z == lvl) {
         return true;
       }
@@ -669,15 +669,15 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   Level? _updateLevels() {
-    var zoom = _tileZoom;
-    var maxZoom = options.maxZoom;
+    final zoom = _tileZoom;
+    final maxZoom = options.maxZoom;
 
     if (zoom == null) return null;
 
-    var toRemove = <double>[];
-    for (var entry in _levels.entries) {
-      var z = entry.key;
-      var lvl = entry.value;
+    final toRemove = <double>[];
+    for (final entry in _levels.entries) {
+      final z = entry.key;
+      final lvl = entry.value;
 
       if (z == zoom || _hasLevelChildren(z)) {
         lvl.zIndex = maxZoom - (zoom - z).abs();
@@ -686,13 +686,13 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       }
     }
 
-    for (var z in toRemove) {
+    for (final z in toRemove) {
       _removeTilesAtZoom(z);
       _levels.remove(z);
     }
 
     var level = _levels[zoom];
-    var map = this.map;
+    final map = this.map;
 
     if (level == null) {
       level = _levels[zoom] = Level();
@@ -707,52 +707,52 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   void _pruneTiles() {
-    var zoom = _tileZoom;
+    final zoom = _tileZoom;
     if (zoom == null) {
       _removeAllTiles();
       return;
     }
 
-    for (var entry in _tiles.entries) {
-      var tile = entry.value;
+    for (final entry in _tiles.entries) {
+      final tile = entry.value;
       tile.retain = tile.current;
     }
 
-    for (var entry in _tiles.entries) {
-      var tile = entry.value;
+    for (final entry in _tiles.entries) {
+      final tile = entry.value;
 
       if (tile.current && !tile.active) {
-        var coords = tile.coords;
+        final coords = tile.coords;
         if (!_retainParent(coords.x, coords.y, coords.z, coords.z - 5)) {
           _retainChildren(coords.x, coords.y, coords.z, coords.z + 2);
         }
       }
     }
 
-    var toRemove = <String>[];
-    for (var entry in _tiles.entries) {
-      var tile = entry.value;
+    final toRemove = <String>[];
+    for (final entry in _tiles.entries) {
+      final tile = entry.value;
 
       if (!tile.retain) {
         toRemove.add(entry.key);
       }
     }
 
-    for (var key in toRemove) {
+    for (final key in toRemove) {
       _removeTile(key);
     }
   }
 
   void _removeTilesAtZoom(double zoom) {
-    var toRemove = <String>[];
-    for (var entry in _tiles.entries) {
+    final toRemove = <String>[];
+    for (final entry in _tiles.entries) {
       if (entry.value.coords.z != zoom) {
         continue;
       }
       toRemove.add(entry.key);
     }
 
-    for (var key in toRemove) {
+    for (final key in toRemove) {
       _removeTile(key);
     }
   }
@@ -764,23 +764,23 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   void _removeAllTiles() {
-    var toRemove = Map<String, Tile>.from(_tiles);
+    final toRemove = Map<String, Tile>.from(_tiles);
 
-    for (var key in toRemove.keys) {
+    for (final key in toRemove.keys) {
       _removeTile(key);
     }
   }
 
   bool _retainParent(double x, double y, double z, double minZoom) {
-    var x2 = (x / 2).floorToDouble();
-    var y2 = (y / 2).floorToDouble();
-    var z2 = z - 1;
-    var coords2 = Coords(x2, y2);
+    final x2 = (x / 2).floorToDouble();
+    final y2 = (y / 2).floorToDouble();
+    final z2 = z - 1;
+    final coords2 = Coords(x2, y2);
     coords2.z = z2;
 
-    var key = _tileCoordsToKey(coords2);
+    final key = _tileCoordsToKey(coords2);
 
-    var tile = _tiles[key];
+    final tile = _tiles[key];
     if (tile != null) {
       if (tile.active) {
         tile.retain = true;
@@ -800,12 +800,12 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   void _retainChildren(double x, double y, double z, double maxZoom) {
     for (var i = 2 * x; i < 2 * x + 2; i++) {
       for (var j = 2 * y; j < 2 * y + 2; j++) {
-        var coords = Coords(i, j);
+        final coords = Coords(i, j);
         coords.z = z + 1;
 
-        var key = _tileCoordsToKey(coords);
+        final key = _tileCoordsToKey(coords);
 
-        var tile = _tiles[key];
+        final tile = _tiles[key];
         if (tile != null) {
           if (tile.active) {
             tile.retain = true;
@@ -859,29 +859,29 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   void _setZoomTransforms(LatLng center, double zoom) {
-    for (var i in _levels.keys) {
+    for (final i in _levels.keys) {
       _setZoomTransform(_levels[i]!, center, zoom);
     }
   }
 
   void _setZoomTransform(Level level, LatLng center, double zoom) {
-    var scale = map.getZoomScale(zoom, level.zoom);
-    var pixelOrigin = map.getNewPixelOrigin(center, zoom).round();
+    final scale = map.getZoomScale(zoom, level.zoom);
+    final pixelOrigin = map.getNewPixelOrigin(center, zoom).round();
     if (level.origin == null) {
       return;
     }
-    var translate = level.origin!.multiplyBy(scale) - pixelOrigin;
+    final translate = level.origin!.multiplyBy(scale) - pixelOrigin;
     level.translatePoint = translate;
     level.scale = scale;
   }
 
   void _resetGrid() {
-    var map = this.map;
-    var crs = map.options.crs;
-    var tileSize = getTileSize();
-    var tileZoom = _tileZoom;
+    final map = this.map;
+    final crs = map.options.crs;
+    final tileSize = getTileSize();
+    final tileZoom = _tileZoom;
 
-    var bounds = map.getPixelWorldBounds(_tileZoom);
+    final bounds = map.getPixelWorldBounds(_tileZoom);
     if (bounds != null) {
       _globalTileRange = _pxBoundsToTileRange(bounds);
     }
@@ -889,10 +889,10 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     // wrapping
     _wrapX = crs.wrapLng;
     if (_wrapX != null) {
-      var first = (map.project(LatLng(0.0, crs.wrapLng!.item1), tileZoom).x /
+      final first = (map.project(LatLng(0.0, crs.wrapLng!.item1), tileZoom).x /
               tileSize.x)
           .floorToDouble();
-      var second = (map.project(LatLng(0.0, crs.wrapLng!.item2), tileZoom).x /
+      final second = (map.project(LatLng(0.0, crs.wrapLng!.item2), tileZoom).x /
               tileSize.y)
           .ceilToDouble();
       _wrapX = Tuple2(first, second);
@@ -900,10 +900,10 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
 
     _wrapY = crs.wrapLat;
     if (_wrapY != null) {
-      var first = (map.project(LatLng(crs.wrapLat!.item1, 0.0), tileZoom).y /
+      final first = (map.project(LatLng(crs.wrapLat!.item1, 0.0), tileZoom).y /
               tileSize.x)
           .floorToDouble();
-      var second = (map.project(LatLng(crs.wrapLat!.item2, 0.0), tileZoom).y /
+      final second = (map.project(LatLng(crs.wrapLat!.item2, 0.0), tileZoom).y /
               tileSize.y)
           .ceilToDouble();
       _wrapY = Tuple2(first, second);
@@ -911,7 +911,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   void _handleMove() {
-    var tileZoom = _clampZoom(map.zoom.roundToDouble());
+    final tileZoom = _clampZoom(map.zoom.roundToDouble());
 
     if (_tileZoom == null) {
       // if there is no _tileZoom available it means we are out within zoom level
@@ -945,9 +945,9 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   Bounds _getTiledPixelBounds(LatLng center) {
-    var scale = map.getZoomScale(map.zoom, _tileZoom);
-    var pixelCenter = map.project(center, _tileZoom).floor();
-    var halfSize = map.size / (scale * 2);
+    final scale = map.getZoomScale(map.zoom, _tileZoom);
+    final pixelCenter = map.project(center, _tileZoom).floor();
+    final halfSize = map.size / (scale * 2);
 
     return Bounds(pixelCenter - halfSize, pixelCenter + halfSize);
   }
@@ -959,22 +959,22 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       return;
     }
 
-    var zoom = _clampZoom(map.zoom);
+    final zoom = _clampZoom(map.zoom);
     center ??= map.center;
 
-    var pixelBounds = _getTiledPixelBounds(center);
-    var tileRange = _pxBoundsToTileRange(pixelBounds);
-    var tileCenter = tileRange.center;
+    final pixelBounds = _getTiledPixelBounds(center);
+    final tileRange = _pxBoundsToTileRange(pixelBounds);
+    final tileCenter = tileRange.center;
     final queue = <Coords<num>>[];
-    var margin = options.keepBuffer;
-    var noPruneRange = Bounds(
+    final margin = options.keepBuffer;
+    final noPruneRange = Bounds(
       tileRange.bottomLeft - CustomPoint(margin, -margin),
       tileRange.topRight + CustomPoint(margin, -margin),
     );
 
-    for (var entry in _tiles.entries) {
-      var tile = entry.value;
-      var c = tile.coords;
+    for (final entry in _tiles.entries) {
+      final tile = entry.value;
+      final c = tile.coords;
 
       if (tile.current == true &&
           (c.z != _tileZoom || !noPruneRange.contains(CustomPoint(c.x, c.y)))) {
@@ -996,7 +996,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
         coords.z = _tileZoom!;
 
         if (options.tileBounds != null) {
-          var tilePxBounds = _pxBoundsToTileRange(
+          final tilePxBounds = _pxBoundsToTileRange(
               _latLngBoundsToPixelBounds(options.tileBounds!, _tileZoom!));
           if (!_areCoordsInsideTileBounds(coords, tilePxBounds)) {
             continue;
@@ -1007,7 +1007,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
           continue;
         }
 
-        var tile = _tiles[_tileCoordsToKey(coords)];
+        final tile = _tiles[_tileCoordsToKey(coords)];
         if (tile != null) {
           tile.current = true;
         } else {
@@ -1028,11 +1028,11 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   bool _isValidTile(Coords coords) {
-    var crs = map.options.crs;
+    final crs = map.options.crs;
 
     if (!crs.infinite) {
       // don't load tile if it's out of bounds and not wrapped
-      var bounds = _globalTileRange;
+      final bounds = _globalTileRange;
       if ((crs.wrapLng == null &&
               (coords.x < bounds.min.x || coords.x > bounds.max.x)) ||
           (crs.wrapLat == null &&
@@ -1045,7 +1045,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   bool _areCoordsInsideTileBounds(Coords coords, Bounds? tileBounds) {
-    var bounds = tileBounds ?? _globalTileRange;
+    final bounds = tileBounds ?? _globalTileRange;
     if ((coords.x < bounds.min.x || coords.x > bounds.max.x) ||
         (coords.y < bounds.min.y || coords.y > bounds.max.y)) {
       return false;
@@ -1054,9 +1054,9 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   Bounds _latLngBoundsToPixelBounds(LatLngBounds bounds, double thisZoom) {
-    var swPixel = map.project(bounds.southWest!, thisZoom).floor();
-    var nePixel = map.project(bounds.northEast!, thisZoom).ceil();
-    var pxBounds = Bounds(swPixel, nePixel);
+    final swPixel = map.project(bounds.southWest!, thisZoom).floor();
+    final nePixel = map.project(bounds.northEast!, thisZoom).ceil();
+    final pxBounds = Bounds(swPixel, nePixel);
     return pxBounds;
   }
 
@@ -1066,15 +1066,15 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
 
   //ignore: unused_element
   Coords _keyToTileCoords(String key) {
-    var k = key.split(':');
-    var coords = Coords(double.parse(k[0]), double.parse(k[1]));
+    final k = key.split(':');
+    final coords = Coords(double.parse(k[0]), double.parse(k[1]));
     coords.z = double.parse(k[2]);
 
     return coords;
   }
 
   void _removeTile(String key) {
-    var tile = _tiles[key];
+    final tile = _tiles[key];
     if (tile == null) {
       return;
     }
@@ -1085,8 +1085,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   void _addTile(Coords<double> coords) {
-    var tileCoordsToKey = _tileCoordsToKey(coords);
-    var tile = _tiles[tileCoordsToKey] = Tile(
+    final tileCoordsToKey = _tileCoordsToKey(coords);
+    final tile = _tiles[tileCoordsToKey] = Tile(
       coords: coords,
       coordsKey: tileCoordsToKey,
       tilePos: _getTilePos(coords),
@@ -1103,27 +1103,27 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   void _evictErrorTilesBasedOnStrategy(Bounds tileRange) {
     if (options.evictErrorTileStrategy ==
         EvictErrorTileStrategy.notVisibleRespectMargin) {
-      var toRemove = <String>[];
-      for (var entry in _tiles.entries) {
-        var tile = entry.value;
+      final toRemove = <String>[];
+      for (final entry in _tiles.entries) {
+        final tile = entry.value;
 
         if (tile.loadError && !tile.current) {
           toRemove.add(entry.key);
         }
       }
 
-      for (var key in toRemove) {
-        var tile = _tiles[key]!;
+      for (final key in toRemove) {
+        final tile = _tiles[key]!;
 
         tile.dispose(true);
         _tiles.remove(key);
       }
     } else if (options.evictErrorTileStrategy ==
         EvictErrorTileStrategy.notVisible) {
-      var toRemove = <String>[];
-      for (var entry in _tiles.entries) {
-        var tile = entry.value;
-        var c = tile.coords;
+      final toRemove = <String>[];
+      for (final entry in _tiles.entries) {
+        final tile = entry.value;
+        final c = tile.coords;
 
         if (tile.loadError &&
             (!tile.current || !tileRange.contains(CustomPoint(c.x, c.y)))) {
@@ -1131,8 +1131,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
         }
       }
 
-      for (var key in toRemove) {
-        var tile = _tiles[key]!;
+      for (final key in toRemove) {
+        final tile = _tiles[key]!;
 
         tile.dispose(true);
         _tiles.remove(key);
@@ -1153,7 +1153,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       tile!.loadError = false;
     }
 
-    var key = _tileCoordsToKey(coords);
+    final key = _tileCoordsToKey(coords);
     tile = _tiles[key];
     if (null == tile) {
       return;
@@ -1171,7 +1171,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       return;
     }
 
-    var fadeInStart = tile.loaded == null
+    final fadeInStart = tile.loaded == null
         ? options.tileFadeInStart
         : options.tileFadeInStartWhenOverride;
     tile.loaded = DateTime.now();
@@ -1209,12 +1209,12 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   CustomPoint _getTilePos(Coords coords) {
-    var level = _levels[coords.z as double]!;
+    final level = _levels[coords.z as double]!;
     return coords.scaleBy(getTileSize()) - level.origin!;
   }
 
   Coords _wrapCoords(Coords coords) {
-    var newCoords = Coords(
+    final newCoords = Coords(
       _wrapX != null
           ? util.wrapNum(coords.x.toDouble(), _wrapX!)
           : coords.x.toDouble(),
@@ -1227,7 +1227,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   Bounds _pxBoundsToTileRange(Bounds bounds) {
-    var tileSize = getTileSize();
+    final tileSize = getTileSize();
     return Bounds(
       bounds.min.unscaleBy(tileSize).floor(),
       bounds.max.unscaleBy(tileSize).ceil() - const CustomPoint(1, 1),
@@ -1235,7 +1235,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   bool _noTilesToLoad() {
-    for (var entry in _tiles.entries) {
+    for (final entry in _tiles.entries) {
       if (entry.value.loaded == null) {
         return false;
       }
@@ -1358,8 +1358,8 @@ class Tile implements Comparable<Tile> {
 
   @override
   int compareTo(Tile other) {
-    var zIndexA = level.zIndex;
-    var zIndexB = other.level.zIndex;
+    final zIndexA = level.zIndex;
+    final zIndexB = other.level.zIndex;
 
     if (zIndexA == zIndexB) {
       return 0;

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -514,7 +514,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       final newOptions = options.additionalOptions;
 
       if (oldUrl != newUrl ||
-          !(const MapEquality()).equals(oldOptions, newOptions)) {
+          !(const MapEquality<String, String>())
+              .equals(oldOptions, newOptions)) {
         if (options.overrideTilesWhenUrlChanges) {
           for (final tile in _tiles.values) {
             tile.imageProvider = options.tileProvider
@@ -1311,6 +1312,7 @@ class Tile implements Comparable<Tile> {
     if (evict) {
       try {
         // ignore: return_type_invalid_for_catch_error
+        // ignore: implicit_dynamic_parameter
         imageProvider.evict().catchError((e) {
           debugPrint(e.toString());
         });
@@ -1372,7 +1374,7 @@ class Tile implements Comparable<Tile> {
   int get hashCode => coords.hashCode;
 
   @override
-  bool operator ==(other) {
+  bool operator ==(Object other) {
     return other is Tile && coords == other.coords;
   }
 }

--- a/lib/src/layer/tile_provider/file_tile_provider_io.dart
+++ b/lib/src/layer/tile_provider/file_tile_provider_io.dart
@@ -2,8 +2,8 @@ import 'dart:io';
 
 import 'package:flutter/widgets.dart';
 
-import '../tile_layer.dart';
-import 'tile_provider.dart';
+import 'package:flutter_map/src/layer/tile_layer.dart';
+import 'package:flutter_map/src/layer/tile_provider/tile_provider.dart';
 
 /// FileTileProvider
 class FileTileProvider extends TileProvider {

--- a/lib/src/layer/tile_provider/file_tile_provider_web.dart
+++ b/lib/src/layer/tile_provider/file_tile_provider_web.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 
-import '../tile_layer.dart';
-import 'tile_provider.dart';
+import 'package:flutter_map/src/layer/tile_layer.dart';
+import 'package:flutter_map/src/layer/tile_provider/tile_provider.dart';
 
 /// FileTileProvider
 

--- a/lib/src/layer/tile_provider/network_image_with_retry.dart
+++ b/lib/src/layer/tile_provider/network_image_with_retry.dart
@@ -16,7 +16,7 @@ class NetworkImageWithRetry extends ImageProvider<NetworkImageWithRetry> {
   NetworkImageWithRetry(this.url, {this.scale = 1.0});
 
   @override
-  ImageStreamCompleter load(NetworkImageWithRetry key, decode) {
+  ImageStreamCompleter load(NetworkImageWithRetry key, DecoderCallback decode) {
     return OneFrameImageStreamCompleter(_loadWithRetry(key, decode),
         informationCollector: () sync* {
       yield ErrorDescription('Image provider: $this');

--- a/lib/src/layer/tile_provider/tile_provider.dart
+++ b/lib/src/layer/tile_provider/tile_provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
-import 'network_image_with_retry.dart';
+import 'package:flutter_map/src/layer/tile_provider/network_image_with_retry.dart';
 
 abstract class TileProvider {
   const TileProvider();

--- a/lib/src/layer/tile_provider/tile_provider.dart
+++ b/lib/src/layer/tile_provider/tile_provider.dart
@@ -11,14 +11,14 @@ abstract class TileProvider {
   void dispose() {}
 
   String getTileUrl(Coords coords, TileLayerOptions options) {
-    var urlTemplate = (options.wmsOptions != null)
+    final urlTemplate = (options.wmsOptions != null)
         ? options.wmsOptions!
             .getUrl(coords, options.tileSize.toInt(), options.retinaMode)
         : options.urlTemplate;
 
-    var z = _getZoomForUrl(coords, options);
+    final z = _getZoomForUrl(coords, options);
 
-    var data = <String, String>{
+    final data = <String, String>{
       'x': coords.x.round().toString(),
       'y': coords.y.round().toString(),
       'z': z.round().toString(),
@@ -28,7 +28,7 @@ abstract class TileProvider {
     if (options.tms) {
       data['y'] = invertY(coords.y.round(), z.round()).toString();
     }
-    var allOpts = Map<String, String>.from(data)
+    final allOpts = Map<String, String>.from(data)
       ..addAll(options.additionalOptions);
     return options.templateFunction(urlTemplate!, allOpts);
   }
@@ -51,7 +51,7 @@ abstract class TileProvider {
     if (options.subdomains.isEmpty) {
       return '';
     }
-    var index = (coords.x + coords.y).round() % options.subdomains.length;
+    final index = (coords.x + coords.y).round() % options.subdomains.length;
     return options.subdomains[index];
   }
 }

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -33,7 +33,7 @@ class FlutterMapState extends MapGestureMixin {
   void initState() {
     super.initState();
     mapState = MapState(options, (degree) {
-      if (mounted) setState(() => {});
+      if (mounted) setState(() {});
     }, mapController.mapEventSink);
     mapController.state = mapState;
 

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -44,7 +44,7 @@ class FlutterMapState extends MapGestureMixin {
   }
 
   void _disposeStreamGroups() {
-    for (var group in groups) {
+    for (final group in groups) {
       group.close();
     }
 
@@ -63,7 +63,7 @@ class FlutterMapState extends MapGestureMixin {
   Stream<void> _merge(LayerOptions options) {
     if (options.rebuild == null) return mapState.onMoved;
 
-    var group = StreamGroup<void>();
+    final group = StreamGroup<void>();
     group.add(mapState.onMoved);
     group.add(options.rebuild!);
     groups.add(group);
@@ -75,7 +75,7 @@ class FlutterMapState extends MapGestureMixin {
     _disposeStreamGroups();
     return LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
-      var hasLateSize = mapState.hasLateSize(constraints);
+      final hasLateSize = mapState.hasLateSize(constraints);
 
       mapState.setOriginalSize(constraints.maxWidth, constraints.maxHeight);
 
@@ -85,9 +85,9 @@ class FlutterMapState extends MapGestureMixin {
       if (hasLateSize) {
         mapState.initIfLateSize();
       }
-      var size = mapState.size;
+      final size = mapState.size;
 
-      var scaleGestureTeam = GestureArenaTeam();
+      final scaleGestureTeam = GestureArenaTeam();
 
       RawGestureDetector scaleGestureDetector({required Widget child}) =>
           RawGestureDetector(
@@ -159,15 +159,15 @@ class FlutterMapState extends MapGestureMixin {
     });
   }
 
-  Widget _buildMap(var size) {
+  Widget _buildMap(CustomPoint<double> size) {
     return ClipRect(
       child: Stack(
         children: [
           OverflowBox(
-            minWidth: size.x as double?,
-            maxWidth: size.x as double?,
-            minHeight: size.y as double?,
-            maxHeight: size.y as double?,
+            minWidth: size.x,
+            maxWidth: size.x,
+            minHeight: size.y,
+            maxHeight: size.y,
             child: Transform.rotate(
               angle: mapState.rotationRad,
               child: Stack(
@@ -197,7 +197,7 @@ class FlutterMapState extends MapGestureMixin {
   }
 
   Widget _createLayer(LayerOptions options, List<MapPlugin> plugins) {
-    for (var plugin in plugins) {
+    for (final plugin in plugins) {
       if (plugin.supportsLayer(options)) {
         return plugin.createLayer(options, mapState, _merge(options));
       }

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -201,7 +201,7 @@ class MapState {
     }
   }
 
-  void _handleMoveEmit(LatLng targetCenter, double targetZoom, hasGesture,
+  void _handleMoveEmit(LatLng targetCenter, double targetZoom, bool hasGesture,
       MapEventSource source, String? id) {
     if (source == MapEventSource.flingAnimationController) {
       emitMapEvent(
@@ -290,8 +290,8 @@ class MapState {
 
   bool rotate(
     double degree, {
-    hasGesture = false,
-    callOnMoveSink = true,
+    bool hasGesture = false,
+    bool callOnMoveSink = true,
     required MapEventSource source,
     String? id,
   }) {
@@ -338,8 +338,8 @@ class MapState {
   }
 
   bool move(LatLng center, double zoom,
-      {hasGesture = false,
-      callOnMoveSink = true,
+      {bool hasGesture = false,
+      bool callOnMoveSink = true,
       required MapEventSource source,
       String? id}) {
     zoom = fitZoomToBounds(zoom);

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -138,9 +138,9 @@ class MapState {
   }
 
   // Extended size of the map where rotation is calculated
-  CustomPoint? _size;
+  CustomPoint<double>? _size;
 
-  CustomPoint get size => _size ?? const CustomPoint(0.0, 0.0);
+  CustomPoint<double> get size => _size ?? const CustomPoint(0.0, 0.0);
 
   void _updateSizeByOriginalSizeAndRotation() {
     final originalWidth = _originalSize!.x;
@@ -183,7 +183,7 @@ class MapState {
 
   // Check if we've just got a new size constraints. Initially a layoutBuilder
   // May not be able to calculate a size, and end up with 0,0
-  bool hasLateSize(constraints) {
+  bool hasLateSize(BoxConstraints constraints) {
     if (options.bounds != null &&
         originalSize != null &&
         originalSize!.x == 0.0 &&
@@ -296,7 +296,7 @@ class MapState {
     String? id,
   }) {
     if (degree != _rotation) {
-      var oldRotation = _rotation;
+      final oldRotation = _rotation;
       rotation = degree;
       _updateSizeByOriginalSizeAndRotation();
 
@@ -359,8 +359,8 @@ class MapState {
     // Try and fit the corners of the map inside the visible area.
     // If it's still outside (so response is null), don't perform a move.
     if (options.maxBounds != null) {
-      var adjustedCenter =
-          adjustCenterIfOutsideMaxBounds(center, zoom, options.maxBounds);
+      final adjustedCenter =
+          adjustCenterIfOutsideMaxBounds(center, zoom, options.maxBounds!);
       if (adjustedCenter == null) {
         return false;
       } else {
@@ -380,7 +380,7 @@ class MapState {
     }
 
     if (options.onPositionChanged != null) {
-      var mapPosition = MapPosition(
+      final mapPosition = MapPosition(
           center: center, bounds: bounds, zoom: zoom, hasGesture: hasGesture);
 
       options.onPositionChanged!(mapPosition, hasGesture);
@@ -405,7 +405,7 @@ class MapState {
     if (!bounds.isValid) {
       throw Exception('Bounds are not valid.');
     }
-    var target = getBoundsCenterZoom(bounds, options);
+    final target = getBoundsCenterZoom(bounds, options);
     move(target.center, target.zoom, source: MapEventSource.fitBounds);
   }
 
@@ -441,7 +441,7 @@ class MapState {
   }
 
   LatLngBounds _calculateBounds() {
-    var bounds = getLastPixelBounds();
+    final bounds = getLastPixelBounds();
     return LatLngBounds(
       unproject(bounds.bottomLeft),
       unproject(bounds.topRight),
@@ -450,20 +450,20 @@ class MapState {
 
   CenterZoom getBoundsCenterZoom(
       LatLngBounds bounds, FitBoundsOptions options) {
-    var paddingTL =
+    final paddingTL =
         CustomPoint<double>(options.padding.left, options.padding.top);
-    var paddingBR =
+    final paddingBR =
         CustomPoint<double>(options.padding.right, options.padding.bottom);
 
-    var paddingTotalXY = paddingTL + paddingBR;
+    final paddingTotalXY = paddingTL + paddingBR;
 
     var zoom = getBoundsZoom(bounds, paddingTotalXY, inside: options.inside);
     zoom = math.min(options.maxZoom, zoom);
 
-    var paddingOffset = (paddingBR - paddingTL) / 2;
-    var swPoint = project(bounds.southWest!, zoom);
-    var nePoint = project(bounds.northEast!, zoom);
-    var center = unproject((swPoint + nePoint) / 2 + paddingOffset, zoom);
+    final paddingOffset = (paddingBR - paddingTL) / 2;
+    final swPoint = project(bounds.southWest!, zoom);
+    final nePoint = project(bounds.northEast!, zoom);
+    final center = unproject((swPoint + nePoint) / 2 + paddingOffset, zoom);
     return CenterZoom(
       center: center,
       zoom: zoom,
@@ -473,17 +473,17 @@ class MapState {
   double getBoundsZoom(LatLngBounds bounds, CustomPoint<double> padding,
       {bool inside = false}) {
     var zoom = this.zoom;
-    var min = options.minZoom ?? 0.0;
-    var max = options.maxZoom ?? double.infinity;
-    var nw = bounds.northWest;
-    var se = bounds.southEast;
+    final min = options.minZoom ?? 0.0;
+    final max = options.maxZoom ?? double.infinity;
+    final nw = bounds.northWest;
+    final se = bounds.southEast;
     var size = this.size - padding;
     // Prevent negative size which results in NaN zoom value later on in the calculation
     size = CustomPoint(math.max(0, size.x), math.max(0, size.y));
-    var boundsSize = Bounds(project(se, zoom), project(nw, zoom)).size;
-    var scaleX = size.x / boundsSize.x;
-    var scaleY = size.y / boundsSize.y;
-    var scale = inside ? math.max(scaleX, scaleY) : math.min(scaleX, scaleY);
+    final boundsSize = Bounds(project(se, zoom), project(nw, zoom)).size;
+    final scaleX = size.x / boundsSize.x;
+    final scaleY = size.y / boundsSize.y;
+    final scale = inside ? math.max(scaleX, scaleY) : math.min(scaleX, scaleY);
 
     zoom = getScaleZoom(scale, zoom);
 
@@ -509,13 +509,13 @@ class MapState {
   }
 
   double getZoomScale(double toZoom, double? fromZoom) {
-    var crs = options.crs;
+    final crs = options.crs;
     fromZoom = fromZoom ?? _zoom;
     return crs.scale(toZoom) / crs.scale(fromZoom);
   }
 
   double getScaleZoom(double scale, double? fromZoom) {
-    var crs = options.crs;
+    final crs = options.crs;
     fromZoom = fromZoom ?? _zoom;
     return crs.zoom(scale * crs.scale(fromZoom)) as double;
   }
@@ -529,38 +529,38 @@ class MapState {
   }
 
   CustomPoint getNewPixelOrigin(LatLng center, [double? zoom]) {
-    var viewHalf = size / 2.0;
+    final viewHalf = size / 2.0;
     return (project(center, zoom) - viewHalf).round();
   }
 
   Bounds getPixelBounds(double zoom) {
-    var mapZoom = zoom;
-    var scale = getZoomScale(mapZoom, zoom);
-    var pixelCenter = project(center, zoom).floor();
-    var halfSize = size / (scale * 2);
+    final mapZoom = zoom;
+    final scale = getZoomScale(mapZoom, zoom);
+    final pixelCenter = project(center, zoom).floor();
+    final halfSize = size / (scale * 2);
     return Bounds(pixelCenter - halfSize, pixelCenter + halfSize);
   }
 
   LatLng? adjustCenterIfOutsideMaxBounds(
-      LatLng testCenter, testZoom, maxBounds) {
+      LatLng testCenter, double testZoom, LatLngBounds maxBounds) {
     LatLng? newCenter;
 
-    var swPixel = project(maxBounds.southWest!, testZoom);
-    var nePixel = project(maxBounds.northEast!, testZoom);
+    final swPixel = project(maxBounds.southWest!, testZoom);
+    final nePixel = project(maxBounds.northEast!, testZoom);
 
-    var centerPix = project(testCenter, testZoom);
+    final centerPix = project(testCenter, testZoom);
 
-    var halfSizeX = size.x / 2;
-    var halfSizeY = size.y / 2;
+    final halfSizeX = size.x / 2;
+    final halfSizeY = size.y / 2;
 
     // Try and find the edge value that the center could use to stay within
     // the maxBounds. This should be ok for panning. If we zoom, it is possible
     // there is no solution to keep all corners within the bounds. If the edges
     // are still outside the bounds, don't return anything.
-    var leftOkCenter = math.min(swPixel.x, nePixel.x) + halfSizeX;
-    var rightOkCenter = math.max(swPixel.x, nePixel.x) - halfSizeX;
-    var topOkCenter = math.min(swPixel.y, nePixel.y) + halfSizeY;
-    var botOkCenter = math.max(swPixel.y, nePixel.y) - halfSizeY;
+    final leftOkCenter = math.min(swPixel.x, nePixel.x) + halfSizeX;
+    final rightOkCenter = math.max(swPixel.x, nePixel.x) - halfSizeX;
+    final topOkCenter = math.min(swPixel.y, nePixel.y) + halfSizeY;
+    final botOkCenter = math.max(swPixel.y, nePixel.y) - halfSizeY;
 
     double? newCenterX;
     double? newCenterY;
@@ -587,8 +587,8 @@ class MapState {
       return testCenter;
     }
 
-    var newCx = newCenterX ?? centerPix.x;
-    var newCy = newCenterY ?? centerPix.y;
+    final newCx = newCenterX ?? centerPix.x;
+    final newCy = newCenterY ?? centerPix.y;
 
     // Have a final check, see if the adjusted center is within maxBounds.
     // If not, give up.

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -47,7 +47,7 @@ class MapControllerImpl implements MapController {
   void fitBounds(
     LatLngBounds bounds, {
     FitBoundsOptions? options =
-        const FitBoundsOptions(padding: EdgeInsets.all(12.0)),
+        const FitBoundsOptions(padding: EdgeInsets.all(12)),
   }) {
     _state.fitBounds(bounds, options!);
   }
@@ -56,7 +56,7 @@ class MapControllerImpl implements MapController {
   CenterZoom centerZoomFitBounds(
     LatLngBounds bounds, {
     FitBoundsOptions? options =
-        const FitBoundsOptions(padding: EdgeInsets.all(12.0)),
+        const FitBoundsOptions(padding: EdgeInsets.all(12)),
   }) {
     return _state.centerZoomFitBounds(bounds, options!);
   }

--- a/lib/src/map/map_state_widget.dart
+++ b/lib/src/map/map_state_widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/widgets.dart';
 
-import 'map.dart';
+import 'package:flutter_map/src/map/map.dart';
 
 class MapStateInheritedWidget extends InheritedWidget {
   final MapState mapState;

--- a/test/flutter_map_test.dart
+++ b/test/flutter_map_test.dart
@@ -67,7 +67,7 @@ class TestApp extends StatefulWidget {
   const TestApp({Key? key}) : super(key: key);
 
   @override
-  _TestAppState createState() => _TestAppState();
+  State<TestApp> createState() => _TestAppState();
 }
 
 class _TestAppState extends State<TestApp> {

--- a/test/flutter_map_test.dart
+++ b/test/flutter_map_test.dart
@@ -73,14 +73,14 @@ class TestApp extends StatefulWidget {
 class _TestAppState extends State<TestApp> {
   final List<Marker> _markers = <Marker>[
     Marker(
-      width: 80.0,
-      height: 80.0,
+      width: 80,
+      height: 80,
       point: LatLng(45.5231, -122.6765),
       builder: (ctx) => const FlutterLogo(),
     ),
     Marker(
-      width: 80.0,
-      height: 80.0,
+      width: 80,
+      height: 80,
       point: LatLng(40, -120), // not visible
       builder: (ctx) => const FlutterLogo(),
     ),
@@ -102,7 +102,7 @@ class _TestAppState extends State<TestApp> {
             child: FlutterMap(
               options: MapOptions(
                 center: LatLng(45.5231, -122.6765),
-                zoom: 13.0,
+                zoom: 13,
               ),
               layers: [
                 TileLayerOptions(

--- a/test/helpers/core.dart
+++ b/test/helpers/core.dart
@@ -3,10 +3,10 @@ import 'dart:math';
 
 bool randomBool() => Random().nextBool();
 
-int randomInt([int max = 1000, zero = true]) =>
+int randomInt([int max = 1000, bool zero = true]) =>
     min(Random().nextInt(max) + (zero ? 0 : 1), max);
 
-double randomDouble([double max = 1000.0, zero = true]) =>
+double randomDouble([double max = 1000.0, bool zero = true]) =>
     min(Random().nextDouble() * max + (zero ? 0 : 1), max);
 
 DateTime randomDateTime() =>


### PR DESCRIPTION
Mostly trivial code changes made by running `dart fix --apply`

The new most important rules enabled are:
  - `prefer_final_locals`: https://dart-lang.github.io/linter/lints/prefer_final_locals.html
  - `prefer_final_in_for_each`: https://dart-lang.github.io/linter/lints/prefer_final_in_for_each.html
  - `avoid_dynamic_calls`: https://dart-lang.github.io/linter/lints/avoid_dynamic_calls.html

All three rules take advantage of relatively recent improvements in the Dart SDK and thus "modernize" the codebase (eg. getting rid of all those `var`), they can potentially have a positive impact on performance as described in the reference links while also ensuring correctness long term.

I've also re-enabled `library_private_types_in_public_api` that is present in `flutter_lints` and was overridden locally.

EDIT:
  - I've now promoted `missing_required_param` and `missing_return` to errors in the analyzer and also enabled the "strong-mode" to avoid weak implicit casts and implicit dynamic.
  - A more cosmetic choice of preferring integer literals and using named constants to avoid copying.