### PR TITLE
update vector_map_tiles docs

### DIFF
--- a/getting-started/explanation/raster-vs-vector-tiles.md
+++ b/getting-started/explanation/raster-vs-vector-tiles.md
@@ -1,7 +1,7 @@
 # Raster vs Vector Tiles
 
 {% hint style="info" %}
-It is important to note that 'flutter\_map' only supports raster tiles. Vector tiles are currently only supported by a community maintained plugin.
+It is important to note that 'flutter\_map' only supports raster tiles natively. Vector tiles can be used with a community maintained plugin.
 
 This is described in more detail at the bottom of this page.
 {% endhint %}
@@ -22,6 +22,5 @@ However it does add complexity to the rendering process as each element needs to
 
 ### Using Vector Tiles
 
-Due to the complications mentioned above, 'flutter\_map' does not natively support vector tiles. However, you can use an existing [community maintained plugin (`vector_map_tiles`)](https://github.com/greensopinion/flutter-vector-map-tiles) to do this.
+Due to the complications mentioned above, 'flutter\_map' does not natively support vector tiles. However, vector tiles can be used with a [community maintained plugin (`vector_map_tiles`)](https://github.com/greensopinion/flutter-vector-map-tiles).
 
-The plugin also supports 'mixed' mode to get the best of both worlds: using raster images during animations to improve performance, and vector rendering to provide sharp visuals and custom theming when idle.

--- a/plugins/list.md
+++ b/plugins/list.md
@@ -19,7 +19,7 @@ However, if you're just browsing, a list is provided below (in no particular ord
 * [`flutter_map_marker_cluster`](https://github.com/lpongetti/flutter\_map\_marker\_cluster) by [lpongetti](https://github.com/lpongetti)\
   Provides beautiful and animated marker clustering functionality
 * [`vector_map_tiles`](https://github.com/greensopinion/flutter-vector-map-tiles) by [greensopinion](https://github.com/greensopinion)\
-  Enables the use of vector and 'mixed' tiles (see the [raster-vs-vector-tiles.md](../getting-started/explanation/raster-vs-vector-tiles.md "mention") page)
+  Enables the use of vector tiles and tile theming (see the [raster-vs-vector-tiles.md](../getting-started/explanation/raster-vs-vector-tiles.md "mention") page)
 * [`flutter_map_line_editor`](https://github.com/ibrierley/flutter\_map\_line\_editor) by [ibrierley](https://github.com/ibrierley)\
   Enables creation/editing of `Polyline`s and `Polygon`s
 * [`flutter_map_location_marker`](https://github.com/tlserver/flutter\_map\_location\_marker) by [tlserver](https://github.com/tlserver)\


### PR DESCRIPTION
Remove reference to mixed mode which
is no longer supported. Minor wording
change to raster vs vector discussion.