### PR TITLE
Fix ignore details.scale = 0 to prevent Unsupported operation: Infinity or NaN toInt

### DIFF
--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -387,7 +387,9 @@ abstract class MapGestureMixin extends State<FlutterMap>
           var mapRotated = false;
           if (hasMove || hasZoom) {
             double newZoom;
-            if (hasZoom) {
+            // checking details.scale to prevent situation whew details comes
+            // with zero scale
+            if (hasZoom && details.scale > 0.0) {
               newZoom = _getZoomForScale(
                   _mapZoomStart, details.scale + _scaleCorrector);
 


### PR DESCRIPTION
Hello!
I found a bug while you trying to scale map with enabled scaffold drawer. If youll try to zoom a map when one of your finger stays on drawer gesture hook, ScaleUpdateDetails with come with ScaleUpdateDetails.scale = 0, and _getZoomForScale will return infinity zoom
You can try to make this moves on example app or just check the video


https://user-images.githubusercontent.com/13536462/196762179-8bf50e6e-9b11-4be1-8656-4483c300866c.mp4

