### PR TITLE
Force move to pick center even if max bounds does not fit

### DIFF
--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -377,15 +377,19 @@ class MapState {
     }
 
     // Try and fit the corners of the map inside the visible area.
-    // If it's still outside (so response is null), don't perform a move.
+    // If it's still outside (so response is null), Adjust zoom to either fit
+    // the options.maxZoom or do a best approx center with grey boundaries to
+    // avoid center never being set.
     if (options.maxBounds != null) {
-      final adjustedCenter =
+      LatLng? adjustedCenter =
           adjustCenterIfOutsideMaxBounds(center, zoom, options.maxBounds!);
       if (adjustedCenter == null) {
-        return false;
-      } else {
-        center = adjustedCenter;
+        final centerZoom = getBoundsCenterZoom(options.maxBounds!,
+            FitBoundsOptions(inside: true, maxZoom: options.maxZoom ?? 17));
+        adjustedCenter = centerZoom.center;
+        zoom = centerZoom.zoom;
       }
+      center = adjustedCenter;
     }
 
     _handleMoveEmit(center, zoom, hasGesture, source, id);

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -377,9 +377,11 @@ class MapState {
     }
 
     // Try and fit the corners of the map inside the visible area.
-    // If it's still outside (so response is null), Adjust zoom to either fit
-    // the options.maxZoom or do a best approx center with grey boundaries to
-    // avoid center never being set.
+    // If it's still outside (so response is null) and the map as already been
+    // drawn do nothing, otherwise on first pass adjust zoom to either fit
+    // the options.maxZoom or draw at max zoom with allowing map to draw
+    // ouside boundaries to avoid center never being set.  In this state the map
+    // is not movable except to rotate.
     if (options.maxBounds != null) {
       LatLng? adjustedCenter =
           adjustCenterIfOutsideMaxBounds(center, zoom, options.maxBounds!);

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -383,13 +383,17 @@ class MapState {
     if (options.maxBounds != null) {
       LatLng? adjustedCenter =
           adjustCenterIfOutsideMaxBounds(center, zoom, options.maxBounds!);
-      if (adjustedCenter == null) {
+      if (adjustedCenter == null && _lastCenter == null) {
         final centerZoom = getBoundsCenterZoom(options.maxBounds!,
             FitBoundsOptions(inside: true, maxZoom: options.maxZoom ?? 17));
         adjustedCenter = centerZoom.center;
         zoom = centerZoom.zoom;
       }
-      center = adjustedCenter;
+      if (adjustedCenter == null) {
+        return false;
+      } else {
+        center = adjustedCenter;
+      }
     }
 
     _handleMoveEmit(center, zoom, hasGesture, source, id);


### PR DESCRIPTION
If bounds do not fit first attempt to zoom up to the max zoom.
If center still cannot work then just set center with max zoom
and live with the grey borders.