### PR TITLE
Prepare For v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .buildlog/
 .history
 .svn/
+.fvm/
 
 # IntelliJ related
 *.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Changelog
 
-## [2.2.0] - 2022/XX/XX
+## [3.0.0] - 2022/09/04
+
+Contains the following additions/removals:
+
+- Multiple changes - [#1333](https://github.com/fleaflet/flutter_map/pull/1333)
+  - Removed deprecated APIs from v2
+  - Removed old layering system
+  - Added new layering system
+  - Removed old plugin registration system
+- Added `Polygon` label rotation (countered to the map rotation) - [#1332](https://github.com/fleaflet/flutter_map/pull/1332)
+
+Contains the following bug fixes:
+
+- Fixed missing widget sizing to fix multiple issues - [#1334](https://github.com/fleaflet/flutter_map/pull/1334)
+- Forced CRS changes to rebuild children - [#1322](https://github.com/fleaflet/flutter_map/issues/1322)
+- Allowed map to absorb gesture events correctly within other scrollables - [#1308](https://github.com/fleaflet/flutter_map/issues/1308)
+- Improved performance by harnessing the full power of Flutter widgets - [#1165](https://github.com/fleaflet/flutter_map/issues/1165), [#958](https://github.com/fleaflet/flutter_map/issues/958)
+
+In other news:
+
+- @MooNag has joined the maintainer team!
+
+Many thanks to these contributors (in no particular order):
+
+- @MooNag
+- @jetpeter
+- @Firefishy
+- ... and all the maintainers
+
+## [2.2.0] - 2022/08/02
 
 Contains the following additions/removals:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Contains the following bug fixes:
 
 In other news:
 
-- @MooNag has joined the maintainer team!
+- @MooNag & @TesteurManiak have joined the maintainer team!
 
 Many thanks to these contributors (in no particular order):
 

--- a/example/lib/pages/animated_map_controller.dart
+++ b/example/lib/pages/animated_map_controller.dart
@@ -183,7 +183,6 @@ class AnimatedMapControllerPageState extends State<AnimatedMapControllerPage>
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   MarkerLayer(markers: markers),

--- a/example/lib/pages/circle.dart
+++ b/example/lib/pages/circle.dart
@@ -41,7 +41,6 @@ class CirclePage extends StatelessWidget {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   CircleLayer(circles: circleMarkers),

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -67,7 +67,6 @@ class HomePage extends StatelessWidget {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   MarkerLayer(markers: markers),

--- a/example/lib/pages/interactive_test_page.dart
+++ b/example/lib/pages/interactive_test_page.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/widgets/drawer.dart';
@@ -17,7 +15,6 @@ class InteractiveTestPage extends StatefulWidget {
 }
 
 class _InteractiveTestPageState extends State<InteractiveTestPage> {
-
   // Enable pinchZoom and doubleTapZoomBy by default
   int flags = InteractiveFlag.pinchZoom | InteractiveFlag.doubleTapZoom;
 
@@ -142,9 +139,9 @@ class _InteractiveTestPageState extends State<InteractiveTestPage> {
               padding: const EdgeInsets.only(top: 8, bottom: 8),
               child: Center(
                 child: Text(
-                      'Current event: ${_latestEvent?.runtimeType ?? "none"}\nSource: ${_latestEvent?.source ?? "none"}',
-                      textAlign: TextAlign.center,
-                    ),
+                  'Current event: ${_latestEvent?.runtimeType ?? "none"}\nSource: ${_latestEvent?.source ?? "none"}',
+                  textAlign: TextAlign.center,
+                ),
               ),
             ),
             Flexible(
@@ -159,7 +156,6 @@ class _InteractiveTestPageState extends State<InteractiveTestPage> {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                 ],

--- a/example/lib/pages/latlng_to_screen_point.dart
+++ b/example/lib/pages/latlng_to_screen_point.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/widgets/drawer.dart';
@@ -58,9 +56,7 @@ class _LatLngScreenPointTestPageState extends State<LatLngScreenPointTestPage> {
               ),
               children: [
                 TileLayer(
-                  urlTemplate:
-                      'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                  subdomains: ['a', 'b', 'c'],
+                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                   userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                 ),
               ],

--- a/example/lib/pages/live_location.dart
+++ b/example/lib/pages/live_location.dart
@@ -143,7 +143,6 @@ class _LiveLocationPageState extends State<LiveLocationPage> {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   MarkerLayer(markers: markers),

--- a/example/lib/pages/many_markers.dart
+++ b/example/lib/pages/many_markers.dart
@@ -79,9 +79,7 @@ class _ManyMarkersPageState extends State<ManyMarkersPage> {
               ),
               children: [
                 TileLayer(
-                  urlTemplate:
-                      'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                  subdomains: ['a', 'b', 'c'],
+                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                   userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                 ),
                 MarkerLayer(

--- a/example/lib/pages/map_controller.dart
+++ b/example/lib/pages/map_controller.dart
@@ -163,7 +163,6 @@ class MapControllerPageState extends State<MapControllerPage> {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   MarkerLayer(markers: markers),
@@ -218,7 +217,6 @@ class _CurrentLocationState extends State<CurrentLocation> {
 
   void onMapEvent(MapEvent mapEvent) {
     if (mapEvent is MapEventMove && mapEvent.id != _eventKey.toString()) {
-    print("map event ${mapEvent.id}");
       setIcon(Icons.gps_not_fixed);
     }
   }
@@ -235,12 +233,7 @@ class _CurrentLocationState extends State<CurrentLocation> {
         id: _eventKey.toString(),
       );
 
-      if (moved) {
-        print("moveed");
-        setIcon(Icons.gps_fixed);
-      } else {
-        setIcon(Icons.gps_not_fixed);
-      }
+      setIcon(moved ? Icons.gps_fixed : Icons.gps_not_fixed);
     } catch (e) {
       setIcon(Icons.gps_off);
     }

--- a/example/lib/pages/map_inside_listview.dart
+++ b/example/lib/pages/map_inside_listview.dart
@@ -29,11 +29,10 @@ class MapInsideListViewPage extends StatelessWidget {
                 ),
                 children: [
                   TileLayer(
-                      urlTemplate:
-                          'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c'],
-                      userAgentPackageName: 'dev.fleaflet.flutter_map.example',
-                    ),
+                    urlTemplate:
+                        'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    userAgentPackageName: 'dev.fleaflet.flutter_map.example',
+                  ),
                   const FlutterMapZoomButtons(
                     minZoom: 4,
                     maxZoom: 19,

--- a/example/lib/pages/marker_anchor.dart
+++ b/example/lib/pages/marker_anchor.dart
@@ -116,7 +116,6 @@ class MarkerAnchorPageState extends State<MarkerAnchorPage> {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   MarkerLayer(markers: markers),

--- a/example/lib/pages/marker_rotate.dart
+++ b/example/lib/pages/marker_rotate.dart
@@ -141,7 +141,6 @@ class MarkerRotatePageState extends State<MarkerRotatePage> {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   MarkerLayer(

--- a/example/lib/pages/max_bounds.dart
+++ b/example/lib/pages/max_bounds.dart
@@ -35,7 +35,6 @@ class MaxBoundsPage extends StatelessWidget {
                     maxZoom: 15,
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                 ],

--- a/example/lib/pages/moving_markers.dart
+++ b/example/lib/pages/moving_markers.dart
@@ -62,7 +62,6 @@ class _MovingMarkersPageState extends State<MovingMarkersPage> {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   MarkerLayer(markers: [_marker!]),

--- a/example/lib/pages/network_tile_provider.dart
+++ b/example/lib/pages/network_tile_provider.dart
@@ -68,7 +68,6 @@ class NetworkTileProviderPage extends StatelessWidget {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     tileProvider: NetworkTileProvider(),
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),

--- a/example/lib/pages/on_tap.dart
+++ b/example/lib/pages/on_tap.dart
@@ -88,7 +88,6 @@ class OnTapPageState extends State<OnTapPage> {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   MarkerLayer(markers: markers),

--- a/example/lib/pages/overlay_image.dart
+++ b/example/lib/pages/overlay_image.dart
@@ -50,11 +50,9 @@ class OverlayImagePage extends StatelessWidget {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
-                  OverlayImageLayer(
-                          overlayImages: overlayImages),
+                  OverlayImageLayer(overlayImages: overlayImages),
                   MarkerLayer(markers: [
                     Marker(
                         point: topLeftCorner,

--- a/example/lib/pages/plugin_scalebar.dart
+++ b/example/lib/pages/plugin_scalebar.dart
@@ -38,7 +38,6 @@ class PluginScaleBar extends StatelessWidget {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                 ],

--- a/example/lib/pages/plugin_zoombuttons.dart
+++ b/example/lib/pages/plugin_zoombuttons.dart
@@ -20,27 +20,26 @@ class PluginZoomButtons extends StatelessWidget {
           children: [
             Flexible(
               child: FlutterMap(
-                options: MapOptions(
-                  center: LatLng(51.5, -0.09),
-                  zoom: 5,
-                ),
-                nonRotatedChildren: const [
-                  FlutterMapZoomButtons(
-                    minZoom: 4,
-                    maxZoom: 19,
-                    mini: true,
-                    padding: 10,
-                    alignment: Alignment.bottomRight,
+                  options: MapOptions(
+                    center: LatLng(51.5, -0.09),
+                    zoom: 5,
                   ),
-                ],
-                children: [
-                  TileLayer(
-                    urlTemplate:
-                        'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
-                    userAgentPackageName: 'dev.fleaflet.flutter_map.example',
-                  ),
-                ]),
+                  nonRotatedChildren: const [
+                    FlutterMapZoomButtons(
+                      minZoom: 4,
+                      maxZoom: 19,
+                      mini: true,
+                      padding: 10,
+                      alignment: Alignment.bottomRight,
+                    ),
+                  ],
+                  children: [
+                    TileLayer(
+                      urlTemplate:
+                          'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                      userAgentPackageName: 'dev.fleaflet.flutter_map.example',
+                    ),
+                  ]),
             ),
           ],
         ),

--- a/example/lib/pages/point_to_latlng.dart
+++ b/example/lib/pages/point_to_latlng.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/widgets/drawer.dart';
@@ -67,9 +65,7 @@ class PointToLatlngPage extends State<PointToLatLngPage> {
             ),
             children: [
               TileLayer(
-                urlTemplate:
-                    'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                subdomains: ['a', 'b', 'c'],
+                urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                 userAgentPackageName: 'dev.fleaflet.flutter_map.example',
               ),
               if (latLng != null)

--- a/example/lib/pages/polygon.dart
+++ b/example/lib/pages/polygon.dart
@@ -49,7 +49,6 @@ class PolygonPage extends StatelessWidget {
       LatLng(59.77, -10.28),
     ];
 
-
     return Scaffold(
       appBar: AppBar(title: const Text('Polygons')),
       drawer: buildDrawer(context, PolygonPage.route),
@@ -71,7 +70,6 @@ class PolygonPage extends StatelessWidget {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   PolygonLayer(polygons: [
@@ -110,12 +108,11 @@ class PolygonPage extends StatelessWidget {
                       label: "Label!",
                     ),
                     Polygon(
-                      points: labelRotatedPoints,
-                      borderStrokeWidth: 4,
-                      borderColor: Colors.purple,
-                      label: "Rotated!",
-                      rotateLabel: true
-                    ),
+                        points: labelRotatedPoints,
+                        borderStrokeWidth: 4,
+                        borderColor: Colors.purple,
+                        label: "Rotated!",
+                        rotateLabel: true),
                   ]),
                 ],
               ),

--- a/example/lib/pages/polyline.dart
+++ b/example/lib/pages/polyline.dart
@@ -84,18 +84,19 @@ class _PolylinePageState extends State<PolylinePage> {
                           TileLayer(
                             urlTemplate:
                                 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                            subdomains: ['a', 'b', 'c'],
                             userAgentPackageName:
                                 'dev.fleaflet.flutter_map.example',
                           ),
-                          PolylineLayer(polylines: [
+                          PolylineLayer(
+                            polylines: [
                               Polyline(
                                   points: points,
                                   strokeWidth: 4,
                                   color: Colors.purple),
                             ],
                           ),
-                          PolylineLayer(polylines: [
+                          PolylineLayer(
+                            polylines: [
                               Polyline(
                                 points: pointsGradient,
                                 strokeWidth: 4,

--- a/example/lib/pages/reset_tile_layer.dart
+++ b/example/lib/pages/reset_tile_layer.dart
@@ -79,7 +79,6 @@ class ResetTileLayerPageState extends State<ResetTileLayerPage> {
                   TileLayer(
                     reset: resetController.stream,
                     urlTemplate: layerToggle ? layer1 : layer2,
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   MarkerLayer(markers: markers)

--- a/example/lib/pages/scale_layer_plugin_option.dart
+++ b/example/lib/pages/scale_layer_plugin_option.dart
@@ -17,7 +17,7 @@ class ScaleLayerPluginOption {
     this.lineColor = Colors.white,
     this.lineWidth = 2,
     this.padding,
-  }) ;
+  });
 }
 
 class ScaleLayerWidget extends StatelessWidget {

--- a/example/lib/pages/stateful_markers.dart
+++ b/example/lib/pages/stateful_markers.dart
@@ -67,7 +67,6 @@ class _StatefulMarkersPageState extends State<StatefulMarkersPage> {
                   TileLayer(
                     urlTemplate:
                         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   MarkerLayer(markers: _markers),

--- a/example/lib/pages/tile_builder_example.dart
+++ b/example/lib/pages/tile_builder_example.dart
@@ -114,7 +114,6 @@ class _TileBuilderPageState extends State<TileBuilderPage> {
           children: [
             TileLayer(
               urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-              subdomains: ['a', 'b', 'c'],
               userAgentPackageName: 'dev.fleaflet.flutter_map.example',
               tileBuilder: tileBuilder,
               tilesContainerBuilder:

--- a/example/lib/pages/tile_loading_error_handle.dart
+++ b/example/lib/pages/tile_loading_error_handle.dart
@@ -42,7 +42,7 @@ class _TileLoadingErrorHandleState extends State<TileLoadingErrorHandle> {
                     TileLayer(
                       urlTemplate:
                           'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c'],
+
                       // For example purposes. It is recommended to use
                       // TileProvider with a caching and retry strategy, like
                       // NetworkTileProvider or CachedNetworkTileProvider

--- a/example/lib/pages/widgets.dart
+++ b/example/lib/pages/widgets.dart
@@ -45,10 +45,9 @@ class WidgetsPage extends StatelessWidget {
                 ],
                 children: [
                   TileLayer(
-                      urlTemplate:
-                          'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c'],
-                      userAgentPackageName: 'dev.fleaflet.flutter_map.example',
+                    urlTemplate:
+                        'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   const MovingWithoutRefreshAllMapMarkers(),
                 ],
@@ -95,7 +94,8 @@ class _MovingWithoutRefreshAllMapMarkersState
 
   @override
   Widget build(BuildContext context) {
-    return MarkerLayer(markers: [_marker!],
+    return MarkerLayer(
+      markers: [_marker!],
     );
   }
 }

--- a/example/lib/pages/wms_tile_layer.dart
+++ b/example/lib/pages/wms_tile_layer.dart
@@ -33,7 +33,7 @@ class WMSLayerPage extends StatelessWidget {
                       baseUrl: 'https://{s}.s2maps-tiles.eu/wms/?',
                       layers: ['s2cloudless-2018_3857'],
                     ),
-                    subdomains: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+                    subdomains: const ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   )
                 ],

--- a/example/lib/pages/zoombuttons_plugin_option.dart
+++ b/example/lib/pages/zoombuttons_plugin_option.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/plugin_api.dart';
 
 class FlutterMapZoomButtons extends StatelessWidget {
-
   final double minZoom;
   final double maxZoom;
   final bool mini;
@@ -19,7 +18,7 @@ class FlutterMapZoomButtons extends StatelessWidget {
       const FitBoundsOptions(padding: EdgeInsets.all(12));
 
   const FlutterMapZoomButtons({
-    super.key, 
+    super.key,
     this.minZoom = 1,
     this.maxZoom = 18,
     this.mini = true,
@@ -42,15 +41,12 @@ class FlutterMapZoomButtons extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
           Padding(
-            padding: EdgeInsets.only(
-                left: padding,
-                top: padding,
-                right: padding),
+            padding:
+                EdgeInsets.only(left: padding, top: padding, right: padding),
             child: FloatingActionButton(
               heroTag: 'zoomInButton',
               mini: mini,
-              backgroundColor:
-                  zoomInColor ?? Theme.of(context).primaryColor,
+              backgroundColor: zoomInColor ?? Theme.of(context).primaryColor,
               onPressed: () {
                 final bounds = map.bounds;
                 final centerZoom = map.getBoundsCenterZoom(bounds, options);
@@ -62,8 +58,7 @@ class FlutterMapZoomButtons extends StatelessWidget {
                     source: MapEventSource.custom);
               },
               child: Icon(zoomInIcon,
-                  color: zoomInColorIcon ??
-                      IconTheme.of(context).color),
+                  color: zoomInColorIcon ?? IconTheme.of(context).color),
             ),
           ),
           Padding(
@@ -71,8 +66,7 @@ class FlutterMapZoomButtons extends StatelessWidget {
             child: FloatingActionButton(
               heroTag: 'zoomOutButton',
               mini: mini,
-              backgroundColor: zoomOutColor ??
-                  Theme.of(context).primaryColor,
+              backgroundColor: zoomOutColor ?? Theme.of(context).primaryColor,
               onPressed: () {
                 final bounds = map.bounds;
                 final centerZoom = map.getBoundsCenterZoom(bounds, options);
@@ -84,8 +78,7 @@ class FlutterMapZoomButtons extends StatelessWidget {
                     source: MapEventSource.custom);
               },
               child: Icon(zoomOutIcon,
-                  color: zoomOutColorIcon ??
-                      IconTheme.of(context).color),
+                  color: zoomOutColorIcon ?? IconTheme.of(context).color),
             ),
           ),
         ],

--- a/example/lib/test_app.dart
+++ b/example/lib/test_app.dart
@@ -34,9 +34,7 @@ class _TestAppState extends State<TestApp> {
               ),
               children: [
                 TileLayer(
-                  urlTemplate:
-                      'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                  subdomains: ['a', 'b', 'c'],
+                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                   userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                 ),
               ],

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -324,8 +324,8 @@ class MapOptions {
         assert(rotationThreshold >= 0.0),
         assert(pinchZoomThreshold >= 0.0),
         assert(pinchMoveThreshold >= 0.0) {
-  assert(!adaptiveBoundaries || screenSize != null,
-      'screenSize must be set in order to enable adaptive boundaries.');
+    assert(!adaptiveBoundaries || screenSize != null,
+        'screenSize must be set in order to enable adaptive boundaries.');
   }
 }
 

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -3,7 +3,6 @@ import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/physics.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/gestures/latlng_tween.dart';
 import 'package:flutter_map/src/map/flutter_map_state.dart';
@@ -99,8 +98,6 @@ abstract class MapGestureMixin extends State<FlutterMap>
   late final AnimationController _doubleTapController;
   late Animation<double> _doubleTapZoomAnimation;
   late Animation<LatLng> _doubleTapCenterAnimation;
-
-  StreamSubscription<MapEvent>? _mapControllerAnimationInterruption;
 
   int _tapUpCounter = 0;
   Timer? _doubleTapHoldMaxDelay;
@@ -483,12 +480,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
             }
           }
 
-          //TODO maybe not needed?
-          if (mapMoved || mapRotated) {
-            mapState.setState(() {
-              
-            });
-          }
+          if (mapMoved || mapRotated) mapState.setState(() {});
         }
       }
     }
@@ -765,7 +757,6 @@ abstract class MapGestureMixin extends State<FlutterMap>
     );
   }
 
-  //TODO refactor
   void _startListeningForAnimationInterruptions() {
     _isListeningForInterruptions = true;
   }
@@ -775,7 +766,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
   }
 
   void handleAnimationInterruptions(MapEvent event) {
-    if(_isListeningForInterruptions == false) {
+    if (_isListeningForInterruptions == false) {
       //Do not handle animation interruptions if not listening
       return;
     }

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -124,7 +124,6 @@ class Marker {
 }
 
 class MarkerLayer extends StatelessWidget {
-
   final List<Marker> markers;
 
   /// If true markers will be counter rotated to the map rotation

--- a/lib/src/layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer.dart
@@ -116,8 +116,8 @@ class PolygonLayer extends StatelessWidget {
     );
   }
 
-  void _fillOffsets(
-      final List<Offset> offsets, final List<LatLng> points, FlutterMapState map) {
+  void _fillOffsets(final List<Offset> offsets, final List<LatLng> points,
+      FlutterMapState map) {
     final len = points.length;
     for (var i = 0; i < len; ++i) {
       final point = points[i];

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -95,8 +95,8 @@ class PolylineLayer extends StatelessWidget {
     );
   }
 
-  void _fillOffsets(
-      final List<Offset> offsets, final List<LatLng> points, FlutterMapState map) {
+  void _fillOffsets(final List<Offset> offsets, final List<LatLng> points,
+      FlutterMapState map) {
     final len = points.length;
     for (var i = 0; i < len; ++i) {
       final point = points[i];

--- a/lib/src/layer/tile_layer/coords.dart
+++ b/lib/src/layer/tile_layer/coords.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/core/util.dart' as util;
 import 'package:tuple/tuple.dart';
@@ -33,5 +31,5 @@ class Coords<T extends num> extends CustomPoint<T> {
   }
 
   @override
-  int get hashCode => hashValues(x.hashCode, y.hashCode, z.hashCode);
+  int get hashCode => Object.hash(x.hashCode, y.hashCode, z.hashCode);
 }

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -25,7 +25,6 @@ part 'tile_layer_options.dart';
 /// https://docs.fleaflet.dev/usage/layers/tile-layer. Some are important to
 /// avoid issues.
 class TileLayer extends StatefulWidget {
-  
   /// Defines the structure to create the URLs for the tiles. `{s}` means one of
   /// the available subdomains (can be omitted) `{z}` zoom level `{x}` and `{y}`
   /// — tile coordinates `{r}` can be used to add "&commat;2x" to the URL to
@@ -277,7 +276,7 @@ class TileLayer extends StatefulWidget {
     this.reset,
     this.tileBounds,
     String userAgentPackageName = 'unknown',
-  }) : updateInterval =
+  })  : updateInterval =
             updateInterval <= Duration.zero ? null : updateInterval,
         tileFadeInDuration =
             tileFadeInDuration <= Duration.zero ? null : tileFadeInDuration,
@@ -317,7 +316,6 @@ class TileLayer extends StatefulWidget {
 }
 
 class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
-
   late Bounds _globalTileRange;
   Tuple2<double, double>? _wrapX;
   Tuple2<double, double>? _wrapY;
@@ -342,9 +340,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     if (widget.reset != null) {
       _resetSub = widget.reset?.listen((_) => _resetTiles());
     }
-
-      //TODO fix
-    // _initThrottleUpdate();
   }
 
   @override
@@ -361,18 +356,15 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       reloadTiles = true;
     }
 
-    reloadTiles |=
-        !_tileManager.allWithinZoom(widget.minZoom, widget.maxZoom);
+    reloadTiles |= !_tileManager.allWithinZoom(widget.minZoom, widget.maxZoom);
 
     if (oldWidget.updateInterval != widget.updateInterval) {
       _throttleUpdate?.close();
-      //TODO fix
-      // _initThrottleUpdate();
     }
 
     if (!reloadTiles) {
-      final oldUrl = oldWidget.wmsOptions?._encodedBaseUrl ??
-          oldWidget.urlTemplate;
+      final oldUrl =
+          oldWidget.wmsOptions?._encodedBaseUrl ?? oldWidget.urlTemplate;
       final newUrl = widget.wmsOptions?._encodedBaseUrl ?? widget.urlTemplate;
 
       final oldOptions = oldWidget.additionalOptions;
@@ -393,22 +385,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       _tileManager.removeAll(widget.evictErrorTileStrategy);
     }
   }
-
-//TODO fix
-  // void _initThrottleUpdate() {
-  //   if (widget.updateInterval == null) {
-  //     _throttleUpdate = null;
-  //   } else {
-  //     _throttleUpdate = StreamController<LatLng?>(sync: true);
-  //     _throttleUpdate!.stream
-  //         .transform(
-  //           util.throttleStreamTransformerWithTrailingCall<LatLng?>(
-  //             widget.updateInterval!,
-  //           ),
-  //         )
-  //         .listen(_update);
-  //   }
-  // }
 
   @override
   void dispose() {
@@ -440,10 +416,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
         // It was a zoom lvl change
         _setView(map, map.center, tileZoom);
       } else {
-        if (_throttleUpdate == null) {
-          //TODO what is this for?
-          // _update(null);
-        } else {
+        if (_throttleUpdate != null) {
           _throttleUpdate!.add(null);
         }
       }
@@ -584,7 +557,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     }
   }
 
-
   Bounds _getTiledPixelBounds(FlutterMapState map, LatLng center) {
     final scale = map.getZoomScale(map.zoom, _tileZoom);
     final pixelCenter = map.project(center, _tileZoom).floor();
@@ -695,7 +667,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     return true;
   }
 
-  Bounds _latLngBoundsToPixelBounds(FlutterMapState map, LatLngBounds bounds, double thisZoom) {
+  Bounds _latLngBoundsToPixelBounds(
+      FlutterMapState map, LatLngBounds bounds, double thisZoom) {
     final swPixel = map.project(bounds.southWest!, thisZoom).floor();
     final nePixel = map.project(bounds.northEast!, thisZoom).ceil();
     final pxBounds = Bounds(swPixel, nePixel);

--- a/lib/src/layer/tile_layer/tile_manager.dart
+++ b/lib/src/layer/tile_layer/tile_manager.dart
@@ -98,8 +98,8 @@ class TileManager {
     Tuple2<double, double>? wrapY,
   ) {
     for (final tile in _tiles.values) {
-      tile.imageProvider = layer.tileProvider
-          .getImage(tile.coords.wrap(wrapX, wrapY), layer);
+      tile.imageProvider =
+          layer.tileProvider.getImage(tile.coords.wrap(wrapX, wrapY), layer);
       tile.loadTileImage();
     }
   }

--- a/lib/src/layer/tile_layer/tile_provider/network_image_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/network_image_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:http/http.dart';
@@ -20,8 +22,8 @@ class FMNetworkImageProvider extends ImageProvider<FMNetworkImageProvider> {
   }) : retryClient = retryClient ?? RetryClient(Client());
 
   @override
-  ImageStreamCompleter load(
-      FMNetworkImageProvider key, DecoderCallback decode) {
+  ImageStreamCompleter loadBuffer(
+      FMNetworkImageProvider key, DecoderBufferCallback decode) {
     return OneFrameImageStreamCompleter(_loadWithRetry(key, decode),
         informationCollector: () sync* {
       yield ErrorDescription('Image provider: $this');
@@ -36,7 +38,7 @@ class FMNetworkImageProvider extends ImageProvider<FMNetworkImageProvider> {
 
   Future<ImageInfo> _loadWithRetry(
     FMNetworkImageProvider key,
-    DecoderCallback decode,
+    DecoderBufferCallback decode,
   ) async {
     assert(key == this);
 
@@ -48,7 +50,8 @@ class FMNetworkImageProvider extends ImageProvider<FMNetworkImageProvider> {
           statusCode: response.statusCode, uri: uri);
     }
 
-    final codec = await decode(response.bodyBytes);
+    final codec =
+        await decode(await ImmutableBuffer.fromUint8List(response.bodyBytes));
     final image = (await codec.getNextFrame()).image;
 
     return ImageInfo(image: image);

--- a/lib/src/layer/tile_layer/tile_provider/network_no_retry_image_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/network_no_retry_image_provider.dart
@@ -24,9 +24,9 @@ class FMNetworkNoRetryImageProvider
           ..userAgent = null;
 
   @override
-  ImageStreamCompleter load(
+  ImageStreamCompleter loadBuffer(
     FMNetworkNoRetryImageProvider key,
-    DecoderCallback decode,
+    DecoderBufferCallback decode,
   ) {
     //ignore: close_sinks
     final StreamController<ImageChunkEvent> chunkEvents =
@@ -52,7 +52,7 @@ class FMNetworkNoRetryImageProvider
 
   Future<Codec> _loadAsync({
     required FMNetworkNoRetryImageProvider key,
-    required DecoderCallback decode,
+    required DecoderBufferCallback decode,
     required StreamController<ImageChunkEvent> chunkEvents,
   }) async {
     try {
@@ -86,7 +86,7 @@ class FMNetworkNoRetryImageProvider
         throw Exception('NetworkImage is an empty file: $resolved');
       }
 
-      return decode(bytes);
+      return decode(await ImmutableBuffer.fromUint8List(bytes));
     } catch (e) {
       scheduleMicrotask(() {
         _ambiguate(_ambiguate(PaintingBinding.instance)?.imageCache)

--- a/lib/src/layer/tile_layer/tile_provider/network_no_retry_image_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/network_no_retry_image_provider.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';

--- a/lib/src/layer/tile_layer/tile_provider/tile_provider_io.dart
+++ b/lib/src/layer/tile_layer/tile_provider/tile_provider_io.dart
@@ -64,6 +64,16 @@ class NetworkNoRetryTileProvider extends TileProvider {
       );
 }
 
+/// [TileProvider] that uses [AssetImage] internally
+class AssetTileProvider extends TileProvider {
+  AssetTileProvider();
+
+  @override
+  ImageProvider getImage(Coords<num> coords, TileLayer options) {
+    return AssetImage(getTileUrl(coords, options));
+  }
+}
+
 /// A very basic [TileProvider] implementation, that can be extended to create your own provider
 ///
 /// Using this method is not recommended any more, except for very simple custom [TileProvider]s. Instead, visit the online documentation at https://docs.fleaflet.dev/plugins/making-a-plugin/creating-new-tile-providers.

--- a/lib/src/layer/tile_layer/tile_provider/tile_provider_web.dart
+++ b/lib/src/layer/tile_layer/tile_provider/tile_provider_web.dart
@@ -41,11 +41,20 @@ class NetworkNoRetryTileProvider extends TileProvider {
   }
 
   @override
-  ImageProvider getImage(Coords<num> coords, TileLayer options) =>
-      NetworkImage(
+  ImageProvider getImage(Coords<num> coords, TileLayer options) => NetworkImage(
         getTileUrl(coords, options),
         headers: headers..remove('User-Agent'),
       );
+}
+
+/// [TileProvider] that uses [AssetImage] internally
+class AssetTileProvider extends TileProvider {
+  AssetTileProvider();
+
+  @override
+  ImageProvider getImage(Coords<num> coords, TileLayer options) {
+    return AssetImage(getTileUrl(coords, options));
+  }
 }
 
 /// A very basic [TileProvider] implementation, that can be extended to create your own provider

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -718,7 +716,6 @@ class FlutterMapState extends MapGestureMixin
     return CustomPoint(tp.dx, tp.dy);
   }
 
-
   _SafeArea? _safeAreaCache;
   double? _safeAreaZoom;
 
@@ -746,9 +743,10 @@ class FlutterMapState extends MapGestureMixin
       return _safeArea!.containPoint(point, fallback);
     } else {
       return LatLng(
-        point.latitude.clamp(options.swPanBoundary!.latitude, options.nePanBoundary!.latitude),
-        point.longitude
-            .clamp(options.swPanBoundary!.longitude, options.nePanBoundary!.longitude),
+        point.latitude.clamp(
+            options.swPanBoundary!.latitude, options.nePanBoundary!.latitude),
+        point.longitude.clamp(
+            options.swPanBoundary!.longitude, options.nePanBoundary!.longitude),
       );
     }
   }
@@ -759,10 +757,14 @@ class FlutterMapState extends MapGestureMixin
       _safeAreaZoom = controllerZoom;
       final halfScreenHeight = _calculateScreenHeightInDegrees() / 2;
       final halfScreenWidth = _calculateScreenWidthInDegrees() / 2;
-      final southWestLatitude = options.swPanBoundary!.latitude + halfScreenHeight;
-      final southWestLongitude = options.swPanBoundary!.longitude + halfScreenWidth;
-      final northEastLatitude = options.nePanBoundary!.latitude - halfScreenHeight;
-      final northEastLongitude = options.nePanBoundary!.longitude - halfScreenWidth;
+      final southWestLatitude =
+          options.swPanBoundary!.latitude + halfScreenHeight;
+      final southWestLongitude =
+          options.swPanBoundary!.longitude + halfScreenWidth;
+      final northEastLatitude =
+          options.nePanBoundary!.latitude - halfScreenHeight;
+      final northEastLongitude =
+          options.nePanBoundary!.longitude - halfScreenWidth;
       _safeAreaCache = _SafeArea(
         LatLng(
           southWestLatitude,
@@ -785,7 +787,6 @@ class FlutterMapState extends MapGestureMixin
   double _calculateScreenHeightInDegrees() =>
       options.screenSize!.height * 170.102258 / math.pow(2, zoom + 8);
 
-
   static FlutterMapState? maybeOf(BuildContext context, {bool nullOk = false}) {
     final widget =
         context.dependOnInheritedWidgetOfExactType<MapStateInheritedWidget>();
@@ -796,8 +797,6 @@ class FlutterMapState extends MapGestureMixin
         'MapState.of() called with a context that does not contain a FlutterMap.');
   }
 }
-
-
 
 class _SafeArea {
   final LatLngBounds bounds;

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -6,7 +6,6 @@ import 'package:flutter_map/src/map/flutter_map_state.dart';
 import 'package:latlong2/latlong.dart';
 
 class MapControllerImpl implements MapController {
-
   final StreamController<MapEvent> _mapEventSink = StreamController.broadcast();
 
   @override
@@ -91,5 +90,4 @@ class MapControllerImpl implements MapController {
     return _state.rotatePoint(mapCenter, point,
         counterRotation: counterRotation);
   }
-  
 }

--- a/lib/src/map/map_state_widget.dart
+++ b/lib/src/map/map_state_widget.dart
@@ -2,7 +2,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_map/src/map/flutter_map_state.dart';
 
 class MapStateInheritedWidget extends InheritedWidget {
-  
   final FlutterMapState mapState;
 
   const MapStateInheritedWidget({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: flutter_map
 description: A versatile mapping package for Flutter, based off leaflet.js, that's simple and easy to learn, yet completely customizable and configurable.
 version: 3.0.0
 repository: https://github.com/fleaflet/flutter_map
+issue_tracker: https://github.com/fleaflet/flutter_map/issues
 documentation: https://docs.fleaflet.dev
 
 environment:
@@ -18,7 +19,7 @@ dependencies:
   meta: ^1.3.0
   polylabel: ^1.0.1
   positioned_tap_detector_2: ^1.0.4
-  proj4dart: ^2.0.0
+  proj4dart: ^2.1.0
   tuple: ^2.0.0
   vector_math: ^2.1.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ documentation: https://docs.fleaflet.dev
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=2.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   async: ^2.8.2

--- a/test/flutter_map_test.dart
+++ b/test/flutter_map_test.dart
@@ -111,9 +111,8 @@ class _TestAppState extends State<TestApp> {
               ),
               children: [
                 TileLayer(
-                    urlTemplate:
-                        'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    subdomains: ['a', 'b', 'c']),
+                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                ),
                 MarkerLayer(markers: _markers),
               ],
             ),


### PR DESCRIPTION
- Removed useless `subdomains` properties from examples
- Added support for Flutter 3.3.0 and set minimum to 3.3.0
- Improved pubspec.yaml with new link to issue tracker
- Updated CHANGELOG