### PR TITLE
fix for 1373, where bounds doesn't get updated after a mapController …

### DIFF
--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -418,7 +418,7 @@ class FlutterMapState extends MapGestureMixin
     newZoom = fitZoomToBounds(newZoom);
     final mapMoved = newCenter != _center || newZoom != _zoom;
 
-    if (!mapMoved || !_bounds.isValid) {
+    if (!mapMoved || !_calculateBounds().isValid) {
       return false;
     }
 
@@ -451,6 +451,7 @@ class FlutterMapState extends MapGestureMixin
     });
 
     _pixelBounds = getPixelBounds(_zoom);
+    _bounds = _calculateBounds();
     _pixelOrigin = getNewPixelOrigin(newCenter);
 
     _handleMoveEmit(


### PR DESCRIPTION
For https://github.com/fleaflet/flutter_map/issues/1373

I think setState gets called, but the onPositionChanged gets called before _bounds is updated (inside build). I've also added an extra check for a valid bounds check to be called on a test new bounds (we don't want to update _bounds if the new position is erm out of bounds). 