### PR TITLE
Changed Attribution Methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
-## [1.0.0] - 2022
+## [1.1.0] - 2022
+
+Contains the following additions/removals:
+
+- Deprecated the existing `attributionBuilder`
+- Added a new method of attribution through `AttributionWidget`
+
+Contains the following bug fixes:
+
+- None
+
+In other news:
+
+- None
+
+Many thanks to these contributors (in no particular order):
+
+- None
+- ... and all the maintainers
+
+---
+
+## [1.0.0] - 2022/06/07
 
 Contains the following additions/removals:
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,6 @@ Widget build(BuildContext context) {
       TileLayerOptions(
         urlTemplate: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
         subdomains: ['a', 'b', 'c'],
-        attributionBuilder: (_) {
-          return Text("© OpenStreetMap contributors");
-        },
       ),
       MarkerLayerOptions(
         markers: [
@@ -76,6 +73,12 @@ Widget build(BuildContext context) {
             ),
           ),
         ],
+      ),
+    ],
+    nonRotatedChildren: [
+      AttributionWidget.defaultWidget(
+        source: 'OpenStreetMap contributors',
+        onSourceTapped: () {},
       ),
     ],
   );

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -63,12 +63,15 @@ class HomePage extends StatelessWidget {
                     urlTemplate:
                         'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                     subdomains: ['a', 'b', 'c'],
-                    // For example purposes. It is recommended to use
-                    // TileProvider with a caching and retry strategy, like
-                    // NetworkTileProvider or CachedNetworkTileProvider
                     tileProvider: const NonCachingNetworkTileProvider(),
                   ),
                   MarkerLayerOptions(markers: markers)
+                ],
+                nonRotatedChildren: [
+                  AttributionWidget.defaultWidget(
+                    source: 'OpenStreetMap contributors',
+                    onSourceTapped: () {},
+                  ),
                 ],
               ),
             ),

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -25,6 +25,7 @@ export 'package:flutter_map/src/geo/latlng_bounds.dart';
 export 'package:flutter_map/src/gestures/interactive_flag.dart';
 export 'package:flutter_map/src/gestures/map_events.dart';
 export 'package:flutter_map/src/gestures/multi_finger_gesture.dart';
+export 'package:flutter_map/src/layer/attribution_layer.dart';
 export 'package:flutter_map/src/layer/circle_layer.dart';
 export 'package:flutter_map/src/layer/group_layer.dart';
 export 'package:flutter_map/src/layer/layer.dart';

--- a/lib/src/layer/attribution_layer.dart
+++ b/lib/src/layer/attribution_layer.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/widgets.dart';
+
+/// Attribution widget layer, usually placed in `nonRotatedChildren`
+///
+/// Can be anchored in a position of the map using [alignment], defaulting to [Alignment.bottomRight]. Then pass [attributionBuilder] to build your custom attribution widget.
+///
+/// Alternatively, use the constructor [defaultWidget] to get a more classic styled attibution box.
+class AttributionWidget extends StatelessWidget {
+  /// Function that returns a widget given a [BuildContext], displayed on the map
+  final WidgetBuilder attributionBuilder;
+
+  /// Anchor the widget in a position of the map, defaulting to [Alignment.bottomRight]
+  final Alignment alignment;
+
+  /// Attribution widget layer, usually placed in `nonRotatedChildren`
+  ///
+  /// Can be anchored in a position of the map using [alignment], defaulting to [Alignment.bottomRight]. Then pass [attributionBuilder] to build your custom attribution widget.
+  ///
+  /// Alternatively, use the constructor [defaultWidget] to get a more classic styled attibution box.
+  const AttributionWidget({
+    Key? key,
+    required this.attributionBuilder,
+    this.alignment = Alignment.bottomRight,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) =>
+      Align(alignment: alignment, child: attributionBuilder(context));
+
+  /// Quick constructor for a more classic styled attibution box
+  ///
+  /// Displayed as a padded translucent white box with the following text: 'flutter_map | © [source]'.
+  ///
+  /// Provide [onSourceTapped] to carry out a function when the box is tapped. If that isn't null, the source text will have [sourceTextStyle] styling - which defaults to a link styling.
+  static Widget defaultWidget({
+    required String source,
+    void Function()? onSourceTapped,
+    TextStyle sourceTextStyle = const TextStyle(color: Color(0xFF0078a8)),
+    Alignment alignment = Alignment.bottomRight,
+  }) =>
+      Align(
+        alignment: alignment,
+        child: ColoredBox(
+          color: const Color(0xCCFFFFFF),
+          child: GestureDetector(
+            onTap: onSourceTapped,
+            child: Padding(
+              padding: const EdgeInsets.all(3),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text('flutter_map | © '),
+                  MouseRegion(
+                    cursor: onSourceTapped == null
+                        ? MouseCursor.defer
+                        : SystemMouseCursors.click,
+                    child: Text(
+                      source,
+                      style: onSourceTapped == null ? null : sourceTextStyle,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+}

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -202,6 +202,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
               );
 
         final attributionLayer =
+            // ignore: deprecated_member_use_from_same_package
             widget.options.attributionBuilder?.call(context);
 
         return Opacity(

--- a/lib/src/layer/tile_layer/tile_layer_options.dart
+++ b/lib/src/layer/tile_layer/tile_layer_options.dart
@@ -226,7 +226,10 @@ class TileLayerOptions extends LayerOptions {
   /// When set to `true`, the `tileFadeIn*` options will be ignored.
   final bool fastReplace;
 
-  ///Attribution widget builder
+  /// [attributionBuilder] has been deprecated. Usage will continue to work, however not as expected. As an alternative, use [AttributionWidget] inside `nonRotatedChildren`.
+  @Deprecated(
+    '`attributionBuilder` has been deprecated. Usage will continue to work, however not as expected. As an alternative, use `AttributionWidget` inside `nonRotatedChildren`.',
+  )
   final WidgetBuilder? attributionBuilder;
 
   ///aligment of the attribution text on the map widget
@@ -238,56 +241,59 @@ class TileLayerOptions extends LayerOptions {
   /// Only load tiles that are within these bounds
   LatLngBounds? tileBounds;
 
-  TileLayerOptions(
-      {this.attributionAlignment = Alignment.bottomRight,
-      this.attributionBuilder,
-      Key? key,
-      // TODO: make required
-      this.urlTemplate,
-      double tileSize = 256.0,
-      double minZoom = 0.0,
-      double maxZoom = 18.0,
-      this.minNativeZoom,
-      this.maxNativeZoom,
-      this.zoomReverse = false,
-      double zoomOffset = 0.0,
-      Map<String, String>? additionalOptions,
-      this.subdomains = const <String>[],
-      this.keepBuffer = 2,
-      this.backgroundColor = const Color(0xFFE0E0E0),
-      @Deprecated('`placeholderImage` has been deprecated with no current replacement or workaround. Usage no longer has an effect internally.')
-          this.placeholderImage,
-      this.errorImage,
-      this.tileProvider = const NonCachingNetworkTileProvider(),
-      this.tms = false,
-      // ignore: avoid_init_to_null
-      this.wmsOptions = null,
-      this.opacity = 1.0,
-      // Tiles will not update more than once every `updateInterval` milliseconds
-      // (default 200) when panning. It can be 0 (but it will calculating for
-      // loading tiles every frame when panning / zooming, flutter is fast) This
-      // can save some fps and even bandwidth (ie. when fast panning / animating
-      // between long distances in short time)
-      // TODO: change to Duration
-      int updateInterval = 200,
-      // Tiles fade in duration in milliseconds (default 100).  This can be set to
-      // 0 to avoid fade in
-      // TODO: change to Duration
-      int tileFadeInDuration = 100,
-      this.tileFadeInStart = 0.0,
-      this.tileFadeInStartWhenOverride = 0.0,
-      this.overrideTilesWhenUrlChanges = false,
-      this.retinaMode = false,
-      this.errorTileCallback,
-      Stream<void>? rebuild,
-      this.templateFunction = util.template,
-      this.tileBuilder,
-      this.tilesContainerBuilder,
-      this.evictErrorTileStrategy = EvictErrorTileStrategy.none,
-      this.fastReplace = false,
-      this.reset,
-      this.tileBounds})
-      : updateInterval =
+  TileLayerOptions({
+    this.attributionAlignment = Alignment.bottomRight,
+    @Deprecated(
+      '`attributionBuilder` has been deprecated. Usage will continue to work, however not as expected. As an alternative, use `AttributionWidget` inside `nonRotatedChildren`.',
+    )
+        this.attributionBuilder,
+    Key? key,
+    // TODO: make required
+    this.urlTemplate,
+    double tileSize = 256.0,
+    double minZoom = 0.0,
+    double maxZoom = 18.0,
+    this.minNativeZoom,
+    this.maxNativeZoom,
+    this.zoomReverse = false,
+    double zoomOffset = 0.0,
+    Map<String, String>? additionalOptions,
+    this.subdomains = const <String>[],
+    this.keepBuffer = 2,
+    this.backgroundColor = const Color(0xFFE0E0E0),
+    @Deprecated('`placeholderImage` has been deprecated with no current replacement or workaround. Usage no longer has an effect internally.')
+        this.placeholderImage,
+    this.errorImage,
+    this.tileProvider = const NonCachingNetworkTileProvider(),
+    this.tms = false,
+    // ignore: avoid_init_to_null
+    this.wmsOptions = null,
+    this.opacity = 1.0,
+    // Tiles will not update more than once every `updateInterval` milliseconds
+    // (default 200) when panning. It can be 0 (but it will calculating for
+    // loading tiles every frame when panning / zooming, flutter is fast) This
+    // can save some fps and even bandwidth (ie. when fast panning / animating
+    // between long distances in short time)
+    // TODO: change to Duration
+    int updateInterval = 200,
+    // Tiles fade in duration in milliseconds (default 100).  This can be set to
+    // 0 to avoid fade in
+    // TODO: change to Duration
+    int tileFadeInDuration = 100,
+    this.tileFadeInStart = 0.0,
+    this.tileFadeInStartWhenOverride = 0.0,
+    this.overrideTilesWhenUrlChanges = false,
+    this.retinaMode = false,
+    this.errorTileCallback,
+    Stream<void>? rebuild,
+    this.templateFunction = util.template,
+    this.tileBuilder,
+    this.tilesContainerBuilder,
+    this.evictErrorTileStrategy = EvictErrorTileStrategy.none,
+    this.fastReplace = false,
+    this.reset,
+    this.tileBounds,
+  })  : updateInterval =
             updateInterval <= 0 ? null : Duration(milliseconds: updateInterval),
         tileFadeInDuration = tileFadeInDuration <= 0
             ? null

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_map
 description: A versatile mapping package for Flutter, based off leaflet.js, that's simple and easy to learn, yet completely customizable and configurable.
-version: 1.0.0
+version: 1.1.0
 repository: https://github.com/fleaflet/flutter_map
 
 environment:


### PR DESCRIPTION
Inline with #1040, this deprecates the old method of attribution via `attributionBuilder`, and replaces it with a new layer widget: `AttributionWidget`.

`AttributionWidget` is intended to be used inside `nonRotatedChildren`. Therefore, both the README, main example page, and in-code documentation reflect this. It now also aligns with the map as expected, unlike the old method.

Also provided is a quicker way to attribute by using `AttributionWidget.defaultWidget`, which automatically styles the widget similar to how it is seen elsewhere on the Internet. The example and README use this for demonstration.

Resolves #1040 by replacing #1012.