### PR TITLE
v2.1.0 Release & Keep Alive Functionality

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -37,6 +37,11 @@ body:
       placeholder: Text automatically formatted as Dart code, on submission
       render: dart
   - type: textarea
+    id: solution
+    attributes:
+      label: Do you have a potential solution?
+      description: "If so, please detail it: it will make it quicker for us to fix the issue"
+  - type: textarea
     id: additional-info
     attributes:
       label: Can you provide any other information?
@@ -101,7 +106,7 @@ body:
           required: true
         - label: I am using the [latest stable version](https://pub.dev/packages/flutter_map) of this package
           required: true
-        - label: I have checked the [Common Issues](https://docs.fleaflet.dev/usage/common-issues) documentation page
+        - label: I have checked the FAQs section on the documentation website
           required: true
         - label: I have checked for similar issues which may be duplicates
           required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@
 
 Contains the following additions/removals:
 
-- Added built in keep alive functionality - [#1312](https://github.com/fleaflet/flutter_map/pull/1293)
+- Added built in keep alive functionality - [#1312](https://github.com/fleaflet/flutter_map/pull/1312)
 - Added disposal of `AnimationController` before it is reassigned - [#1303](https://github.com/fleaflet/flutter_map/pull/1303)
+- Added better polar projection support and example - [#1295](https://github.com/fleaflet/flutter_map/pull/1295)
+- Added stroke cap and stroke join options to `Polygon`s - [#1295](https://github.com/fleaflet/flutter_map/pull/1295)
 
 Contains the following bug fixes:
 
-- Remove a class of `LateInitializationError`s by reworking `MapController` lifecycle - [#1293](https://github.com/fleaflet/flutter_map/pull/1293) for [#1288](https://github.com/fleaflet/flutter_map/issues/1288)
+- Removed a class of `LateInitializationError`s by reworking `MapController` lifecycle - [#1293](https://github.com/fleaflet/flutter_map/pull/1293) for [#1288](https://github.com/fleaflet/flutter_map/issues/1288)
+- Improved performance during painting `Polygon`s - [#1295](https://github.com/fleaflet/flutter_map/pull/1295)
 
 In other news:
 
@@ -19,6 +22,7 @@ Many thanks to these contributors (in no particular order):
 
 - @Zverik
 - @rbellens
+- @JosefWN
 - ... and all the maintainers
 
 ## [2.0.0] - 2022/07/11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
-## [2.0.0] - 2022/XX/XX
+## [2.1.0] - 2022/XX/XX
+
+Contains the following additions/removals:
+
+- Added built in keep alive functionality
+
+Contains the following bug fixes:
+
+- Remove a class of `LateInitializationError`s by reworking `MapController` lifecycle - [#1293](https://github.com/fleaflet/flutter_map/pull/1293) for [#1288](https://github.com/fleaflet/flutter_map/issues/1288)
+
+In other news:
+
+- None
+
+Many thanks to these contributors (in no particular order):
+
+- @Zverik
+- ... and all the maintainers
+
+## [2.0.0] - 2022/07/11
 
 Contains the following additions/removals:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Contains the following additions/removals:
 
-- Added built in keep alive functionality
+- Added built in keep alive functionality - [#1312](https://github.com/fleaflet/flutter_map/pull/1293)
 
 Contains the following bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Contains the following additions/removals:
 
 - Added built in keep alive functionality - [#1312](https://github.com/fleaflet/flutter_map/pull/1293)
+- Added disposal of `AnimationController` before it is reassigned - [#1303](https://github.com/fleaflet/flutter_map/pull/1303)
 
 Contains the following bug fixes:
 
@@ -17,6 +18,7 @@ In other news:
 Many thanks to these contributors (in no particular order):
 
 - @Zverik
+- @rbellens
 - ... and all the maintainers
 
 ## [2.0.0] - 2022/07/11

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -291,6 +291,14 @@ class MapOptions {
   /// would represent the full extent of the map, so no gray area outside of it.
   final LatLngBounds? maxBounds;
 
+  /// Flag to enable the built in keep alive functionality
+  ///
+  /// If the map is within a complex layout, such as a [ListView] or [PageView],
+  /// the map will reset to it's inital position after it appears back into view.
+  /// To ensure this doesn't happen, enable this flag to prevent the [FlutterMap]
+  /// widget from rebuilding.
+  final bool keepAlive;
+
   _SafeArea? _safeAreaCache;
   double? _safeAreaZoom;
 
@@ -334,6 +342,7 @@ class MapOptions {
     this.swPanBoundary,
     this.nePanBoundary,
     this.maxBounds,
+    this.keepAlive = false,
   })  : center = center ?? LatLng(50.5, 30.51),
         assert(rotationThreshold >= 0.0),
         assert(pinchZoomThreshold >= 0.0),

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -9,7 +9,8 @@ import 'package:flutter_map/src/map/map.dart';
 import 'package:flutter_map/src/map/map_state_widget.dart';
 import 'package:positioned_tap_detector_2/positioned_tap_detector_2.dart';
 
-class FlutterMapState extends MapGestureMixin {
+class FlutterMapState extends MapGestureMixin
+    with AutomaticKeepAliveClientMixin {
   final List<StreamGroup<void>> groups = <StreamGroup<void>>[];
   final _positionedTapController = PositionedTapController();
 
@@ -73,6 +74,7 @@ class FlutterMapState extends MapGestureMixin {
   @override
   Widget build(BuildContext context) {
     _disposeStreamGroups();
+    super.build(context);
     return LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
       final hasLateSize = mapState.hasLateSize(constraints);
@@ -230,4 +232,7 @@ Can't find correct layer for $options. Perhaps when you create your FlutterMap y
 
     options: new MapOptions(plugins: [MyFlutterMapPlugin()])"""));
   }
+
+  @override
+  bool get wantKeepAlive => options.keepAlive;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_map
 description: A versatile mapping package for Flutter, based off leaflet.js, that's simple and easy to learn, yet completely customizable and configurable.
-version: 2.0.0
+version: 2.1.0
 repository: https://github.com/fleaflet/flutter_map
 documentation: https://docs.fleaflet.dev
 


### PR DESCRIPTION
Designed to complement #1293. Added a `keepAlive` option (defaults to `false`) to `MapOptions`. Mixed in `AutomaticKeepAliveClientMixin` with `FlutterMapState`, and made necessary changes. Set `wantKeepAlive` getter to return the value of the `keepAlive` option.

Also contains the updates needed for v2.1.0 release. Waiting on all PRs marked with '[v2.1.0]' before merging this, as the CHANGELOG will need to be updated for each of them.