### PR TITLE
Deprecate obsolete fit parameter

### DIFF
--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -333,13 +333,11 @@ class MapOptions {
 class FitBoundsOptions {
   final EdgeInsets padding;
   final double maxZoom;
-  final double? zoom;
   final bool inside;
 
   const FitBoundsOptions({
     this.padding = EdgeInsets.zero,
     this.maxZoom = 17.0,
-    this.zoom,
     this.inside = false,
   });
 }

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -333,11 +333,16 @@ class MapOptions {
 class FitBoundsOptions {
   final EdgeInsets padding;
   final double maxZoom;
+  @Deprecated('This property is unused and will be removed in the next major release.')
+  /// TODO: remove this property in the next major release.
+  final double? zoom;
   final bool inside;
 
   const FitBoundsOptions({
     this.padding = EdgeInsets.zero,
     this.maxZoom = 17.0,
+    @Deprecated('This property is unused and will be removed in the next major release.')
+    this.zoom,
     this.inside = false,
   });
 }


### PR DESCRIPTION
I always wondered what the use of the `zoom` parameter of the `FitBoundsOptions` class was.
When working on #1367 I finally had the chance to look into it. As it turns out this parameter is never used nor is it documented.

Since this is a somewhat breaking change I made a separate PR.