### PR TITLE
fix for web not displaying non-https images on example page.

### DIFF
--- a/example/lib/pages/epsg4326_crs.dart
+++ b/example/lib/pages/epsg4326_crs.dart
@@ -34,7 +34,7 @@ class EPSG4326Page extends StatelessWidget {
                   TileLayerOptions(
                     wmsOptions: WMSTileLayerOptions(
                       crs: const Epsg4326(),
-                      baseUrl: 'http://ows.mundialis.de/services/service?',
+                      baseUrl: 'https://ows.mundialis.de/services/service?',
                       layers: ['TOPO-OSM-WMS'],
                     ),
                   )


### PR DESCRIPTION
Example page for epsg4326 doesn't work on the web, as the browser will complain about being unable to fetch non-https files.