### PR TITLE
Upgrade dependencies, fix EPSG:3413 example

### DIFF
--- a/example/lib/pages/epsg3413_crs.dart
+++ b/example/lib/pages/epsg3413_crs.dart
@@ -154,7 +154,7 @@ class _EPSG3413PageState extends State<EPSG3413Page> {
                           LatLng(85.2802493, 79.794166),
                         ),
                         imageProvider: Image.asset(
-                          'map/epsg3413/amsr2.png',
+                          'assets/map/epsg3413/amsr2.png',
                         ).image,
                       )
                     ],

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,8 @@ publish_to: "none"
 version: 1.0.0
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:
@@ -13,7 +14,7 @@ dependencies:
     path: ../
   location: ^4.4.0
   latlong2: ^0.8.1
-  proj4dart: ^2.0.0
+  proj4dart: ^2.1.0
   positioned_tap_detector_2: ^1.0.4
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,26 +6,26 @@ issue_tracker: https://github.com/fleaflet/flutter_map/issues
 documentation: https://docs.fleaflet.dev
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
   flutter: ">=3.3.0"
 
 dependencies:
-  async: ^2.8.2
-  collection: ^1.15.0
+  async: ^2.9.0
+  collection: ^1.16.0
   flutter:
     sdk: flutter
-  http: ^0.13.3
+  http: ^0.13.5
   latlong2: ^0.8.0
-  meta: ^1.3.0
+  meta: ^1.8.0
   polylabel: ^1.0.1
   positioned_tap_detector_2: ^1.0.4
   proj4dart: ^2.1.0
   tuple: ^2.0.0
-  vector_math: ^2.1.0
+  vector_math: ^2.1.2
 
 dev_dependencies:
-  flutter_lints: ">=1.0.4"
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.2
-  test: ^1.16.8
+  mockito: ^5.3.0
+  test: ^1.21.4


### PR DESCRIPTION
Upgrades the project to the latest compatible dependencies.

Also adds `assets/` path prefix to a broken `Image.asset()` in the EPSG:3413 example.

Tested on all examples, seems to work except for https://github.com/fleaflet/flutter_map/issues/1360.