### PR TITLE
Expose RetryClient in NetworkTileProvider initialisation

### DIFF
--- a/lib/src/layer/tile_layer/tile_provider/network_image_with_retry.dart
+++ b/lib/src/layer/tile_layer/tile_provider/network_image_with_retry.dart
@@ -10,10 +10,24 @@ class NetworkImageWithRetry extends ImageProvider<NetworkImageWithRetry> {
   /// The scale to place in the [ImageInfo] object of the image.
   final double scale;
 
-  /// The http RetryClient that is used for the requests
-  final RetryClient retryClient = RetryClient(Client());
+  ///
+  final String? expectedFormat;
 
-  NetworkImageWithRetry(this.url, {this.scale = 1.0});
+  /// The http RetryClient that is used for the requests
+  late RetryClient retryClient;
+
+  NetworkImageWithRetry(this.url, {this.scale = 1.0, this.expectedFormat}) {
+    if (expectedFormat == null) {
+      retryClient = RetryClient(
+        Client(),
+      );
+    } else {
+      retryClient = RetryClient(
+        Client(),
+        when: (p0) => p0.headers['content-type'] == expectedFormat,
+      );
+    }
+  }
 
   @override
   ImageStreamCompleter load(NetworkImageWithRetry key, DecoderCallback decode) {

--- a/lib/src/layer/tile_layer/tile_provider/network_image_with_retry.dart
+++ b/lib/src/layer/tile_layer/tile_provider/network_image_with_retry.dart
@@ -15,8 +15,7 @@ class NetworkImageWithRetry extends ImageProvider<NetworkImageWithRetry> {
 
   NetworkImageWithRetry(this.url,
       {this.scale = 1.0, RetryClient? retryClient}) {
-    retryClient = retryClient ?? RetryClient(Client());
-
+    this.retryClient = retryClient ?? RetryClient(Client());
   }
 
   @override

--- a/lib/src/layer/tile_layer/tile_provider/tile_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/tile_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_provider/network_image_with_retry.dart';
+import 'package:http/retry.dart';
 
 abstract class TileProvider {
   const TileProvider();
@@ -56,10 +57,13 @@ abstract class TileProvider {
 }
 
 class NetworkTileProvider extends TileProvider {
+  RetryClient? retryClient;
+
+  NetworkTileProvider({this.retryClient});
   @override
   ImageProvider getImage(Coords<num> coords, TileLayerOptions options) {
     return NetworkImageWithRetry(getTileUrl(coords, options),
-        expectedFormat: options.wmsOptions?.format);
+        retryClient: retryClient);
   }
 }
 

--- a/lib/src/layer/tile_layer/tile_provider/tile_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/tile_provider.dart
@@ -58,7 +58,8 @@ abstract class TileProvider {
 class NetworkTileProvider extends TileProvider {
   @override
   ImageProvider getImage(Coords<num> coords, TileLayerOptions options) {
-    return NetworkImageWithRetry(getTileUrl(coords, options));
+    return NetworkImageWithRetry(getTileUrl(coords, options),
+        expectedFormat: options.wmsOptions?.format);
   }
 }
 


### PR DESCRIPTION
This pull request adds optional parameter `RetryClient` for `NetworkTileProvider`. I made this fork to scratch my own itch with some stubborn tile servers that are either too slow or don't follow the standard conventions. Some servers require longer cooldown between the requests therefore more than 3 retries are needed (as was the default in `NetworkImageWithRetry`). 