### PR TITLE
[WIP] provide support for pitch

### DIFF
--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - Flutter (1.0.0)
+  - location (0.0.1):
+    - Flutter
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - location (from `.symlinks/plugins/location/ios`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  location:
+    :path: ".symlinks/plugins/location/ios"
+
+SPEC CHECKSUMS:
+  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  location: 3a2eed4dd2fab25e7b7baf2a9efefe82b512d740
+
+PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
+
+COCOAPODS: 1.11.3

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -156,7 +156,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -41,5 +41,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map_example/pages/epsg4326_crs.dart';
 import 'package:flutter_map_example/pages/map_inside_listview.dart';
 import 'package:flutter_map_example/pages/network_tile_provider.dart';
+import 'package:flutter_map_example/pages/pitch.dart';
 import 'package:flutter_map_example/pages/point_to_latlng.dart';
 
 import './pages/animated_map_controller.dart';
@@ -67,6 +68,7 @@ class MyApp extends StatelessWidget {
         MarkerRotatePage.route: (context) => const MarkerRotatePage(),
         MovingMarkersPage.route: (context) => const MovingMarkersPage(),
         CirclePage.route: (context) => const CirclePage(),
+        PitchPage.route: (context) => const PitchPage(),
         OverlayImagePage.route: (context) => const OverlayImagePage(),
         PolygonPage.route: (context) => const PolygonPage(),
         SlidingMapPage.route: (_) => const SlidingMapPage(),

--- a/example/lib/pages/pitch.dart
+++ b/example/lib/pages/pitch.dart
@@ -56,12 +56,7 @@ class _PitchPage extends State<PitchPage> {
                 MarkerLayerOptions(
                     key: const Key("otherMarkers"),
                     applyPitch: false,
-                    markers: [
-                      _marker(
-                          LatLng(coordinates.latitude, coordinates.longitude),
-                          Colors.red,
-                          rotate: true)
-                    ]),
+                    markers: [_marker(coordinates, Colors.red, rotate: false)]),
               ],
             )),
           ],

--- a/example/lib/pages/pitch.dart
+++ b/example/lib/pages/pitch.dart
@@ -27,7 +27,7 @@ class _PitchPage extends State<PitchPage> {
   @override
   Widget build(BuildContext context) {
     final coordinates = LatLng(49.246292, -123.116226);
-    const pitch = 40.0;
+    const pitch = 60.0;
     return Scaffold(
       appBar: AppBar(title: const Text('Pitch')),
       drawer: buildDrawer(context, PitchPage.route),
@@ -50,17 +50,17 @@ class _PitchPage extends State<PitchPage> {
                     urlTemplate:
                         'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                     subdomains: ['a', 'b', 'c']),
-                MarkerLayerOptions(
-                    key: const Key("pitchMarkers"),
-                    markers: [_marker(coordinates, Colors.blue)]),
+                MarkerLayerOptions(key: const Key("pitchMarkers"), markers: [
+                  _marker(coordinates, Colors.grey.shade600, rotate: false)
+                ]),
                 MarkerLayerOptions(
                     key: const Key("otherMarkers"),
                     applyPitch: false,
                     markers: [
                       _marker(
-                          LatLng(coordinates.latitude,
-                              coordinates.longitude + 0.0005),
-                          Colors.red)
+                          LatLng(coordinates.latitude, coordinates.longitude),
+                          Colors.red,
+                          rotate: true)
                     ]),
               ],
             )),
@@ -70,12 +70,13 @@ class _PitchPage extends State<PitchPage> {
     );
   }
 
-  Marker _marker(LatLng coordinates, Color color) => Marker(
+  Marker _marker(LatLng coordinates, Color color, {required bool rotate}) =>
+      Marker(
         width: 48.0,
         height: 48.0,
         point: coordinates,
         builder: (ctx) => Icon(Icons.location_pin, color: color, size: 48),
-        rotate: true,
+        rotate: rotate,
         anchorPos: AnchorPos.align(AnchorAlign.top),
       );
 }

--- a/example/lib/pages/pitch.dart
+++ b/example/lib/pages/pitch.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../widgets/drawer.dart';
+
+class PitchPage extends StatefulWidget {
+  static const String route = 'pitch';
+
+  const PitchPage({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() {
+    return _PitchPage();
+  }
+}
+
+class _PitchPage extends State<PitchPage> {
+  late MapController controller;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = MapController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final coordinates = LatLng(49.246292, -123.116226);
+    const pitch = 60.0;
+    return Scaffold(
+      appBar: AppBar(title: Text('Pitch')),
+      drawer: buildDrawer(context, PitchPage.route),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Text(
+                  'Showing (${coordinates.latitude}, ${coordinates.longitude}) at pitch $pitch'),
+            ),
+            Flexible(
+                child: FlutterMap(
+              options:
+                  MapOptions(center: coordinates, zoom: 10.0, pitch: pitch),
+              mapController: controller,
+              layers: [
+                TileLayerOptions(
+                    urlTemplate:
+                        'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    subdomains: ['a', 'b', 'c']),
+              ],
+            )),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/pages/pitch.dart
+++ b/example/lib/pages/pitch.dart
@@ -27,9 +27,9 @@ class _PitchPage extends State<PitchPage> {
   @override
   Widget build(BuildContext context) {
     final coordinates = LatLng(49.246292, -123.116226);
-    const pitch = 60.0;
+    const pitch = 40.0;
     return Scaffold(
-      appBar: AppBar(title: Text('Pitch')),
+      appBar: AppBar(title: const Text('Pitch')),
       drawer: buildDrawer(context, PitchPage.route),
       body: Padding(
         padding: const EdgeInsets.all(8.0),
@@ -50,6 +50,18 @@ class _PitchPage extends State<PitchPage> {
                     urlTemplate:
                         'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                     subdomains: ['a', 'b', 'c']),
+                MarkerLayerOptions(
+                    key: const Key("pitchMarkers"),
+                    markers: [_marker(coordinates, Colors.blue)]),
+                MarkerLayerOptions(
+                    key: const Key("otherMarkers"),
+                    applyPitch: false,
+                    markers: [
+                      _marker(
+                          LatLng(coordinates.latitude,
+                              coordinates.longitude + 0.0005),
+                          Colors.red)
+                    ]),
               ],
             )),
           ],
@@ -57,4 +69,13 @@ class _PitchPage extends State<PitchPage> {
       ),
     );
   }
+
+  Marker _marker(LatLng coordinates, Color color) => Marker(
+        width: 48.0,
+        height: 48.0,
+        point: coordinates,
+        builder: (ctx) => Icon(Icons.location_pin, color: color, size: 48),
+        rotate: true,
+        anchorPos: AnchorPos.align(AnchorAlign.top),
+      );
 }

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -20,6 +20,7 @@ import '../pages/moving_markers.dart';
 import '../pages/offline_map.dart';
 import '../pages/on_tap.dart';
 import '../pages/overlay_image.dart';
+import '../pages/pitch.dart';
 import '../pages/plugin_api.dart';
 import '../pages/plugin_scalebar.dart';
 import '../pages/plugin_zoombuttons.dart';
@@ -178,6 +179,12 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           context,
           const Text('Overlay Image'),
           OverlayImagePage.route,
+          currentRoute,
+        ),
+        _buildMenuItem(
+          context,
+          const Text('Pitch'),
+          PitchPage.route,
           currentRoute,
         ),
         _buildMenuItem(

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -123,6 +123,17 @@ abstract class MapController {
   /// same as the old rotate)
   bool rotate(double degree, {String? id});
 
+  /// Sets the map pitch to the given angle in degrees.
+  ///
+  /// Optionally provide [id] attribute and if you listen to [mapEventStream]
+  /// later a [MapEventRotate] event will be emitted (if rotate was success)
+  /// with same [id] attribute. Event's source attribute will be
+  /// [MapEventSource.mapController].
+  ///
+  /// returns `true` if tilt was success (it won't be successful if pitch is
+  /// same as the old pitch)
+  bool tilt(double pitch, {String? id});
+
   /// Calls [move] and [rotate] together however layers will rebuild just once
   /// instead of twice
   MoveAndRotateResult moveAndRotate(LatLng center, double zoom, double degree,
@@ -270,6 +281,9 @@ class MapOptions {
   final LatLng? swPanBoundary;
   final LatLng? nePanBoundary;
 
+  /// The pich in degrees from the plane of the screen. Defaults to 0.
+  final double pitch;
+
   /// Restrict outer edges of map to LatLng Bounds, to prevent gray areas when
   /// panning or zooming. LatLngBounds(LatLng(-90, -180.0), LatLng(90.0, 180.0))
   /// would represent the full extent of the map, so no gray area outside of it.
@@ -313,6 +327,7 @@ class MapOptions {
     this.swPanBoundary,
     this.nePanBoundary,
     this.maxBounds,
+    this.pitch = 0.0,
   })  : center = center ?? LatLng(50.5, 30.51),
         assert(rotationThreshold >= 0.0),
         assert(pinchZoomThreshold >= 0.0),
@@ -324,6 +339,7 @@ class MapOptions {
         'screenSize must be set in order to enable adaptive boundaries.');
     assert(!adaptiveBoundaries || controller != null,
         'controller must be set in order to enable adaptive boundaries.');
+    assert(pitch >= 0 && pitch <= 90, 'pitch must be >= 0 and <= 80');
   }
 
   //if there is a pan boundary, do not cross

--- a/lib/src/gestures/map_events.dart
+++ b/lib/src/gestures/map_events.dart
@@ -256,3 +256,23 @@ class MapEventRotateEnd extends MapEvent {
       required double zoom})
       : super(source: source, center: center, zoom: zoom);
 }
+
+class MapEventPitch extends MapEvent {
+  /// Custom ID to identify related object(s)
+  final String? id;
+
+  /// Current pitch in degrees
+  final double currentPitch;
+
+  /// Target pitch in degrees
+  final double targetPitch;
+
+  MapEventPitch({
+    required this.id,
+    required this.currentPitch,
+    required this.targetPitch,
+    required MapEventSource source,
+    required LatLng center,
+    required double zoom,
+  }) : super(source: source, center: center, zoom: zoom);
+}

--- a/lib/src/layer/layer.dart
+++ b/lib/src/layer/layer.dart
@@ -7,5 +7,15 @@ import 'package:flutter/foundation.dart';
 class LayerOptions {
   final Key? key;
   final Stream<void>? rebuild;
-  LayerOptions({this.key, this.rebuild});
+
+  /// Indicates whether pitch should be applied to this layer. When true, the
+  /// layer is rendered with pitch applied to create perspective when the
+  /// map has non-zero pitch.
+  ///
+  /// Layers that render flat to the viewport (without perspective) should pass
+  /// false. Layers that render flat to the viewport must account for pitch and
+  /// rotation when computing positioning.
+  final bool applyPitch;
+
+  LayerOptions({this.key, this.rebuild, this.applyPitch = true});
 }

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -294,18 +294,16 @@ class _MarkerLayerState extends State<MarkerLayer> {
           }
           var position = Offset(pos.x.toDouble(), pos.y.toDouble());
           if (!layerOptions.applyPitch && map.rotation != 0.0) {
-            final fromCenter =
-                position.translate(-map.size.x / 2, -map.size.y / 2);
             position = applyRotationTranslation(
-                    radians: map.rotationRad, point: fromCenter)
-                .translate(map.size.x / 2, map.size.y / 2);
+                size: map.size, radians: map.rotationRad, point: position);
           }
           position = Offset(position.dx - width, position.dy - height);
           if (!layerOptions.applyPitch && map.pitch != 0.0) {
             position = applyPitchTranslation(
-                height: map.size.y,
-                radians: map.pitchRad,
-                point: position.translate(0, -height));
+                    size: map.size,
+                    radians: map.pitchRad,
+                    point: position.translate(marker.width / 2, marker.height))
+                .translate(-marker.width / 2, -marker.height);
           }
 
           markers.add(

--- a/lib/src/layer/translations.dart
+++ b/lib/src/layer/translations.dart
@@ -1,20 +1,28 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 
+import 'package:flutter_map/src/core/point.dart';
+
 Offset applyRotationTranslation(
-    {required double radians, required Offset point}) {
-  final matrix = Matrix4.rotationZ(radians);
-  return MatrixUtils.transformPoint(matrix, point);
+    {required CustomPoint<num> size,
+    required double radians,
+    required Offset point}) {
+  final fromCenter = point.translate(-size.x / 2, -size.y / 2);
+  final matrix = Matrix4.identity()..multiply(Matrix4.rotationZ(radians));
+  return MatrixUtils.transformPoint(matrix, fromCenter)
+      .translate(size.x / 2, size.y / 2);
 }
 
 Offset applyPitchTranslation(
-    {required double height, required double radians, required Offset point}) {
-  // cos(θ) = adjacent/hypotenuse
-  final translation = Alignment.center.alongSize(Size(0, height));
-  final matrix = Matrix4.identity();
-  matrix.translate(translation.dx, translation.dy);
-  matrix.multiply(Matrix4.rotationX(radians));
-  matrix.translate(-translation.dx, -translation.dy);
+    {required CustomPoint<num> size,
+    required double radians,
+    required Offset point}) {
+  final translation =
+      Alignment.center.alongSize(Size(size.x.toDouble(), size.y.toDouble()));
+  final matrix = Matrix4.identity()
+    ..translate(translation.dx, translation.dy)
+    ..multiply(Matrix4.identity()
+      ..setEntry(3, 1, -0.002)
+      ..rotateX(radians))
+    ..translate(-translation.dx, -translation.dy);
   return MatrixUtils.transformPoint(matrix, point);
 }

--- a/lib/src/layer/translations.dart
+++ b/lib/src/layer/translations.dart
@@ -1,0 +1,20 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+Offset applyRotationTranslation(
+    {required double radians, required Offset point}) {
+  final matrix = Matrix4.rotationZ(radians);
+  return MatrixUtils.transformPoint(matrix, point);
+}
+
+Offset applyPitchTranslation(
+    {required double height, required double radians, required Offset point}) {
+  // cos(θ) = adjacent/hypotenuse
+  final translation = Alignment.center.alongSize(Size(0, height));
+  final matrix = Matrix4.identity();
+  matrix.translate(translation.dx, translation.dy);
+  matrix.multiply(Matrix4.rotationX(radians));
+  matrix.translate(-translation.dx, -translation.dy);
+  return MatrixUtils.transformPoint(matrix, point);
+}

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -200,7 +200,7 @@ class FlutterMapState extends MapGestureMixin {
 
   Widget _applyPitch(Widget widget) => Transform(
       transform: Matrix4.rotationX(mapState.pitchRad),
-      alignment: Alignment.bottomCenter,
+      alignment: Alignment.center,
       transformHitTests: true,
       child: widget);
 

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -199,7 +199,9 @@ class FlutterMapState extends MapGestureMixin {
       Transform.rotate(angle: mapState.rotationRad, child: widget);
 
   Widget _applyPitch(Widget widget) => Transform(
-      transform: Matrix4.rotationX(mapState.pitchRad),
+      transform: Matrix4.identity()
+        ..setEntry(3, 1, -0.002)
+        ..rotateX(mapState.pitchRad),
       alignment: Alignment.center,
       transformHitTests: true,
       child: widget);

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -32,9 +32,13 @@ class FlutterMapState extends MapGestureMixin {
   @override
   void initState() {
     super.initState();
-    mapState = MapState(options, (degree) {
+
+    stateUpdater(double degree) {
       if (mounted) setState(() {});
-    }, mapController.mapEventSink);
+    }
+
+    mapState = MapState(options, mapController.mapEventSink,
+        onPitchChanged: stateUpdater, onRotationChanged: stateUpdater);
     mapController.state = mapState;
 
     // Callback onMapCreated if not null
@@ -168,18 +172,22 @@ class FlutterMapState extends MapGestureMixin {
             maxWidth: size.x,
             minHeight: size.y,
             maxHeight: size.y,
-            child: Transform.rotate(
-              angle: mapState.rotationRad,
-              child: Stack(
-                children: [
-                  if (widget.children.isNotEmpty) ...widget.children,
-                  if (widget.layers.isNotEmpty)
-                    ...widget.layers.map(
-                      (layer) => _createLayer(layer, options.plugins),
-                    )
-                ],
-              ),
-            ),
+            child: Transform(
+                transform: Matrix4.rotationX(mapState.pitchRad),
+                alignment: Alignment.bottomCenter,
+                transformHitTests: true,
+                child: Transform.rotate(
+                  angle: mapState.rotationRad,
+                  child: Stack(
+                    children: [
+                      if (widget.children.isNotEmpty) ...widget.children,
+                      if (widget.layers.isNotEmpty)
+                        ...widget.layers.map(
+                          (layer) => _createLayer(layer, options.plugins),
+                        )
+                    ],
+                  ),
+                )),
           ),
           Stack(
             children: [

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -186,7 +186,7 @@ class MapState {
         _originalSize!.y != height) {
       _originalSize = CustomPoint<double>(width, height);
 
-      _updateSizeByOriginalSizeAndRotation();
+      _updateSizeByOriginalSizeAndRotationPitch();
 
       // rebuild layers if screen size has been changed
       if (!isCurrSizeNull) {
@@ -200,21 +200,26 @@ class MapState {
 
   CustomPoint<double> get size => _size ?? const CustomPoint(0.0, 0.0);
 
-  void _updateSizeByOriginalSizeAndRotation() {
+  void _updateSizeByOriginalSizeAndRotationPitch() {
     final originalWidth = _originalSize!.x;
     final originalHeight = _originalSize!.y;
 
+    var heightWithPitch = originalHeight;
+    if (_pitch != 0.0) {
+      final cosAngle = math.cos(_pitchRad).abs();
+      heightWithPitch = originalHeight / cosAngle;
+    }
     if (_rotation != 0.0) {
       final cosAngle = math.cos(_rotationRad).abs();
       final sinAngle = math.sin(_rotationRad).abs();
       final num width =
-          (originalWidth * cosAngle) + (originalHeight * sinAngle);
+          (originalWidth * cosAngle) + (heightWithPitch * sinAngle);
       final num height =
-          (originalHeight * cosAngle) + (originalWidth * sinAngle);
+          (heightWithPitch * cosAngle) + (originalWidth * sinAngle);
 
       _size = CustomPoint<double>(width, height);
     } else {
-      _size = CustomPoint<double>(originalWidth, originalHeight);
+      _size = CustomPoint<double>(originalWidth, heightWithPitch);
     }
 
     if (!_initialized) {
@@ -356,7 +361,7 @@ class MapState {
     if (degree != _rotation) {
       final oldRotation = _rotation;
       rotation = degree;
-      _updateSizeByOriginalSizeAndRotation();
+      _updateSizeByOriginalSizeAndRotationPitch();
 
       onRotationChanged(_rotation);
 
@@ -459,6 +464,7 @@ class MapState {
     }
     final previousPitch = _pitch;
     this.pitch = pitch;
+    _updateSizeByOriginalSizeAndRotationPitch();
 
     onPitchChanged(_pitch);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   positioned_tap_detector_2: ^1.0.4
   proj4dart: ^2.0.0
   tuple: ^2.0.0
-  vector_math: ^2.1.0
+  vector_math: ^2.1.2
 
 dev_dependencies:
   flutter_lints: ">=1.0.4"


### PR DESCRIPTION
Provide a way to set the pitch of a map either via options or through the controller.
This enables maps to be displayed with a perspective applied so that it appears as if the viewer is looking at the map at an angle.

Marker layers can be rendered flat to the map (i.e. with pitch) or flat to the viewport (i.e. without pitch). This option can be used to create markers that either appear to be map features (such as arrows) or appear to stand up from the map surface, which is useful for pins or text bubbles.

This PR is a WIP (work in progress), there is more work to be done before this should be merged.

Fixes #1268
Makes obsolete #1269