### PR TITLE
fix double/int exception

### DIFF
--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -518,7 +518,7 @@ class MapState {
     final se = bounds.southEast;
     var size = this.size - padding;
     // Prevent negative size which results in NaN zoom value later on in the calculation
-    size = CustomPoint(math.max(0, size.x), math.max(0, size.y));
+    size = CustomPoint(math.max(0.0, size.x), math.max(0.0, size.y));
     final boundsSize = Bounds(project(se, zoom), project(nw, zoom)).size;
     final scaleX = size.x / boundsSize.x;
     final scaleY = size.y / boundsSize.y;


### PR DESCRIPTION
There's an odd exception that gets created, when we use fitBounds and padding. Sometimes flutter_map can't get a "size" (widget size) immediately, and a padding is used. This causes flutter_map to have a zero size, and subtract a padding, leading to a negative size within getBoundsZoom() in map.dart.

I.e ```var size = this.size - padding;```

As it ends up with a negative size variable, it then hits the line  ```size = CustomPoint(math.max(0, size.x), math.max(0, size.y));``` which turns it into an Integer CustomPoint. However, project later needs a double. 

So we can either force it with setting math.max and use 0.0 instead of 0, or I guess we can add a .toDouble() on math.max(0, size.x).toDouble() if wanted to be more explicitly.