### PR TITLE
Improve Attribution

### DIFF
--- a/example/lib/pages/epsg3413_crs.dart
+++ b/example/lib/pages/epsg3413_crs.dart
@@ -154,7 +154,7 @@ class _EPSG3413PageState extends State<EPSG3413Page> {
                           LatLng(85.2802493, 79.794166),
                         ),
                         imageProvider: Image.asset(
-                          'map/epsg3413/amsr2.png',
+                          'assets/map/epsg3413/amsr2.png',
                         ).image,
                       )
                     ],

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -58,9 +58,14 @@ class HomePage extends StatelessWidget {
                   zoom: 5,
                 ),
                 nonRotatedChildren: [
-                  AttributionWidget.defaultWidget(
-                    source: 'OpenStreetMap contributors',
-                    onSourceTapped: () {},
+                  //AttributionLayer.defaultWidget(
+                  //  source: '© OpenStreetMap contributors',
+                  //  onSourceTapped: () {},
+                  //),
+                  AttributionLayer(
+                    attributions: {
+                      const Text('© OpenStreetMap contributors'): () {}
+                    },
                   ),
                 ],
                 children: [

--- a/example/lib/pages/reset_tile_layer.dart
+++ b/example/lib/pages/reset_tile_layer.dart
@@ -20,7 +20,7 @@ class ResetTileLayerPageState extends State<ResetTileLayerPage> {
   StreamController<void> resetController = StreamController.broadcast();
 
   String layer1 = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
-  String layer2 = 'http://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png';
+  String layer2 = 'https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png';
   bool layerToggle = true;
 
   @override
@@ -79,6 +79,7 @@ class ResetTileLayerPageState extends State<ResetTileLayerPage> {
                   TileLayer(
                     reset: resetController.stream,
                     urlTemplate: layerToggle ? layer1 : layer2,
+                    subdomains: layerToggle ? const [] : const ['a', 'b', 'c'],
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   MarkerLayer(markers: markers)

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,8 @@ publish_to: "none"
 version: 1.0.0
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:
@@ -13,7 +14,7 @@ dependencies:
     path: ../
   location: ^4.4.0
   latlong2: ^0.8.1
-  proj4dart: ^2.0.0
+  proj4dart: ^2.1.0
   positioned_tap_detector_2: ^1.0.4
 
 dev_dependencies:

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -340,12 +340,18 @@ class FitBoundsOptions {
   final double? zoom;
   final bool inside;
 
+  /// By default calculations will return fractional zoom levels.
+  /// If this parameter is set to [true] fractional zoom levels will be round
+  /// to the next suitable integer.
+  final bool forceIntegerZoomLevel;
+
   const FitBoundsOptions({
     this.padding = EdgeInsets.zero,
     this.maxZoom = 17.0,
     @Deprecated('This property is unused and will be removed in the next major release.')
         this.zoom,
     this.inside = false,
+    this.forceIntegerZoomLevel = false,
   });
 }
 

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -333,7 +333,9 @@ class MapOptions {
 class FitBoundsOptions {
   final EdgeInsets padding;
   final double maxZoom;
-  @Deprecated('This property is unused and will be removed in the next major release.')
+  @Deprecated(
+      'This property is unused and will be removed in the next major release.')
+
   /// TODO: remove this property in the next major release.
   final double? zoom;
   final bool inside;
@@ -342,7 +344,7 @@ class FitBoundsOptions {
     this.padding = EdgeInsets.zero,
     this.maxZoom = 17.0,
     @Deprecated('This property is unused and will be removed in the next major release.')
-    this.zoom,
+        this.zoom,
     this.inside = false,
   });
 }

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -333,12 +333,15 @@ class MapOptions {
 class FitBoundsOptions {
   final EdgeInsets padding;
   final double maxZoom;
+  @Deprecated('This property is unused and will be removed in the next major release.')
+  /// TODO: remove this property in the next major release.
   final double? zoom;
   final bool inside;
 
   const FitBoundsOptions({
     this.padding = EdgeInsets.zero,
     this.maxZoom = 17.0,
+    @Deprecated('This property is unused and will be removed in the next major release.')
     this.zoom,
     this.inside = false,
   });

--- a/lib/src/layer/attribution_layer.dart
+++ b/lib/src/layer/attribution_layer.dart
@@ -1,11 +1,104 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
-/// Attribution widget layer, usually placed in `nonRotatedChildren`
+class AttributionLayer extends StatefulWidget {
+  const AttributionLayer.custom({
+    super.key,
+    required Widget Function(BuildContext context) customBuilder,
+  })  : _customBuilder = customBuilder,
+        attributions = null,
+        alignment = Alignment.bottomRight,
+        backgroundColor = const Color(0xCCFFFFFF),
+        animationDuration = const Duration(milliseconds: 250),
+        animationCurve = Curves.fastOutSlowIn;
+
+  const AttributionLayer({
+    super.key,
+    this.attributions,
+    this.alignment = Alignment.bottomRight,
+    this.backgroundColor = const Color(0xCCFFFFFF),
+    this.animationDuration = const Duration(milliseconds: 250),
+    this.animationCurve = Curves.fastOutSlowIn,
+  }) : _customBuilder = null;
+
+  final Widget Function(BuildContext context)? _customBuilder;
+
+  final Map<Text, void Function()>? attributions;
+  final Alignment alignment;
+  final Color backgroundColor;
+
+  final Duration animationDuration;
+  final Curve animationCurve;
+
+  @override
+  State<AttributionLayer> createState() => _AttributionLayerState();
+}
+
+class _AttributionLayerState extends State<AttributionLayer>
+    with TickerProviderStateMixin {
+  late final _animationController = AnimationController(
+    duration: widget.animationDuration,
+    vsync: this,
+  );
+  late final _animation = CurvedAnimation(
+    parent: _animationController,
+    curve: widget.animationCurve,
+  );
+
+  late final Map<Text, void Function()> _attributions = {
+    ...widget.attributions ?? {},
+    const Text('flutter_map & the authors'): () {},
+  };
+
+  @override
+  Widget build(BuildContext context) => widget._customBuilder != null
+      ? widget._customBuilder!(context)
+      : Align(
+          alignment: widget.alignment,
+          child: ColoredBox(
+            color: widget.backgroundColor,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 6),
+              child: GestureDetector(
+                onTap: () {
+                  if (_animation.status != AnimationStatus.completed) {
+                    _animationController.forward();
+                  } else {
+                    _animationController.reverse();
+                  }
+                },
+                child: IntrinsicWidth(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizeTransition(
+                        sizeFactor: _animation,
+                        axis: Axis.vertical,
+                        child: SingleChildScrollView(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.end,
+                            children: [
+                              ..._attributions.keys.toList(),
+                              const Divider(),
+                            ],
+                          ),
+                        ),
+                      ),
+                      const Text('Show Map Attributions'),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+}
+
+/*/// Attribution widget layer, usually placed in `nonRotatedChildren`
 ///
 /// Can be anchored in a position of the map using [alignment], defaulting to [Alignment.bottomRight]. Then pass [attributionBuilder] to build your custom attribution widget.
 ///
 /// Alternatively, use the constructor [defaultWidget] to get a more classic styled attibution box.
-class AttributionWidget extends StatelessWidget {
+class AttributionLayer extends StatelessWidget {
   /// Function that returns a widget given a [BuildContext], displayed on the map
   final WidgetBuilder attributionBuilder;
 
@@ -17,7 +110,7 @@ class AttributionWidget extends StatelessWidget {
   /// Can be anchored in a position of the map using [alignment], defaulting to [Alignment.bottomRight]. Then pass [attributionBuilder] to build your custom attribution widget.
   ///
   /// Alternatively, use the constructor [defaultWidget] to get a more classic styled attibution box.
-  const AttributionWidget({
+  const AttributionLayer({
     Key? key,
     required this.attributionBuilder,
     this.alignment = Alignment.bottomRight,
@@ -66,3 +159,4 @@ class AttributionWidget extends StatelessWidget {
         ),
       );
 }
+*/

--- a/lib/src/layer/tile_layer/tile_provider/network_image_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/network_image_provider.dart
@@ -45,7 +45,7 @@ class FMNetworkImageProvider extends ImageProvider<FMNetworkImageProvider> {
     FMNetworkImageProvider key,
     DecoderBufferCallback decode, [
     bool useFallback = false,
-    ]) async {
+  ]) async {
     assert(key == this);
     assert(useFallback == false || fallbackUrl != null);
 
@@ -58,9 +58,9 @@ class FMNetworkImageProvider extends ImageProvider<FMNetworkImageProvider> {
             statusCode: response.statusCode, uri: uri);
       }
 
-    final codec =
-        await decode(await ImmutableBuffer.fromUint8List(response.bodyBytes));
-    final image = (await codec.getNextFrame()).image;
+      final codec =
+          await decode(await ImmutableBuffer.fromUint8List(response.bodyBytes));
+      final image = (await codec.getNextFrame()).image;
 
       return ImageInfo(image: image);
     } catch (e) {

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -510,7 +510,12 @@ class FlutterMapState extends MapGestureMixin
 
     final paddingTotalXY = paddingTL + paddingBR;
 
-    var zoom = getBoundsZoom(bounds, paddingTotalXY, inside: options.inside);
+    var zoom = getBoundsZoom(
+      bounds,
+      paddingTotalXY,
+      inside: options.inside,
+      forceIntegerZoomLevel: options.forceIntegerZoomLevel,
+    );
     zoom = math.min(options.maxZoom, zoom);
 
     final paddingOffset = (paddingBR - paddingTL) / 2;
@@ -524,7 +529,7 @@ class FlutterMapState extends MapGestureMixin
   }
 
   double getBoundsZoom(LatLngBounds bounds, CustomPoint<double> padding,
-      {bool inside = false}) {
+      {bool inside = false, bool forceIntegerZoomLevel = false}) {
     var zoom = this.zoom;
     final min = options.minZoom ?? 0.0;
     final max = options.maxZoom ?? double.infinity;
@@ -539,6 +544,10 @@ class FlutterMapState extends MapGestureMixin
     final scale = inside ? math.max(scaleX, scaleY) : math.min(scaleX, scaleY);
 
     zoom = getScaleZoom(scale, zoom);
+
+    if (forceIntegerZoomLevel) {
+      zoom = inside ? zoom.ceilToDouble() : zoom.floorToDouble();
+    }
 
     return math.max(min, math.min(max, zoom));
   }

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -42,11 +42,11 @@ class FlutterMapState extends MapGestureMixin
 
     move(options.center, zoom, source: MapEventSource.initialization);
 
-    // Funally, fit the map to restrictions
-    if (options.bounds != null) {
-      fitBounds(options.bounds!, options.boundsOptions);
-    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      // Finally, fit the map to restrictions
+      if (options.bounds != null) {
+        fitBounds(options.bounds!, options.boundsOptions);
+      }
       options.onMapReady?.call();
     });
   }
@@ -164,10 +164,6 @@ class FlutterMapState extends MapGestureMixin
     _pixelBounds = getPixelBounds(zoom);
     _bounds = _calculateBounds();
     _pixelOrigin = getNewPixelOrigin(_center);
-
-    if (options.bounds != null) {
-      fitBounds(options.bounds!, options.boundsOptions);
-    }
 
     return LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,26 +6,26 @@ issue_tracker: https://github.com/fleaflet/flutter_map/issues
 documentation: https://docs.fleaflet.dev
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
   flutter: ">=3.3.0"
 
 dependencies:
-  async: ^2.8.2
-  collection: ^1.15.0
+  async: ^2.9.0
+  collection: ^1.16.0
   flutter:
     sdk: flutter
-  http: ^0.13.3
+  http: ^0.13.5
   latlong2: ^0.8.0
-  meta: ^1.3.0
+  meta: ^1.8.0
   polylabel: ^1.0.1
   positioned_tap_detector_2: ^1.0.4
   proj4dart: ^2.1.0
   tuple: ^2.0.0
-  vector_math: ^2.1.0
+  vector_math: ^2.1.2
 
 dev_dependencies:
-  flutter_lints: ">=1.0.4"
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.2
-  test: ^1.16.8
+  mockito: ^5.3.0
+  test: ^1.21.4

--- a/test/flutter_map_controller_test.dart
+++ b/test/flutter_map_controller_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+
+void main() {
+  testWidgets('test fit bounds methods', (tester) async {
+    final controller = MapController();
+    final bounds = LatLngBounds(
+      LatLng(51, 0),
+      LatLng(52, 1),
+    );
+    final expectedCenter = LatLng(51.50274289405741, 0.49999999999999833);
+
+    await tester.pumpWidget(TestApp(controller: controller));
+
+    {
+      const fitOptions = FitBoundsOptions();
+
+      final expectedBounds = LatLngBounds(
+        LatLng(51.00145915187144, -0.3079873797085076),
+        LatLng(52.001427481787005, 1.298485398623206),
+      );
+      const expectedZoom = 7.451812751543818;
+
+      final fit = controller.centerZoomFitBounds(bounds, options: fitOptions);
+      controller.move(fit.center, fit.zoom);
+      await tester.pump();
+      expect(controller.bounds, equals(expectedBounds));
+      expect(controller.center, equals(expectedCenter));
+      expect(controller.zoom, equals(expectedZoom));
+
+      controller.fitBounds(bounds, options: fitOptions);
+      await tester.pump();
+      expect(controller.bounds, equals(expectedBounds));
+      expect(controller.center, equals(expectedCenter));
+      expect(controller.zoom, equals(expectedZoom));
+    }
+
+    {
+      const fitOptions = FitBoundsOptions(
+        forceIntegerZoomLevel: true,
+      );
+
+      final expectedBounds = LatLngBounds(
+        LatLng(50.819818262156545, -0.6042480468750001),
+        LatLng(52.1874047455997, 1.5930175781250002),
+      );
+      const expectedZoom = 7;
+
+      final fit = controller.centerZoomFitBounds(bounds, options: fitOptions);
+      controller.move(fit.center, fit.zoom);
+      await tester.pump();
+      expect(controller.bounds, equals(expectedBounds));
+      expect(controller.center, equals(expectedCenter));
+      expect(controller.zoom, equals(expectedZoom));
+
+      controller.fitBounds(bounds, options: fitOptions);
+      await tester.pump();
+      expect(controller.bounds, equals(expectedBounds));
+      expect(controller.center, equals(expectedCenter));
+      expect(controller.zoom, equals(expectedZoom));
+    }
+
+    {
+      const fitOptions = FitBoundsOptions(
+        inside: true,
+      );
+
+      final expectedBounds = LatLngBounds(
+        LatLng(51.19148727133182, -6.195044477408375e-13),
+        LatLng(51.8139520195805, 0.999999999999397),
+      );
+      const expectedZoom = 8.135709286104404;
+
+      final fit = controller.centerZoomFitBounds(bounds, options: fitOptions);
+      controller.move(fit.center, fit.zoom);
+      await tester.pump();
+
+      expect(controller.bounds, equals(expectedBounds));
+      expect(controller.center, equals(expectedCenter));
+      expect(controller.zoom, equals(expectedZoom));
+
+      controller.fitBounds(bounds, options: fitOptions);
+      await tester.pump();
+      expect(controller.bounds, equals(expectedBounds));
+      expect(controller.center, equals(expectedCenter));
+      expect(controller.zoom, equals(expectedZoom));
+    }
+
+    {
+      const fitOptions = FitBoundsOptions(
+        inside: true,
+        forceIntegerZoomLevel: true,
+      );
+
+      final expectedBounds = LatLngBounds(
+        LatLng(51.33232774035881, 0.22521972656250003),
+        LatLng(51.67425842259517, 0.7745361328125),
+      );
+      const expectedZoom = 9;
+
+      final fit = controller.centerZoomFitBounds(bounds, options: fitOptions);
+      controller.move(fit.center, fit.zoom);
+      await tester.pump();
+      expect(controller.bounds, equals(expectedBounds));
+      expect(controller.center, equals(expectedCenter));
+      expect(controller.zoom, equals(expectedZoom));
+
+      controller.fitBounds(bounds, options: fitOptions);
+      await tester.pump();
+      expect(controller.bounds, equals(expectedBounds));
+      expect(controller.center, equals(expectedCenter));
+      expect(controller.zoom, equals(expectedZoom));
+    }
+  });
+}
+
+class TestApp extends StatelessWidget {
+  final MapController controller;
+
+  const TestApp({
+    required this.controller,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          // ensure that map is always of the same size
+          child: SizedBox(
+            width: 200,
+            height: 200,
+            child: FlutterMap(
+              mapController: controller,
+              options: MapOptions(),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
The previous `AttributionWidget` was brought in fairly quickly to replace a deprecated and removed API. Whilst it was acceptable for simple maps with only a few attributions, it is not designed well to handle too many.

Designed to close #1379 by introducing breaking changes to improve the experience. Now, a `Map<Text, void Function()>` is passed to the default builder, which will be laid out in an expandable column to prevent clutter.

This is a breaking change and may not be to the liking of everyone. It is difficult to develop a feature like this - because everyone will want it to behave slightly different. Therefore, I would like a significant amount of feedback before merging.