### PR TITLE
[v2.2.0] Add Rotation Capability To `OverlayImage`

### DIFF
--- a/example/lib/pages/overlay_image.dart
+++ b/example/lib/pages/overlay_image.dart
@@ -11,15 +11,20 @@ class OverlayImagePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var overlayImages = <OverlayImage>[
+    final topLeftCorner = LatLng(53.377, -2.999);
+    final bottomRightCorner = LatLng(53.475, 0.275);
+    final bottomLeftCorner = LatLng(52.503, -1.868);
+
+    final overlayImages = [
       OverlayImage(
           bounds: LatLngBounds(LatLng(51.5, -0.09), LatLng(48.8566, 2.3522)),
           opacity: 0.8,
           imageProvider: const NetworkImage(
               'https://images.pexels.com/photos/231009/pexels-photo-231009.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=300&w=600')),
-      OverlayImage(
-          bounds: LatLngBounds(LatLng(53.377, -2.999), LatLng(53.475, 0.275)),
-          rotationPoint: LatLng(52.503, -1.868),
+      RotatedOverlayImage(
+          topLeftCorner: topLeftCorner,
+          bottomLeftCorner: bottomLeftCorner,
+          bottomRightCorner: bottomRightCorner,
           opacity: 0.8,
           imageProvider: const NetworkImage(
               'https://images.pexels.com/photos/231009/pexels-photo-231009.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=300&w=600')),
@@ -49,7 +54,21 @@ class OverlayImagePage extends StatelessWidget {
                     subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
-                  OverlayImageLayerOptions(overlayImages: overlayImages)
+                  OverlayImageLayerOptions(overlayImages: overlayImages),
+                  MarkerLayerOptions(markers: [
+                    Marker(
+                        point: topLeftCorner,
+                        builder: (context) => const _Circle(
+                            color: Colors.redAccent, label: "TL")),
+                    Marker(
+                        point: bottomLeftCorner,
+                        builder: (context) => const _Circle(
+                            color: Colors.redAccent, label: "BL")),
+                    Marker(
+                        point: bottomRightCorner,
+                        builder: (context) => const _Circle(
+                            color: Colors.redAccent, label: "BR")),
+                  ])
                 ],
               ),
             ),
@@ -57,5 +76,26 @@ class OverlayImagePage extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+class _Circle extends StatelessWidget {
+  final String label;
+  final Color color;
+
+  const _Circle({Key? key, required this.label, required this.color})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        child: Center(
+          child: Text(
+            label,
+            style: const TextStyle(
+                fontWeight: FontWeight.bold, color: Colors.white),
+          ),
+        ));
   }
 }

--- a/example/lib/pages/overlay_image.dart
+++ b/example/lib/pages/overlay_image.dart
@@ -17,6 +17,12 @@ class OverlayImagePage extends StatelessWidget {
           opacity: 0.8,
           imageProvider: const NetworkImage(
               'https://images.pexels.com/photos/231009/pexels-photo-231009.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=300&w=600')),
+      OverlayImage(
+          bounds: LatLngBounds(LatLng(53.377, -2.999), LatLng(53.475, 0.275)),
+          rotationPoint: LatLng(52.503, -1.868),
+          opacity: 0.8,
+          imageProvider: const NetworkImage(
+              'https://images.pexels.com/photos/231009/pexels-photo-231009.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=300&w=600')),
     ];
 
     return Scaffold(

--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -7,7 +7,7 @@ import 'package:flutter_map/src/core/bounds.dart';
 import 'package:latlong2/latlong.dart';
 
 class OverlayImageLayerOptions extends LayerOptions {
-  final List<OverlayImage> overlayImages;
+  final List<BaseOverlayImage> overlayImages;
 
   OverlayImageLayerOptions({
     Key? key,
@@ -16,31 +16,132 @@ class OverlayImageLayerOptions extends LayerOptions {
   }) : super(key: key, rebuild: rebuild);
 }
 
-class OverlayImage {
+/// Base class for all overlay images.
+abstract class BaseOverlayImage {
+  ImageProvider get imageProvider;
+
+  double get opacity;
+
+  bool get gaplessPlayback;
+
+  Positioned buildPositionedForOverlay(MapState map);
+
+  Image buildImageForOverlay() {
+    return Image(
+      image: imageProvider,
+      fit: BoxFit.fill,
+      color: Color.fromRGBO(255, 255, 255, opacity),
+      colorBlendMode: BlendMode.modulate,
+      gaplessPlayback: gaplessPlayback,
+    );
+  }
+}
+
+/// Unrotated overlay image that spans between a given bounding box.
+///
+/// The shortest side of the image will be placed along the shortest side of the
+/// bounding box to minimize distortion.
+class OverlayImage extends BaseOverlayImage {
   final LatLngBounds bounds;
+  @override
   final ImageProvider imageProvider;
+  @override
   final double opacity;
+  @override
   final bool gaplessPlayback;
-
-  /// A third lat/lng point to span a rotated/skewed bounding box.
-  /// This defines the bottom left corner of the image.
-  ///
-  /// The image is transformed so that its corners touch the following points:
-  /// - top-left and bottom-right: the points from [bounds]
-  /// - bottom-left: the [rotationPoint]
-  /// - top-right: derived from the other points
-  final LatLng? rotationPoint;
-
-  /// The filter quality when rotating the image.
-  final FilterQuality? filterQuality;
 
   OverlayImage(
       {required this.bounds,
       required this.imageProvider,
       this.opacity = 1.0,
+      this.gaplessPlayback = false});
+
+  @override
+  Positioned buildPositionedForOverlay(MapState map) {
+    final pixelOrigin = map.getPixelOrigin();
+    // northWest is not necessarily upperLeft depending on projection
+    final bounds = Bounds<num>(
+      map.project(this.bounds.northWest) - pixelOrigin,
+      map.project(this.bounds.southEast) - pixelOrigin,
+    );
+    return Positioned(
+        left: bounds.topLeft.x.toDouble(),
+        top: bounds.topLeft.y.toDouble(),
+        width: bounds.size.x.toDouble(),
+        height: bounds.size.y.toDouble(),
+        child: buildImageForOverlay());
+  }
+}
+
+/// Spans an image across three corner points.
+///
+/// Therefore this layer can be used to rotate or skew an image on the map.
+///
+/// The image is transformed so that its corners touch the [topLeftCorner],
+/// [bottomLeftCorner] and [bottomRightCorner] points while the top-right
+/// corner point is derived from the other points.
+class RotatedOverlayImage extends BaseOverlayImage {
+  @override
+  final ImageProvider imageProvider;
+
+  final LatLng topLeftCorner, bottomLeftCorner, bottomRightCorner;
+
+  @override
+  final double opacity;
+
+  @override
+  final bool gaplessPlayback;
+
+  /// The filter quality when rotating the image.
+  final FilterQuality? filterQuality;
+
+  RotatedOverlayImage(
+      {required this.imageProvider,
+      required this.topLeftCorner,
+      required this.bottomLeftCorner,
+      required this.bottomRightCorner,
+      this.opacity = 1.0,
       this.gaplessPlayback = false,
-      this.rotationPoint,
       this.filterQuality = FilterQuality.medium});
+
+  @override
+  Positioned buildPositionedForOverlay(MapState map) {
+    final pixelOrigin = map.getPixelOrigin();
+
+    final pxTopLeft = map.project(topLeftCorner) - pixelOrigin;
+    final pxBottomRight = map.project(bottomRightCorner) - pixelOrigin;
+    final pxBottomLeft = (map.project(bottomLeftCorner) - pixelOrigin);
+    // calculate pixel coordinate of top-right corner by calculating the
+    // vector from bottom-left to top-left and adding it to bottom-right
+    final pxTopRight = (pxTopLeft - pxBottomLeft + pxBottomRight);
+
+    // update/enlarge bounds so the new corner points fit within
+    final bounds = Bounds<num>(pxTopLeft, pxBottomRight)
+        .extend(pxTopRight)
+        .extend(pxBottomLeft);
+
+    final vectorX = (pxTopRight - pxTopLeft) / bounds.size.x;
+    final vectorY = (pxBottomLeft - pxTopLeft) / bounds.size.y;
+    final offset = pxTopLeft - bounds.topLeft;
+
+    final a = vectorX.x.toDouble();
+    final b = vectorX.y.toDouble();
+    final c = vectorY.x.toDouble();
+    final d = vectorY.y.toDouble();
+    final tx = offset.x.toDouble();
+    final ty = offset.y.toDouble();
+
+    return Positioned(
+        left: bounds.topLeft.x.toDouble(),
+        top: bounds.topLeft.y.toDouble(),
+        width: bounds.size.x.toDouble(),
+        height: bounds.size.y.toDouble(),
+        child: Transform(
+            transform:
+                Matrix4(a, b, 0, 0, c, d, 0, 0, 0, 0, 1, 0, tx, ty, 0, 1),
+            filterQuality: filterQuality,
+            child: buildImageForOverlay()));
+  }
 }
 
 class OverlayImageLayerWidget extends StatelessWidget {
@@ -73,65 +174,11 @@ class OverlayImageLayer extends StatelessWidget {
           child: Stack(
             children: <Widget>[
               for (var overlayImage in overlayImageOpts.overlayImages)
-                _positionedForOverlay(overlayImage),
+                overlayImage.buildPositionedForOverlay(map),
             ],
           ),
         );
       },
     );
-  }
-
-  Positioned _positionedForOverlay(OverlayImage overlayImage) {
-    final pixelOrigin = map.getPixelOrigin();
-    // northWest is not necessarily upperLeft depending on projection
-    var bounds = Bounds<num>(
-      map.project(overlayImage.bounds.northWest) - pixelOrigin,
-      map.project(overlayImage.bounds.southEast) - pixelOrigin,
-    );
-
-    Widget child = Image(
-      image: overlayImage.imageProvider,
-      fit: BoxFit.fill,
-      color: Color.fromRGBO(255, 255, 255, overlayImage.opacity),
-      colorBlendMode: BlendMode.modulate,
-      gaplessPlayback: overlayImage.gaplessPlayback,
-    );
-
-    if (overlayImage.rotationPoint != null) {
-      final pxTopLeft = bounds.topLeft;
-      final pxBottomRight = bounds.bottomRight;
-      final pxBottomLeft =
-          map.project(overlayImage.rotationPoint!) - pixelOrigin;
-      // calculate pixel coordinate of top-right corner by calculating the
-      // vector from bottom-left to top-left and adding it to bottom-right
-      final pxTopRight = pxTopLeft - pxBottomLeft + pxBottomRight;
-
-      // update/enlarge bounds so the new corner points fit within
-      bounds = bounds.extend(pxTopRight).extend(pxBottomLeft);
-
-      final vectorX = (pxTopRight - pxTopLeft) / bounds.size.x;
-      final vectorY = (pxBottomLeft - pxTopLeft) / bounds.size.y;
-      final offset = pxTopLeft - bounds.topLeft;
-
-      final a = vectorX.x.toDouble();
-      final b = vectorX.y.toDouble();
-      final c = vectorY.x.toDouble();
-      final d = vectorY.y.toDouble();
-      final tx = offset.x.toDouble();
-      final ty = offset.y.toDouble();
-
-      child = Transform(
-        transform: Matrix4(a, b, 0, 0, c, d, 0, 0, 0, 0, 1, 0, tx, ty, 0, 1),
-        filterQuality: overlayImage.filterQuality,
-        child: child,
-      );
-    }
-
-    return Positioned(
-        left: bounds.topLeft.x.toDouble(),
-        top: bounds.topLeft.y.toDouble(),
-        width: bounds.size.x.toDouble(),
-        height: bounds.size.y.toDouble(),
-        child: child);
   }
 }

--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -4,6 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:flutter_map/src/core/bounds.dart';
+import 'package:latlong2/latlong.dart';
 
 class OverlayImageLayerOptions extends LayerOptions {
   final List<OverlayImage> overlayImages;
@@ -21,12 +22,25 @@ class OverlayImage {
   final double opacity;
   final bool gaplessPlayback;
 
-  OverlayImage({
-    required this.bounds,
-    required this.imageProvider,
-    this.opacity = 1.0,
-    this.gaplessPlayback = false,
-  });
+  /// A third lat/lng point to span a rotated/skewed bounding box.
+  /// This defines the bottom left corner of the image.
+  ///
+  /// The image is transformed so that its corners touch the following points:
+  /// - top-left and bottom-right: the points from [bounds]
+  /// - bottom-left: the [rotationPoint]
+  /// - top-right: derived from the other points
+  final LatLng? rotationPoint;
+
+  /// The filter quality when rotating the image.
+  final FilterQuality? filterQuality;
+
+  OverlayImage(
+      {required this.bounds,
+      required this.imageProvider,
+      this.opacity = 1.0,
+      this.gaplessPlayback = false,
+      this.rotationPoint,
+      this.filterQuality = FilterQuality.medium});
 }
 
 class OverlayImageLayerWidget extends StatelessWidget {
@@ -68,24 +82,56 @@ class OverlayImageLayer extends StatelessWidget {
   }
 
   Positioned _positionedForOverlay(OverlayImage overlayImage) {
+    final pixelOrigin = map.getPixelOrigin();
     // northWest is not necessarily upperLeft depending on projection
-    final bounds = Bounds<num>(
-      map.project(overlayImage.bounds.northWest) - map.getPixelOrigin(),
-      map.project(overlayImage.bounds.southEast) - map.getPixelOrigin(),
+    var bounds = Bounds<num>(
+      map.project(overlayImage.bounds.northWest) - pixelOrigin,
+      map.project(overlayImage.bounds.southEast) - pixelOrigin,
     );
 
-    return Positioned(
-      left: bounds.topLeft.x.toDouble(),
-      top: bounds.topLeft.y.toDouble(),
-      width: bounds.size.x.toDouble(),
-      height: bounds.size.y.toDouble(),
-      child: Image(
-        image: overlayImage.imageProvider,
-        fit: BoxFit.fill,
-        color: Color.fromRGBO(255, 255, 255, overlayImage.opacity),
-        colorBlendMode: BlendMode.modulate,
-        gaplessPlayback: overlayImage.gaplessPlayback,
-      ),
+    Widget child = Image(
+      image: overlayImage.imageProvider,
+      fit: BoxFit.fill,
+      color: Color.fromRGBO(255, 255, 255, overlayImage.opacity),
+      colorBlendMode: BlendMode.modulate,
+      gaplessPlayback: overlayImage.gaplessPlayback,
     );
+
+    if (overlayImage.rotationPoint != null) {
+      final pxTopLeft = bounds.topLeft;
+      final pxBottomRight = bounds.bottomRight;
+      final pxBottomLeft =
+          map.project(overlayImage.rotationPoint!) - pixelOrigin;
+      // calculate pixel coordinate of top-right corner by calculating the
+      // vector from bottom-left to top-left and adding it to bottom-right
+      final pxTopRight = pxTopLeft - pxBottomLeft + pxBottomRight;
+
+      // update/enlarge bounds so the new corner points fit within
+      bounds = bounds.extend(pxTopRight).extend(pxBottomLeft);
+
+      final vectorX = (pxTopRight - pxTopLeft) / bounds.size.x;
+      final vectorY = (pxBottomLeft - pxTopLeft) / bounds.size.y;
+      final offset = pxTopLeft - bounds.topLeft;
+
+      final a = vectorX.x.toDouble();
+      final b = vectorX.y.toDouble();
+      final c = vectorY.x.toDouble();
+      final d = vectorY.y.toDouble();
+      final tx = offset.x.toDouble();
+      final ty = offset.y.toDouble();
+
+      child = Transform(
+        transform: Matrix4(a, b, 0, 0, c, d, 0, 0, 0, 0, 1, 0, tx, ty, 0, 1),
+        filterQuality: overlayImage.filterQuality,
+        child: child,
+      );
+    }
+
+    return Positioned(
+        left: bounds.topLeft.x.toDouble(),
+        top: bounds.topLeft.y.toDouble(),
+        width: bounds.size.x.toDouble(),
+        height: bounds.size.y.toDouble(),
+        child: child);
   }
 }


### PR DESCRIPTION
Currently the OverlayImage layer only accepts a rectengular bounding box based on two corner points.
This doesn't allow rotating overlaid images like it is possible in other map frameworks.

[Mapbox for example](https://docs.mapbox.com/mapbox-gl-js/example/image-on-a-map/) requires a latitude/longitude for each corner of the image.

For Leaflet the following plugin/layer exists which just requires 3 points to be defined (because it derives the 4th point itself): https://github.com/IvanSanchez/Leaflet.ImageOverlay.Rotated

This PR is based on the beforehand mentioned `Leaflet.ImageOverlay.Rotated` layer and adds a third point to rotate/skew the image.