### PR TITLE
FlyTo method for zoom/panning between locations 

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -57,7 +57,8 @@ class MyApp extends StatelessWidget {
         EsriPage.route: (context) => const EsriPage(),
         PolylinePage.route: (context) => const PolylinePage(),
         MapControllerPage.route: (context) => const MapControllerPage(),
-	MapControllerFlyToPage.route: (context) => const MapControllerFlyToPage(),
+        MapControllerFlyToPage.route: (context) =>
+            const MapControllerFlyToPage(),
         AnimatedMapControllerPage.route: (context) =>
             const AnimatedMapControllerPage(),
         MarkerAnchorPage.route: (context) => const MarkerAnchorPage(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,6 +13,7 @@ import './pages/interactive_test_page.dart';
 import './pages/live_location.dart';
 import './pages/many_markers.dart';
 import './pages/map_controller.dart';
+import './pages/map_controller_flyto.dart';
 import './pages/marker_anchor.dart';
 import './pages/marker_rotate.dart';
 import './pages/max_bounds.dart';
@@ -56,6 +57,7 @@ class MyApp extends StatelessWidget {
         EsriPage.route: (context) => const EsriPage(),
         PolylinePage.route: (context) => const PolylinePage(),
         MapControllerPage.route: (context) => const MapControllerPage(),
+	MapControllerFlyToPage.route: (context) => const MapControllerFlyToPage(),
         AnimatedMapControllerPage.route: (context) =>
             const AnimatedMapControllerPage(),
         MarkerAnchorPage.route: (context) => const MarkerAnchorPage(),

--- a/example/lib/pages/map_controller_flyto.dart
+++ b/example/lib/pages/map_controller_flyto.dart
@@ -1,0 +1,254 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:location/location.dart';
+
+import '../widgets/drawer.dart';
+
+class MapControllerFlyToPage extends StatefulWidget {
+  static const String route = 'map_controller_flyto';
+
+  const MapControllerFlyToPage({Key? key}) : super(key: key);
+
+  @override
+  MapControllerFlyToPageState createState() {
+    return MapControllerFlyToPageState();
+  }
+}
+
+class MapControllerFlyToPageState extends State<MapControllerFlyToPage> {
+  static LatLng london = LatLng(51.5, -0.09);
+  static LatLng texas = LatLng(31.0, -100.0);
+  static LatLng dublin = LatLng(53.3498, -6.2603);
+
+  late final MapController mapController;
+  double rotation = 0.0;
+
+  @override
+  void initState() {
+    super.initState();
+    mapController = MapController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var markers = <Marker>[
+      Marker(
+        width: 80.0,
+        height: 80.0,
+        point: london,
+        builder: (ctx) => Container(
+          key: const Key('blue'),
+          child: const FlutterLogo(),
+        ),
+      ),
+      Marker(
+        width: 80.0,
+        height: 80.0,
+        point: dublin,
+        builder: (ctx) => const FlutterLogo(
+          key: Key('green'),
+          textColor: Colors.green,
+        ),
+      ),
+      Marker(
+        width: 80.0,
+        height: 80.0,
+        point: texas,
+        builder: (ctx) => Container(
+          key: const Key('purple'),
+          child: const FlutterLogo(textColor: Colors.purple),
+        ),
+      ),
+    ];
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('MapController FlyTo')),
+      drawer: buildDrawer(context, MapControllerFlyToPage.route),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Row(
+                children: <Widget>[
+                  MaterialButton(
+                    onPressed: () {
+                      mapController.flyTo(london, zoom: 18.0, duration: 3);
+                    },
+                    child: const Text('London'),
+                  ),
+                  MaterialButton(
+                    onPressed: () {
+                      mapController.flyTo(texas, zoom: 5.0, duration: 3);
+                    },
+                    child: const Text('Texas'),
+                  ),
+                  MaterialButton(
+                    onPressed: () {
+                      mapController.flyTo(dublin, zoom: 5, duration: 3 );
+                    },
+                    child: const Text('Dublin'),
+                  ),
+                  CurrentLocation(mapController: mapController),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Row(
+                children: <Widget>[
+                  MaterialButton(
+                    onPressed: () {
+                      var bounds = LatLngBounds();
+                      bounds.extend(dublin);
+                      bounds.extend(texas);
+                      bounds.extend(london);
+                      mapController.fitBounds(
+                        bounds,
+                        options: const FitBoundsOptions(
+                          padding: EdgeInsets.only(left: 15.0, right: 15.0),
+                        ),
+                      );
+                    },
+                    child: const Text('Fit Bounds'),
+                  ),
+                  Builder(builder: (BuildContext context) {
+                    return MaterialButton(
+                      onPressed: () {
+                        final bounds = mapController.bounds!;
+
+                        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                          content: Text(
+                            'Map bounds: \n'
+                            'E: ${bounds.east} \n'
+                            'N: ${bounds.north} \n'
+                            'W: ${bounds.west} \n'
+                            'S: ${bounds.south}',
+                          ),
+                        ));
+                      },
+                      child: const Text('Get Bounds'),
+                    );
+                  }),
+                  const Text('Rotation:'),
+                  Expanded(
+                    child: Slider(
+                      value: rotation,
+                      min: 0.0,
+                      max: 360,
+                      onChanged: (degree) {
+                        setState(() {
+                          rotation = degree;
+                        });
+                        mapController.rotate(degree);
+                      },
+                    ),
+                  )
+                ],
+              ),
+            ),
+            Flexible(
+              child: FlutterMap(
+                mapController: mapController,
+                options: MapOptions(
+                  center: LatLng(51.5, -0.09),
+                  zoom: 5.0,
+                  maxZoom: 18.0,
+                  minZoom: 3.0,
+                ),
+                layers: [
+                  TileLayerOptions(
+                      urlTemplate:
+                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                      subdomains: ['a', 'b', 'c']),
+                  MarkerLayerOptions(markers: markers)
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class CurrentLocation extends StatefulWidget {
+  const CurrentLocation({
+    Key? key,
+    required this.mapController,
+  }) : super(key: key);
+
+  final MapController mapController;
+
+  @override
+  _CurrentLocationState createState() => _CurrentLocationState();
+}
+
+class _CurrentLocationState extends State<CurrentLocation> {
+  int _eventKey = 0;
+
+  var icon = Icons.gps_not_fixed;
+  late final StreamSubscription<MapEvent> mapEventSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+
+    mapEventSubscription =
+        widget.mapController.mapEventStream.listen(onMapEvent);
+  }
+
+  @override
+  void dispose() {
+    mapEventSubscription.cancel();
+    super.dispose();
+  }
+
+  void setIcon(IconData newIcon) {
+    if (newIcon != icon && mounted) {
+      setState(() {
+        icon = newIcon;
+      });
+    }
+  }
+
+  void onMapEvent(MapEvent mapEvent) {
+    if (mapEvent is MapEventMove && mapEvent.id == _eventKey.toString()) {
+      setIcon(Icons.gps_not_fixed);
+    }
+  }
+
+  void _moveToCurrent() async {
+    _eventKey++;
+    var location = Location();
+
+    try {
+      var currentLocation = await location.getLocation();
+      var moved = widget.mapController.move(
+        LatLng(currentLocation.latitude!, currentLocation.longitude!),
+        18,
+        id: _eventKey.toString(),
+      );
+
+      if (moved) {
+        setIcon(Icons.gps_fixed);
+      } else {
+        setIcon(Icons.gps_not_fixed);
+      }
+    } catch (e) {
+      setIcon(Icons.gps_off);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: Icon(icon),
+      onPressed: _moveToCurrent,
+    );
+  }
+}

--- a/example/lib/pages/map_controller_flyto.dart
+++ b/example/lib/pages/map_controller_flyto.dart
@@ -89,7 +89,7 @@ class MapControllerFlyToPageState extends State<MapControllerFlyToPage> {
                   ),
                   MaterialButton(
                     onPressed: () {
-                      mapController.flyTo(dublin, zoom: 5, duration: 3 );
+                      mapController.flyTo(dublin, zoom: 5, duration: 3);
                     },
                     child: const Text('Dublin'),
                   ),

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -6,6 +6,7 @@ import 'package:flutter_map_example/pages/network_tile_provider.dart';
 import 'package:flutter_map_example/pages/point_to_latlng.dart';
 
 import '../pages/animated_map_controller.dart';
+import '../pages/map_controller_flyto.dart';
 import '../pages/circle.dart';
 import '../pages/custom_crs/custom_crs.dart';
 import '../pages/esri.dart';
@@ -118,6 +119,12 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           context,
           const Text('Animated MapController'),
           AnimatedMapControllerPage.route,
+          currentRoute,
+        ),
+	_buildMenuItem(
+          context,
+          const Text('MapController FlyTo'),
+          MapControllerFlyToPage.route,
           currentRoute,
         ),
         _buildMenuItem(

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -121,7 +121,7 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           AnimatedMapControllerPage.route,
           currentRoute,
         ),
-	_buildMenuItem(
+        _buildMenuItem(
           context,
           const Text('MapController FlyTo'),
           MapControllerFlyToPage.route,

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -141,7 +141,7 @@ abstract class MapController {
   /// Do curved fly animation to destination. Duration can vary depending on the
   /// distance, however speed will influence how fast that moves though.
   @experimental
-  void flyTo(LatLng targetCenter, {double? zoom, double? duration });
+  void flyTo(LatLng targetCenter, {double? zoom, double? duration});
 
   Future<void> get onReady;
 

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -16,6 +16,7 @@ import 'package:flutter_map/src/map/flutter_map_state.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:flutter_map/src/plugins/plugin.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:meta/meta.dart';
 import 'package:positioned_tap_detector_2/positioned_tap_detector_2.dart';
 
 export 'package:flutter_map/src/core/center_zoom.dart';
@@ -136,6 +137,11 @@ abstract class MapController {
   /// through the [options] parameter.
   CenterZoom centerZoomFitBounds(LatLngBounds bounds,
       {FitBoundsOptions? options});
+
+  /// Do curved fly animation to destination. Duration can vary depending on the
+  /// distance, however speed will influence how fast that moves though.
+  @experimental
+  void flyTo(LatLng targetCenter, {double? zoom, double? duration });
 
   Future<void> get onReady;
 

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -84,10 +84,9 @@ class MapControllerImpl implements MapController {
 
   @experimental
   @override
-  void flyTo (LatLng destinationLatLng, { double? zoom, double? duration }) {
-    Movement.flyTo(_state, destinationLatLng, zoom: zoom, duration: duration );
+  void flyTo(LatLng destinationLatLng, {double? zoom, double? duration}) {
+    Movement.flyTo(_state, destinationLatLng, zoom: zoom, duration: duration);
   }
-
 
   @override
   LatLng? pointToLatLng(CustomPoint localPoint) {

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -5,7 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/core/bounds.dart';
 import 'package:flutter_map/src/map/map_state_widget.dart';
+import 'package:flutter_map/src/map/movement.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:meta/meta.dart';
 
 class MapControllerImpl implements MapController {
   final Completer<void> _readyCompleter = Completer<void>();
@@ -79,6 +81,13 @@ class MapControllerImpl implements MapController {
   bool rotate(double degree, {String? id}) {
     return _state.rotate(degree, id: id, source: MapEventSource.mapController);
   }
+
+  @experimental
+  @override
+  void flyTo (LatLng destinationLatLng, { double? zoom, double? duration }) {
+    Movement.flyTo(_state, destinationLatLng, zoom: zoom, duration: duration );
+  }
+
 
   @override
   LatLng? pointToLatLng(CustomPoint localPoint) {

--- a/lib/src/map/movement.dart
+++ b/lib/src/map/movement.dart
@@ -1,4 +1,3 @@
-
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -6,7 +5,6 @@ import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong2/latlong.dart';
 
 class Movement {
-
   // FlyTo Converted from leaflet.js map.js
   /*
   BSD 2-Clause License
@@ -39,9 +37,8 @@ class Movement {
   static bool alreadyFlying = false;
 
   static void flyTo(MapState mapState, LatLng targetCenter,
-      { double? zoom,  double? duration }) {
-
-    if(alreadyFlying) return;
+      {double? zoom, double? duration}) {
+    if (alreadyFlying) return;
 
     alreadyFlying = true;
     final CustomPoint from = mapState.project(mapState.getCenter());
@@ -80,9 +77,11 @@ class Movement {
     double sinh(double n) {
       return (math.exp(n) - math.exp(-n)) / 2;
     }
+
     double cosh(double n) {
       return (math.exp(n) + math.exp(-n)) / 2;
     }
+
     double tanh(double n) {
       return sinh(n) / cosh(n);
     }
@@ -92,6 +91,7 @@ class Movement {
     double w(double s) {
       return w0 * (cosh(r0) / cosh(r0 + rho * s));
     }
+
     double u(double s) {
       return w0 * (cosh(r0) * tanh(r0 + rho * s) - sinh(r0)) / rho2;
     }
@@ -106,10 +106,7 @@ class Movement {
     duration = duration != null ? 1000 * duration : 1000 * S * 0.8;
 
     void frame() async {
-      final t = DateTime
-          .now()
-          .difference(start)
-          .inMilliseconds / duration!;
+      final t = DateTime.now().difference(start).inMilliseconds / duration!;
       final s = easeOut(t) * S;
 
       if (t <= 1) {
@@ -119,8 +116,8 @@ class Movement {
         final newZoom = mapState.getScaleZoom(w0 / w(s), startZoom);
 
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          mapState.move(
-              newPos, newZoom, source: MapEventSource.flingAnimationController);
+          mapState.move(newPos, newZoom,
+              source: MapEventSource.flingAnimationController);
           frame();
         });
         WidgetsBinding.instance.ensureVisualUpdate();

--- a/lib/src/map/movement.dart
+++ b/lib/src/map/movement.dart
@@ -1,0 +1,108 @@
+
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/map/map.dart';
+import 'package:latlong2/latlong.dart';
+
+class Movement {
+
+  static bool alreadyFlying = false;
+
+  // Converted from leaflet.js map.js
+  static void flyTo(MapState mapState, LatLng targetCenter,
+      { double? zoom,  double? duration }) {
+
+    if(alreadyFlying) return;
+
+    alreadyFlying = true;
+    final CustomPoint from = mapState.project(mapState.getCenter());
+    final CustomPoint to = mapState.project(targetCenter);
+    final CustomPoint size = mapState.size;
+    final double startZoom = mapState.zoom;
+
+    final targetZoom = zoom ?? startZoom;
+
+    final w0 = math.max(size.x, size.y);
+    final w1 = w0 *
+        mapState.getZoomScale(startZoom, targetZoom); // was other way around
+    var u1 = to.distanceTo(from);
+
+    if (u1 == 0) {
+      u1 = 1;
+    }
+    const double rho = 1.42;
+    const double rho2 = rho * rho;
+
+    double r(int i) {
+      final int s1 = i == 1 ? -1 : 1;
+      final double s2 = i == 1 ? w1.toDouble() : w0.toDouble();
+      final double t1 = w1 * w1 - w0 * w0 + s1 * rho2 * rho2 * u1 * u1;
+      final double b1 = 2 * s2 * rho2 * u1;
+      final double b = t1 / b1;
+      final double sq = math.sqrt(b * b + 1) - b;
+
+      // workaround for floating point precision bug when sq = 0, log = -Infinite,
+      // thus triggering an infinite loop in flyTo
+      final double log = sq < 0.000000001 ? -18 : math.log(sq);
+
+      return log;
+    }
+
+    double sinh(double n) {
+      return (math.exp(n) - math.exp(-n)) / 2;
+    }
+    double cosh(double n) {
+      return (math.exp(n) + math.exp(-n)) / 2;
+    }
+    double tanh(double n) {
+      return sinh(n) / cosh(n);
+    }
+
+    final double r0 = r(0);
+
+    double w(double s) {
+      return w0 * (cosh(r0) / cosh(r0 + rho * s));
+    }
+    double u(double s) {
+      return w0 * (cosh(r0) * tanh(r0 + rho * s) - sinh(r0)) / rho2;
+    }
+
+    double easeOut(double t) {
+      return 1 - math.pow(1.0 - t, 1.5).toDouble();
+    }
+
+    final DateTime start = DateTime.now();
+    final double S = (r(1) - r0) / rho;
+
+    duration = duration != null ? 1000 * duration : 1000 * S * 0.8;
+
+    void frame() async {
+      final t = DateTime
+          .now()
+          .difference(start)
+          .inMilliseconds / duration!;
+      final s = easeOut(t) * S;
+
+      if (t <= 1) {
+        final newPos = mapState.unproject(
+            from + ((to - from).multiplyBy(u(s) / u1)),
+            startZoom); // double check brackets
+        final newZoom = mapState.getScaleZoom(w0 / w(s), startZoom);
+
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          mapState.move(
+              newPos, newZoom, source: MapEventSource.flingAnimationController);
+          frame();
+        });
+        WidgetsBinding.instance.ensureVisualUpdate();
+      } else {
+        mapState.move(targetCenter, targetZoom,
+            source: MapEventSource.flingAnimationController);
+        alreadyFlying = false;
+      }
+    }
+
+    frame();
+  }
+}

--- a/lib/src/map/movement.dart
+++ b/lib/src/map/movement.dart
@@ -7,9 +7,37 @@ import 'package:latlong2/latlong.dart';
 
 class Movement {
 
+  // FlyTo Converted from leaflet.js map.js
+  /*
+  BSD 2-Clause License
+
+  Copyright (c) 2010-2022, Vladimir Agafonkin
+  Copyright (c) 2010-2011, CloudMade
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
   static bool alreadyFlying = false;
 
-  // Converted from leaflet.js map.js
   static void flyTo(MapState mapState, LatLng targetCenter,
       { double? zoom,  double? duration }) {
 


### PR DESCRIPTION
Don't merge this yet, looking for testing feedback.

This is a conversion of Leaflets **flyTo** method. This follows the typical map zoom behaviour we would see between 2 distant locations, where it will zoom out first, pan, then zoom in, in a smooth curve style.

As it's experimental it's not too tightly woven into the normal gesture code, so currently it doesn't care about other gestures and cancelling them (it currently must complete its flyTo, it can't be interrupted). I also haven't added any custom events (I'm also a bit hesitant to have zillions of different types of events atm, so it currently will probably do a fling animation event if anyone cares, but that can be changed)

There's an example MapController FlyTo page in the examples folder.

I'm not sure of the best location for it, so currently it's sat on it's own in a map/movement.dart file, as it feels like it would pollute gestures.dart where other similar code is.

Use is ```mapController.flyTo(texas, zoom: 5.0, duration: 3);```

I've kept original leaflet license in there (not entirely sure this is needed, as I think it was copied original from some other math work some others did, but it feels like it's the right thing to do..but does that clash with flutter_map license ?).

Note, one thing I've been looking at, is flutter_maps slightly odd double tap animated/zoom pan behaviour where it always curves out before in. Ultimately, we could do a flyTo there instead of that (tested that, and I think it works better, but I think that's one step too far currently).