### PR TITLE
Fix `bounds` Issue (for #1362)

### DIFF
--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -42,11 +42,11 @@ class FlutterMapState extends MapGestureMixin
 
     move(options.center, zoom, source: MapEventSource.initialization);
 
-    // Funally, fit the map to restrictions
-    if (options.bounds != null) {
-      fitBounds(options.bounds!, options.boundsOptions);
-    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      // Finally, fit the map to restrictions
+      if (options.bounds != null) {
+        fitBounds(options.bounds!, options.boundsOptions);
+      }
       options.onMapReady?.call();
     });
   }
@@ -164,10 +164,6 @@ class FlutterMapState extends MapGestureMixin
     _pixelBounds = getPixelBounds(zoom);
     _bounds = _calculateBounds();
     _pixelOrigin = getNewPixelOrigin(_center);
-
-    if (options.bounds != null) {
-      fitBounds(options.bounds!, options.boundsOptions);
-    }
 
     return LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {


### PR DESCRIPTION
Possible fix for the recent ```bounds``` issue. Needs proper testing before merging as I'm not quite familiar with bounds and recent changes. 

What this does is remove the fitBounds in the build method (I'm not sure this is needed there at all, as long as its run once?), and move it just to the initState (but it looks like it needs to run in the WidgetsBinding.instance.addPostFrameCallback for it to take effect...I'm not entirely sure if this is best or if its better before/after options.onMapReady?.call()).

Few thoughts...should ```bounds``` (I think we should think of it as initialFitBounds if my understanding of it is correct, and maybe rename one day) only run here...are there any other situations when we need to reset bounds ? Are there any possible race conditions where this is in the wrong place.

We can test the basics with something like this in one of the examples...
```
options: MapOptions(
                    bounds: LatLngBounds(
                      LatLng(56.6877, 11.5089),
                      LatLng(56.7378, 11.6644),
                    )
                ),
```
