### PR TITLE
Fix "rotation" in the "Options" section of the document

### DIFF
--- a/usage/options.md
+++ b/usage/options.md
@@ -67,7 +67,7 @@ will make the map center on London at first, and ensure that the gray void aroun
 Takes a double specifying the bearing of the map when it is first built. For example:
 
 ```dart
-        center: 180.0,
+        rotation: 180.0,
 ```
 
 will put the South of the map at the top of the device.


### PR DESCRIPTION
Hello. I have fixed a minor typo in the document.