### PR TITLE
Minor documentation updates

### DIFF
--- a/getting-started/explanation/raster-vs-vector-tiles.md
+++ b/getting-started/explanation/raster-vs-vector-tiles.md
@@ -23,5 +23,3 @@ However it does add complexity to the rendering process as each element needs to
 ### Using Vector Tiles
 
 Due to the complications mentioned above, 'flutter\_map' does not natively support vector tiles. However, vector tiles can be used with a [community maintained plugin (`vector_map_tiles`)](https://github.com/greensopinion/flutter-vector-map-tiles) to do this.
-
-The plugin also supports 'mixed' mode to get the best of both worlds: using raster images during animations to improve performance, and vector rendering to provide sharp visuals and custom theming when idle.

--- a/usage/basics.md
+++ b/usage/basics.md
@@ -4,7 +4,7 @@
 
 ```dart
 FlutterMap(
-    controller: MapController(),
+    mapController: MapController(),
     options: MapOptions(),
     children: [],
 ),
@@ -18,7 +18,7 @@ This is the main widget for this library, and it takes three main properties. op
 *   ``[`children`](layers/) (required)
 
     Takes a list of `Widget`s that will be displayed on the map. These can be any widget, but are usually`Layer`s.
-*   ``[`controller`](controller.md) (optional)
+*   ``[`mapController`](controller.md) (optional)
 
     Takes a `MapController` that can be used to programmatically control the map, as well as listen to an events `Stream`.
 


### PR DESCRIPTION
When setting up `flutter_map` with the `vector_map_tiles` plugin, I noticed a couple of things to update in the docs.
* The basic `flutter_map` usage example uses a named argument `controller`. I needed to update the argument to `mapController` in order to get the example working.
* The section on vector tiles mentions the "mixed" mode for `vector_map_tiles`, which has been removed. It looks like the paragraph was removed in #1361, but that change did not make its way into 1dfdc38193c2954bbc8c4471cc3364cb76b987e8. Sorry to bring this up again if that was the intention.

Thank you for all of the work on this package. It's been a joy to use!