### PR TITLE
fix for double click not keeping track with event position

### DIFF
--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -34,17 +34,13 @@ abstract class MapGestureMixin extends State<FlutterMap>
       final newZoom = (mapState.zoom + pointerSignal.scrollDelta.dy * -0.005)
           .clamp(minZoom, maxZoom);
       // Calculate offset of mouse cursor from viewport center
-      final cursorPos = CustomPoint(
-          pointerSignal.localPosition.dx, pointerSignal.localPosition.dy);
-      final viewCenter = mapState.originalSize! / 2;
-      final offset = (cursorPos - viewCenter).rotate(mapState.rotationRad);
-      // Match new center coordinate to mouse cursor position
-      final scale = mapState.getZoomScale(newZoom, mapState.zoom);
-      final newOffset = offset * (1.0 - 1.0 / scale);
-      final mapCenter = mapState.project(mapState.center);
-      final newCenter = mapState.unproject(mapCenter + newOffset);
+      final List<dynamic> newCenterZoom = _getNewEventCenterZoomPosition(
+          CustomPoint(pointerSignal.localPosition.dx,
+              pointerSignal.localPosition.dy),newZoom);
+
       // Move to new center and zoom level
-      mapState.move(newCenter, newZoom, source: MapEventSource.scrollWheel);
+      mapState.move(newCenterZoom[0] as LatLng, newCenterZoom[1] as double,
+          source: MapEventSource.scrollWheel);
     }
   }
 
@@ -598,7 +594,6 @@ abstract class MapGestureMixin extends State<FlutterMap>
 
   void handleDoubleTap(TapPosition tapPosition) {
     _resetDoubleTapHold();
-
     if (!options.allowPanning) {
       return;
     }
@@ -608,42 +603,36 @@ abstract class MapGestureMixin extends State<FlutterMap>
 
     if (InteractiveFlag.hasFlag(
         options.interactiveFlags, InteractiveFlag.doubleTapZoom)) {
-      final centerPos = _pointToOffset(mapState.originalSize!) / 2.0;
-      final newZoom = _getZoomForScale(mapState.zoom, 2);
-      final focalDelta = _getDoubleTapFocalDelta(
-          centerPos, tapPosition.relative!, newZoom - mapState.zoom);
-      final newCenter = _offsetToCrs(centerPos + focalDelta);
-      _startDoubleTapAnimation(newZoom, newCenter);
+      final centerZoom = _getNewEventCenterZoomPosition(
+          CustomPoint(tapPosition.relative!.dx, tapPosition.relative!.dy),
+          _getZoomForScale(mapState.zoom, 2));
+      _startDoubleTapAnimation(centerZoom[1] as double, centerZoom[0] as LatLng);
     }
   }
 
-  Offset _getDoubleTapFocalDelta(
-      Offset centerPos, Offset tapPos, double zoomDiff) {
-    final tapDelta = tapPos - centerPos;
-    final zoomScale = 1 / math.pow(2, zoomDiff);
-    // The map center offset within which double-tap won't cause zooming to
-    // previously invisible area
-    final maxDelta = centerPos * (1 - zoomScale);
-    final tappedOutExtent =
-        tapDelta.dx.abs() > maxDelta.dx || tapDelta.dy.abs() > maxDelta.dy;
-    return tappedOutExtent
-        ? _projectDeltaOnBounds(tapDelta, maxDelta)
-        : tapDelta;
-  }
-
-  Offset _projectDeltaOnBounds(Offset delta, Offset maxDelta) {
-    final weightX = delta.dx.abs() / maxDelta.dx;
-    final weightY = delta.dy.abs() / maxDelta.dy;
-    return delta / math.max(weightX, weightY);
+  // If we double click in the corner of a map, calculate the new
+  // center of the whole map after a zoom, to retain that offset position
+  // so that the same event LatLng is still under the cursor.
+  
+  List<dynamic> _getNewEventCenterZoomPosition(CustomPoint cursorPos, double newZoom) {
+    // Calculate offset of mouse cursor from viewport center
+    final viewCenter = mapState.originalSize! / 2;
+    final offset = (cursorPos - viewCenter).rotate(mapState.rotationRad);
+    // Match new center coordinate to mouse cursor position
+    final scale = mapState.getZoomScale(newZoom, mapState.zoom);
+    final newOffset = offset * (1.0 - 1.0 / scale);
+    final mapCenter = mapState.project(mapState.center);
+    final newCenter = mapState.unproject(mapCenter + newOffset);
+    return <dynamic>[newCenter, newZoom];
   }
 
   void _startDoubleTapAnimation(double newZoom, LatLng newCenter) {
     _doubleTapZoomAnimation = Tween<double>(begin: mapState.zoom, end: newZoom)
-        .chain(CurveTween(curve: Curves.fastOutSlowIn))
+        .chain(CurveTween(curve: Curves.linear))
         .animate(_doubleTapController);
     _doubleTapCenterAnimation =
         LatLngTween(begin: mapState.center, end: newCenter)
-            .chain(CurveTween(curve: Curves.fastOutSlowIn))
+            .chain(CurveTween(curve: Curves.linear))
             .animate(_doubleTapController);
     _doubleTapController.forward(from: 0);
   }
@@ -669,6 +658,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
   }
 
   void _handleDoubleTapZoomAnimation() {
+    print("${_doubleTapCenterAnimation.value}");
     mapState.move(
       _doubleTapCenterAnimation.value,
       _doubleTapZoomAnimation.value,


### PR DESCRIPTION
Don't merge this just yet, but is for testing currently. Fixes https://github.com/fleaflet/flutter_map/issues/1265

Previously double click wouldn't zoom to correct position. This should fix that, and refactors mousewheel zoom to use the same code now, in a separate method.

Also slight change is the animation easing on double click. There is a bug (existing before this change), where a zoom doesn't follow the correct linear path. The easing doesn't help here, so keeping it simple, so it's slightly less obvious, but ideally needs a fix in the future.

