### PR TITLE
Improved GitHub Actions Workflows

### DIFF
--- a/.github/workflows/delete_old_runs.yml
+++ b/.github/workflows/delete_old_runs.yml
@@ -1,0 +1,16 @@
+name: Delete Old Workflow Runs
+on:
+  schedule:
+    - cron: "0 0 * * 1" # Run every Monday
+  workflow_dispatch:
+
+jobs:
+  del_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 7
+          keep_minimum_runs: 0

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,25 +1,119 @@
-name: Tests
+name: Analyse & Build
+on: [push, workflow_dispatch]
 
-on:
-  push:
-    branches: master
-  pull_request:
-
-defaults:
-  run:
-    shell: bash
 jobs:
-  test:
-    name: "Analyze and test"
+  package-analysis:
+    name: "Analyse Package"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1
-      - run: flutter pub get
-      - run: dart format --output=none --set-exit-if-changed .
-      - run: dart analyze --fatal-infos --fatal-warnings
-      - run: flutter test -r expanded
-#      - uses: actions/setup-java@v1
-#        with:
-#          java-version: '12.x'
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Run Dart Package Analyser
+        uses: axel-op/dart-package-analyzer@v3
+        id: analysis
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check Package Scores
+        env:
+          TOTAL: ${{ steps.analysis.outputs.total }}
+          TOTAL_MAX: ${{ steps.analysis.outputs.total_max }}
+        run: |
+          if (( $TOTAL < $TOTAL_MAX ))
+          then
+            echo Package score less than available score. Improve the score!
+            exit 1
+          fi
 
+  content-analysis:
+    name: "Analyse Contents"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Setup Java 17 Environment
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+      - name: Setup Flutter Environment
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+      - name: Ensure Correct Flutter Installation
+        run: flutter --version
+      - name: Get All Dependencies
+        run: flutter pub get
+      - name: Check Formatting
+        run: dart format --output=none --set-exit-if-changed .
+      - name: Check Lints
+        run: dart analyze --fatal-infos --fatal-warnings
+      - name: Run Tests
+        run: flutter test -r expanded
+
+  check-example-changes:
+    name: "Check Example Application For Changes"
+    runs-on: "ubuntu-20.04"
+    outputs:
+      example_changed: ${{ steps.check_file_changed.outputs.example_changed }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Compare Commit Diffs
+        shell: pwsh
+        id: check_file_changed
+        run: |
+          $diff = git diff --name-only HEAD^ HEAD
+          $SourceDiff = $diff | Where-Object { $_ -match '^example/'}
+          $HasDiff = $SourceDiff.Length -gt 0
+          Write-Host "::set-output name=example_changed::$HasDiff"
+
+  build-example:
+    name: "Build Example Applications"
+    runs-on: windows-latest
+    needs: [check-example-changes, content-analysis, package-analysis]
+    if: needs.check-example-changes.outputs.example_changed == 'True'
+    defaults:
+      run:
+        working-directory: ./example
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Setup Java 17 Environment
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+      - name: Setup Flutter Environment
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+      - name: Ensure Correct Flutter Installation
+        run: flutter --version
+      - name: Ensure Clean Flutter Environment
+        run: flutter clean
+      - name: Remove Existing Prebuilt Applications
+        run: Remove-Item "prebuiltExampleApplications" -Recurse -ErrorAction Ignore
+        working-directory: .
+      - name: Create Prebuilt Applications (Output) Directory
+        run: md prebuiltExampleApplications
+        working-directory: .
+      - name: Build Android Application
+        run: flutter build apk --split-per-abi --obfuscate --split-debug-info=/symbols
+      - name: Move Android Application To Output Directory
+        run: move "example\build\app\outputs\flutter-apk\app-armeabi-v7a-release.apk" "prebuiltExampleApplications\AndroidApplication.apk"
+        working-directory: .
+      - name: Build Windows Application
+        run: flutter build windows --obfuscate --split-debug-info=/symbols
+      - name: Archive (ZIP) Windows Application To Output Directory
+        uses: vimtor/action-zip@v1
+        with:
+          files: ./example/build/windows/runner/Release
+          dest: prebuiltExampleApplications/WindowsApplication.zip
+      - name: Commit Output Directory
+        uses: EndBug/add-and-commit@v9.0.1
+        with:
+          message: "Built Example Applications"
+          add: "prebuiltExampleApplications/"
+          default_author: github_actions

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Dart Package Analyser
         uses: axel-op/dart-package-analyzer@v3
         id: analysis
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Java 17 Environment
         uses: actions/setup-java@v3
         with:
@@ -57,7 +57,7 @@ jobs:
       example_changed: ${{ steps.check_file_changed.outputs.example_changed }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Compare Commit Diffs
@@ -79,7 +79,7 @@ jobs:
         working-directory: ./example
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Java 17 Environment
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -50,70 +50,70 @@ jobs:
       - name: Run Tests
         run: flutter test -r expanded
 
-  check-example-changes:
-    name: "Check Example Application For Changes"
-    runs-on: "ubuntu-20.04"
-    outputs:
-      example_changed: ${{ steps.check_file_changed.outputs.example_changed }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Compare Commit Diffs
-        shell: pwsh
-        id: check_file_changed
-        run: |
-          $diff = git diff --name-only HEAD^ HEAD
-          $SourceDiff = $diff | Where-Object { $_ -match '^example/'}
-          $HasDiff = $SourceDiff.Length -gt 0
-          Write-Host "::set-output name=example_changed::$HasDiff"
-
-  build-example:
-    name: "Build Example Applications"
-    runs-on: windows-latest
-    needs: [check-example-changes, content-analysis, package-analysis]
-    if: needs.check-example-changes.outputs.example_changed == 'True'
-    defaults:
-      run:
-        working-directory: ./example
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-      - name: Setup Java 17 Environment
-        uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: "17"
-      - name: Setup Flutter Environment
-        uses: subosito/flutter-action@v2
-        with:
-          channel: "stable"
-      - name: Ensure Correct Flutter Installation
-        run: flutter --version
-      - name: Ensure Clean Flutter Environment
-        run: flutter clean
-      - name: Remove Existing Prebuilt Applications
-        run: Remove-Item "prebuiltExampleApplications" -Recurse -ErrorAction Ignore
-        working-directory: .
-      - name: Create Prebuilt Applications (Output) Directory
-        run: md prebuiltExampleApplications
-        working-directory: .
-      - name: Build Android Application
-        run: flutter build apk --split-per-abi --obfuscate --split-debug-info=/symbols
-      - name: Move Android Application To Output Directory
-        run: move "example\build\app\outputs\flutter-apk\app-armeabi-v7a-release.apk" "prebuiltExampleApplications\AndroidApplication.apk"
-        working-directory: .
-      - name: Build Windows Application
-        run: flutter build windows --obfuscate --split-debug-info=/symbols
-      - name: Archive (ZIP) Windows Application To Output Directory
-        uses: vimtor/action-zip@v1
-        with:
-          files: ./example/build/windows/runner/Release
-          dest: prebuiltExampleApplications/WindowsApplication.zip
-      - name: Commit Output Directory
-        uses: EndBug/add-and-commit@v9.0.1
-        with:
-          message: "Built Example Applications"
-          add: "prebuiltExampleApplications/"
-          default_author: github_actions
+  #check-example-changes:
+  #  name: "Check Example Application For Changes"
+  #  runs-on: "ubuntu-20.04"
+  #  outputs:
+  #    example_changed: ${{ steps.check_file_changed.outputs.example_changed }}
+  #  steps:
+  #    - name: Checkout Repository
+  #      uses: actions/checkout@v3
+  #      with:
+  #        fetch-depth: 2
+  #    - name: Compare Commit Diffs
+  #      shell: pwsh
+  #      id: check_file_changed
+  #      run: |
+  #        $diff = git diff --name-only HEAD^ HEAD
+  #        $SourceDiff = $diff | Where-Object { $_ -match '^example/'}
+  #        $HasDiff = $SourceDiff.Length -gt 0
+  #        Write-Host "::set-output name=example_changed::$HasDiff"
+  #
+  #build-example:
+  #  name: "Build Example Applications"
+  #  runs-on: windows-latest
+  #  needs: [check-example-changes, content-analysis, package-analysis]
+  #  if: needs.check-example-changes.outputs.example_changed == 'True'
+  #  defaults:
+  #    run:
+  #      working-directory: ./example
+  #  steps:
+  #    - name: Checkout Repository
+  #      uses: actions/checkout@v3
+  #    - name: Setup Java 17 Environment
+  #      uses: actions/setup-java@v3
+  #      with:
+  #        distribution: "temurin"
+  #        java-version: "17"
+  #    - name: Setup Flutter Environment
+  #      uses: subosito/flutter-action@v2
+  #      with:
+  #        channel: "stable"
+  #    - name: Ensure Correct Flutter Installation
+  #      run: flutter --version
+  #    - name: Ensure Clean Flutter Environment
+  #      run: flutter clean
+  #    - name: Remove Existing Prebuilt Applications
+  #      run: Remove-Item "prebuiltExampleApplications" -Recurse -ErrorAction Ignore
+  #      working-directory: .
+  #    - name: Create Prebuilt Applications (Output) Directory
+  #      run: md prebuiltExampleApplications
+  #      working-directory: .
+  #    - name: Build Android Application
+  #      run: flutter build apk --split-per-abi --obfuscate --split-debug-info=/symbols
+  #    - name: Move Android Application To Output Directory
+  #      run: move "example\build\app\outputs\flutter-apk\app-armeabi-v7a-release.apk" "prebuiltExampleApplications\AndroidApplication.apk"
+  #      working-directory: .
+  #    - name: Build Windows Application
+  #      run: flutter build windows --obfuscate --split-debug-info=/symbols
+  #    - name: Archive (ZIP) Windows Application To Output Directory
+  #      uses: vimtor/action-zip@v1
+  #      with:
+  #        files: ./example/build/windows/runner/Release
+  #        dest: prebuiltExampleApplications/WindowsApplication.zip
+  #    - name: Commit Output Directory
+  #      uses: EndBug/add-and-commit@v9.0.1
+  #      with:
+  #        message: "Built Example Applications"
+  #        add: "prebuiltExampleApplications/"
+  #        default_author: github_actions

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,19 +1,18 @@
-name: 'Close stale issues and PR'
+name: "Close stale issues and PR"
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: "30 1 * * *"
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
+          stale-pr-message: "This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days."
+          close-issue-message: "This issue was closed because it has been stalled for 5 days with no activity."
           days-before-stale: 30
           days-before-close: 5
           days-before-pr-close: -1
-


### PR DESCRIPTION
I've been working on my plugin for flutter_map, and I have setup a multi-step workflow to increase productivity. I have carried over my changes to here, and you can see the things that have changed below. A run of these can be found at https://github.com/JaffaKetchup/flutter_map_tile_caching/actions/runs/2752638748.

In addition to testing the code contents of this library, there is now an automatically compiled package report reflecting what the [pub.dev score](https://pub.dev/packages/flutter_map/score) should be on publishing. If the expected score is less than the possible score, then this check fails. This can be changed if necessary.

If both of those checks (content and package score) pass, then there is an automatic example app builder, which builds an optimised APK for Android and ZIP archive for Windows. It's intelligent enough to only build the example app if its source has changed, as it's quite an expensive operation (up to 15 mins computing time). Note that that means that a change in the library to fix a bug will not update the example application, unless the example application has been changed. These are then outputted to a directory called 'prebuiltExampleApplications', which is committed.  
In the future, it is easily possible to set up automatic web building and deployment to Firebase Hosting (free), as I have done this in the past and still have the configuration for it. However, this will require @johnpryan's assistance as it requires adding repository secrets.

To reduce the number of workflow run logs (currently at 939), I've also included a simple workflow which will delete all old workflow runs (older than 7 days). This runs automatically every Monday.

---

**Things to consider:** 
- Should the example builder be run on every (content and package check passing) commit instead of just those that have changed the example? This will avoid issues where the example still contains bugs after they have been fixed because the example source hasn't changed.
- Do we want to allow a certain margin of error in the package analysis?
- Do we want to change the times at which the log cleaner runs?