### PR TITLE
Fix for example with web failing for non-https link 

### DIFF
--- a/example/lib/pages/epsg4326_crs.dart
+++ b/example/lib/pages/epsg4326_crs.dart
@@ -34,7 +34,7 @@ class EPSG4326Page extends StatelessWidget {
                   TileLayerOptions(
                     wmsOptions: WMSTileLayerOptions(
                       crs: const Epsg4326(),
-                      baseUrl: 'http://ows.mundialis.de/services/service?',
+                      baseUrl: 'https://ows.mundialis.de/services/service?',
                       layers: ['TOPO-OSM-WMS'],
                     ),
                   )


### PR DESCRIPTION
Redoing PR for none https link in example page after Git issue, causing errors when using Flutter web. Mobile is fine normally, this only affects browser.