### PR TITLE
Reduce unnecessary casts, use convert when unsafe

### DIFF
--- a/example/lib/pages/scale_layer_plugin_option.dart
+++ b/example/lib/pages/scale_layer_plugin_option.dart
@@ -101,18 +101,16 @@ class ScalePainter extends CustomPainter {
 
     const sizeForStartEnd = 4;
     final paddingLeft =
-        padding == null ? 0 : padding!.left + sizeForStartEnd / 2;
-    var paddingTop = padding == null ? 0 : padding!.top;
+        padding == null ? 0.0 : padding!.left + sizeForStartEnd / 2;
+    var paddingTop = padding == null ? 0.0 : padding!.top;
 
     final textSpan = TextSpan(style: textStyle, text: text);
     final textPainter =
         TextPainter(text: textSpan, textDirection: TextDirection.ltr)..layout();
-    textPainter.paint(
-        canvas,
-        Offset(width / 2 - textPainter.width / 2 + paddingLeft,
-            paddingTop as double));
+    textPainter.paint(canvas,
+        Offset(width / 2 - textPainter.width / 2 + paddingLeft, paddingTop));
     paddingTop += textPainter.height;
-    final p1 = Offset(paddingLeft as double, sizeForStartEnd + paddingTop);
+    final p1 = Offset(paddingLeft, sizeForStartEnd + paddingTop);
     final p2 = Offset(paddingLeft + width, sizeForStartEnd + paddingTop);
     // draw start line
     canvas.drawLine(Offset(paddingLeft, paddingTop),

--- a/lib/src/geo/crs/crs.dart
+++ b/lib/src/geo/crs/crs.dart
@@ -51,7 +51,7 @@ abstract class Crs {
   }
 
   /// Scale to Zoom function.
-  num zoom(double scale) {
+  double zoom(double scale) {
     return math.log(scale / 256) / math.ln2;
   }
 
@@ -296,7 +296,7 @@ class Proj4Crs extends Crs {
 
   /// Scale to Zoom function.
   @override
-  num zoom(double scale) {
+  double zoom(double scale) {
     // Find closest number in _scales, down
     final downScale = _closestElement(_scales, scale);
     if (downScale == null) {
@@ -305,7 +305,7 @@ class Proj4Crs extends Crs {
     final downZoom = _scales.indexOf(downScale);
     // Check if scale is downScale => return array index
     if (scale == downScale) {
-      return downZoom;
+      return downZoom.toDouble();
     }
     // Interpolate
     final nextZoom = downZoom + 1;

--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -15,34 +15,34 @@ class LatLngBounds {
 
   LatLngBounds.fromPoints(List<LatLng> points) {
     if (points.isNotEmpty) {
-      num? minX;
-      num? maxX;
-      num? minY;
-      num? maxY;
+      double minX = 180;
+      double maxX = -180;
+      double minY = 90;
+      double maxY = -90;
 
       for (final point in points) {
-        final num x = point.longitudeInRad;
-        final num y = point.latitudeInRad;
+        final double x = point.longitude;
+        final double y = point.latitude;
 
-        if (minX == null || minX > x) {
+        if (minX > x) {
           minX = x;
         }
 
-        if (minY == null || minY > y) {
+        if (minY > y) {
           minY = y;
         }
 
-        if (maxX == null || maxX < x) {
+        if (maxX < x) {
           maxX = x;
         }
 
-        if (maxY == null || maxY < y) {
+        if (maxY < y) {
           maxY = y;
         }
       }
 
-      _sw = LatLng(radianToDeg(minY as double), radianToDeg(minX as double));
-      _ne = LatLng(radianToDeg(maxY as double), radianToDeg(maxX as double));
+      _sw = LatLng(minY, minX);
+      _ne = LatLng(maxY, maxX);
     }
   }
 

--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -14,36 +14,38 @@ class LatLngBounds {
   }
 
   LatLngBounds.fromPoints(List<LatLng> points) {
-    if (points.isNotEmpty) {
-      double minX = 180;
-      double maxX = -180;
-      double minY = 90;
-      double maxY = -90;
+    if (points.isEmpty) {
+      return;
+    }
 
-      for (final point in points) {
-        final double x = point.longitude;
-        final double y = point.latitude;
+    double minX = 180;
+    double maxX = -180;
+    double minY = 90;
+    double maxY = -90;
 
-        if (minX > x) {
-          minX = x;
-        }
+    for (final point in points) {
+      final double x = point.longitude;
+      final double y = point.latitude;
 
-        if (minY > y) {
-          minY = y;
-        }
-
-        if (maxX < x) {
-          maxX = x;
-        }
-
-        if (maxY < y) {
-          maxY = y;
-        }
+      if (minX > x) {
+        minX = x;
       }
 
-      _sw = LatLng(minY, minX);
-      _ne = LatLng(maxY, maxX);
+      if (minY > y) {
+        minY = y;
+      }
+
+      if (maxX < x) {
+        maxX = x;
+      }
+
+      if (maxY < y) {
+        maxY = y;
+      }
     }
+
+    _sw = LatLng(minY, minX);
+    _ne = LatLng(maxY, maxX);
   }
 
   /// Expands bounding box by [latlng] coordinate point. This method mutates

--- a/lib/src/layer/circle_layer.dart
+++ b/lib/src/layer/circle_layer.dart
@@ -10,7 +10,7 @@ class CircleMarker {
   final Color borderColor;
   final bool useRadiusInMeter;
   Offset offset = Offset.zero;
-  num realRadius = 0;
+  double realRadius = 0;
   CircleMarker({
     required this.point,
     required this.radius,
@@ -72,11 +72,8 @@ class CirclePainter extends CustomPainter {
       ..style = PaintingStyle.fill
       ..color = circle.color;
 
-    _paintCircle(
-        canvas,
-        circle.offset,
-        circle.useRadiusInMeter ? circle.realRadius as double : circle.radius,
-        paint);
+    _paintCircle(canvas, circle.offset,
+        circle.useRadiusInMeter ? circle.realRadius : circle.radius, paint);
 
     if (circle.borderStrokeWidth > 0) {
       final paint = Paint()
@@ -84,11 +81,8 @@ class CirclePainter extends CustomPainter {
         ..color = circle.borderColor
         ..strokeWidth = circle.borderStrokeWidth;
 
-      _paintCircle(
-          canvas,
-          circle.offset,
-          circle.useRadiusInMeter ? circle.realRadius as double : circle.radius,
-          paint);
+      _paintCircle(canvas, circle.offset,
+          circle.useRadiusInMeter ? circle.realRadius : circle.radius, paint);
     }
   }
 

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -570,7 +570,7 @@ class FlutterMapState extends MapGestureMixin
   double getScaleZoom(double scale, double? fromZoom) {
     final crs = options.crs;
     fromZoom = fromZoom ?? _zoom;
-    return crs.zoom(scale * crs.scale(fromZoom)) as double;
+    return crs.zoom(scale * crs.scale(fromZoom));
   }
 
   Bounds? getPixelWorldBounds(double? zoom) {


### PR DESCRIPTION
- Fixes https://github.com/fleaflet/flutter_map/issues/1346
- `LatLngBounds.fromPoints` converted degrees to radians, then radians back to degrees... Also used num and nullables although we were only dealing with doubles.
- Removed some unnecessary casts coming from inferred types (where double can be inferred rather than num).

Not sure if we can guarantee that all `CustomPoint<num>` are in fact doubles, but left them for now since it would be a bigger change.