### PR TITLE
the zoom speed using the mouse wheel can be adjusted

### DIFF
--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -253,6 +253,7 @@ class MapOptions {
   /// his mouse. This is supported on web and desktop, but might also work well
   /// on Android. A [Listener] is used to capture the onPointerSignal events.
   final bool enableScrollWheel;
+  final double scrollWheelVelocity;
 
   final double? minZoom;
   final double? maxZoom;
@@ -309,6 +310,7 @@ class MapOptions {
     this.pinchMoveWinGestures =
         MultiFingerGesture.pinchZoom | MultiFingerGesture.pinchMove,
     this.enableScrollWheel = true,
+    this.scrollWheelVelocity = 0.005,
     this.minZoom,
     this.maxZoom,
     this.interactiveFlags = InteractiveFlag.all,

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -58,7 +58,9 @@ abstract class MapGestureMixin extends State<FlutterMap>
       // Calculate new zoom level
       final minZoom = mapState.options.minZoom ?? 0.0;
       final maxZoom = mapState.options.maxZoom ?? double.infinity;
-      final newZoom = (mapState.zoom - pointerSignal.scrollDelta.dy * mapState.options.scrollWheelVelocity)
+      final newZoom = (mapState.zoom -
+              pointerSignal.scrollDelta.dy *
+                  mapState.options.scrollWheelVelocity)
           .clamp(minZoom, maxZoom);
       // Calculate offset of mouse cursor from viewport center
       final List<dynamic> newCenterZoom = _getNewEventCenterZoomPosition(

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -58,7 +58,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
       // Calculate new zoom level
       final minZoom = mapState.options.minZoom ?? 0.0;
       final maxZoom = mapState.options.maxZoom ?? double.infinity;
-      final newZoom = (mapState.zoom + pointerSignal.scrollDelta.dy * -0.005)
+      final newZoom = (mapState.zoom - pointerSignal.scrollDelta.dy * mapState.options.scrollWheelVelocity)
           .clamp(minZoom, maxZoom);
       // Calculate offset of mouse cursor from viewport center
       final List<dynamic> newCenterZoom = _getNewEventCenterZoomPosition(


### PR DESCRIPTION
The standard zoom speed using the mouse wheel does not fit all needs. It would be nice if it can be adjusted. This tiny code change allows to override the currently fixed value.