### PR TITLE
Add key to Polyline, CircleMarker + Test utilities

### DIFF
--- a/lib/src/layer/circle_layer.dart
+++ b/lib/src/layer/circle_layer.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/src/map/flutter_map_state.dart';
 import 'package:latlong2/latlong.dart' hide Path;
 
 class CircleMarker {
+  final Key? key;
   final LatLng point;
   final double radius;
   final Color color;
@@ -11,9 +12,11 @@ class CircleMarker {
   final bool useRadiusInMeter;
   Offset offset = Offset.zero;
   double realRadius = 0;
+
   CircleMarker({
     required this.point,
     required this.radius,
+    this.key,
     this.useRadiusInMeter = false,
     this.color = const Color(0xFF00FF00),
     this.borderStrokeWidth = 0.0,
@@ -46,6 +49,7 @@ class CircleLayer extends StatelessWidget {
 
           circleWidgets.add(
             CustomPaint(
+              key: key,
               painter: CirclePainter(circle),
               size: size,
             ),

--- a/lib/src/layer/circle_layer.dart
+++ b/lib/src/layer/circle_layer.dart
@@ -49,7 +49,7 @@ class CircleLayer extends StatelessWidget {
 
           circleWidgets.add(
             CustomPaint(
-              key: key,
+              key: circle.key,
               painter: CirclePainter(circle),
               size: size,
             ),

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -7,6 +7,7 @@ import 'package:flutter_map/src/map/flutter_map_state.dart';
 import 'package:latlong2/latlong.dart';
 
 class Polyline {
+  final Key? key;
   final List<LatLng> points;
   final List<Offset> offsets = [];
   final double strokeWidth;
@@ -22,6 +23,7 @@ class Polyline {
 
   Polyline({
     required this.points,
+    this.key,
     this.strokeWidth = 1.0,
     this.color = const Color(0xFF00FF00),
     this.borderStrokeWidth = 0.0,
@@ -82,10 +84,13 @@ class PolylineLayer extends StatelessWidget {
 
           _fillOffsets(polylineOpt.offsets, polylineOpt.points, map);
 
-          polylineWidgets.add(CustomPaint(
-            painter: PolylinePainter(polylineOpt, saveLayers),
-            size: size,
-          ));
+          polylineWidgets.add(
+            CustomPaint(
+              key: polylineOpt.key,
+              painter: PolylinePainter(polylineOpt, saveLayers),
+              size: size,
+            ),
+          );
         }
 
         return Stack(
@@ -95,8 +100,11 @@ class PolylineLayer extends StatelessWidget {
     );
   }
 
-  void _fillOffsets(final List<Offset> offsets, final List<LatLng> points,
-      FlutterMapState map) {
+  void _fillOffsets(
+    final List<Offset> offsets,
+    final List<LatLng> points,
+    FlutterMapState map,
+  ) {
     final len = points.length;
     for (var i = 0; i < len; ++i) {
       final point = points[i];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,6 @@
 name: flutter_map
-description: A versatile mapping package for Flutter, based off leaflet.js, that's simple and easy to learn, yet completely customizable and configurable.
+description: A versatile mapping package for Flutter, based off leaflet.js,
+  that's simple and easy to learn, yet completely customizable and configurable.
 version: 3.0.0
 repository: https://github.com/fleaflet/flutter_map
 issue_tracker: https://github.com/fleaflet/flutter_map/issues
@@ -27,5 +28,5 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  mockito: ^5.3.0
+  mocktail: ^0.3.0
   test: ^1.21.4

--- a/test/flutter_map_controller_test.dart
+++ b/test/flutter_map_controller_test.dart
@@ -1,9 +1,13 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
 
+import 'test_utils/mocks.dart';
+import 'test_utils/test_app.dart';
+
 void main() {
+  setupMocks();
+
   testWidgets('test fit bounds methods', (tester) async {
     final controller = MapController();
     final bounds = LatLngBounds(
@@ -114,32 +118,4 @@ void main() {
       expect(controller.zoom, equals(expectedZoom));
     }
   });
-}
-
-class TestApp extends StatelessWidget {
-  final MapController controller;
-
-  const TestApp({
-    required this.controller,
-    Key? key,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: Center(
-          // ensure that map is always of the same size
-          child: SizedBox(
-            width: 200,
-            height: 200,
-            child: FlutterMap(
-              mapController: controller,
-              options: MapOptions(),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
 }

--- a/test/flutter_map_test.dart
+++ b/test/flutter_map_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:mockito/mockito.dart';
 
+import 'test_utils/test_app.dart';
+
 class MockHttpClientResponse extends Mock implements HttpClientResponse {
   final _stream = readFile();
 
@@ -59,7 +61,7 @@ class MockHttpOverrides extends HttpOverrides {
 void main() {
   testWidgets('flutter_map', (tester) async {
     HttpOverrides.global = MockHttpOverrides();
-    await tester.pumpWidget(const TestApp());
+    await tester.pumpWidget(_buildTestApp());
     expect(find.byType(FlutterMap), findsOneWidget);
     expect(find.byType(TileLayer), findsOneWidget);
     expect(find.byType(RawImage), findsWidgets);
@@ -68,15 +70,8 @@ void main() {
   });
 }
 
-class TestApp extends StatefulWidget {
-  const TestApp({Key? key}) : super(key: key);
-
-  @override
-  State<TestApp> createState() => _TestAppState();
-}
-
-class _TestAppState extends State<TestApp> {
-  final List<Marker> _markers = <Marker>[
+Widget _buildTestApp() {
+  final markers = <Marker>[
     Marker(
       width: 80,
       height: 80,
@@ -91,34 +86,5 @@ class _TestAppState extends State<TestApp> {
     ),
   ];
 
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: SizedBox(
-            width: 200,
-            height: 200,
-            child: FlutterMap(
-              options: MapOptions(
-                center: LatLng(45.5231, -122.6765),
-                zoom: 13,
-              ),
-              children: [
-                TileLayer(
-                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                ),
-                MarkerLayer(markers: _markers),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
+  return TestApp(markers: markers);
 }

--- a/test/flutter_map_test.dart
+++ b/test/flutter_map_test.dart
@@ -59,32 +59,28 @@ class MockHttpOverrides extends HttpOverrides {
 }
 
 void main() {
+  final markers = <Marker>[
+    Marker(
+      width: 80,
+      height: 80,
+      point: LatLng(45.5231, -122.6765),
+      builder: (_) => const FlutterLogo(),
+    ),
+    Marker(
+      width: 80,
+      height: 80,
+      point: LatLng(40, -120), // not visible
+      builder: (_) => const FlutterLogo(),
+    ),
+  ];
+
   testWidgets('flutter_map', (tester) async {
     HttpOverrides.global = MockHttpOverrides();
-    await tester.pumpWidget(_buildTestApp());
+    await tester.pumpWidget(TestApp(markers: markers));
     expect(find.byType(FlutterMap), findsOneWidget);
     expect(find.byType(TileLayer), findsOneWidget);
     expect(find.byType(RawImage), findsWidgets);
     expect(find.byType(MarkerLayer), findsWidgets);
     expect(find.byType(FlutterLogo), findsOneWidget);
   });
-}
-
-Widget _buildTestApp() {
-  final markers = <Marker>[
-    Marker(
-      width: 80,
-      height: 80,
-      point: LatLng(45.5231, -122.6765),
-      builder: (ctx) => const FlutterLogo(),
-    ),
-    Marker(
-      width: 80,
-      height: 80,
-      point: LatLng(40, -120), // not visible
-      builder: (ctx) => const FlutterLogo(),
-    ),
-  ];
-
-  return TestApp(markers: markers);
 }

--- a/test/flutter_map_test.dart
+++ b/test/flutter_map_test.dart
@@ -1,81 +1,30 @@
-import 'dart:async';
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
-import 'package:mockito/mockito.dart';
 
+import 'test_utils/mocks.dart';
 import 'test_utils/test_app.dart';
 
-class MockHttpClientResponse extends Mock implements HttpClientResponse {
-  final _stream = readFile();
-
-  @override
-  int get statusCode => HttpStatus.ok;
-
-  @override
-  int get contentLength => File('test/res/map.png').lengthSync();
-
-  @override
-  HttpClientResponseCompressionState get compressionState =>
-      HttpClientResponseCompressionState.notCompressed;
-
-  @override
-  StreamSubscription<List<int>> listen(void Function(List<int> event)? onData,
-      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
-    return _stream.listen(
-      onData,
-      onError: onError,
-      onDone: onDone,
-      cancelOnError: cancelOnError,
-    );
-  }
-
-  static Stream<List<int>> readFile() => File('test/res/map.png').openRead();
-}
-
-class MockHttpHeaders extends Mock implements HttpHeaders {}
-
-class MockHttpClientRequest extends Mock implements HttpClientRequest {
-  @override
-  HttpHeaders get headers => MockHttpHeaders();
-
-  @override
-  Future<HttpClientResponse> close() => Future.value(MockHttpClientResponse());
-}
-
-class MockClient extends Mock implements HttpClient {
-  @override
-  Future<HttpClientRequest> getUrl(Uri url) {
-    return Future.value(MockHttpClientRequest());
-  }
-}
-
-class MockHttpOverrides extends HttpOverrides {
-  @override
-  HttpClient createHttpClient(SecurityContext? securityContext) => MockClient();
-}
-
 void main() {
-  final markers = <Marker>[
-    Marker(
-      width: 80,
-      height: 80,
-      point: LatLng(45.5231, -122.6765),
-      builder: (_) => const FlutterLogo(),
-    ),
-    Marker(
-      width: 80,
-      height: 80,
-      point: LatLng(40, -120), // not visible
-      builder: (_) => const FlutterLogo(),
-    ),
-  ];
+  setupMocks();
 
   testWidgets('flutter_map', (tester) async {
-    HttpOverrides.global = MockHttpOverrides();
+    final markers = <Marker>[
+      Marker(
+        width: 80,
+        height: 80,
+        point: LatLng(45.5231, -122.6765),
+        builder: (_) => const FlutterLogo(),
+      ),
+      Marker(
+        width: 80,
+        height: 80,
+        point: LatLng(40, -120), // not visible
+        builder: (_) => const FlutterLogo(),
+      ),
+    ];
+
     await tester.pumpWidget(TestApp(markers: markers));
     expect(find.byType(FlutterMap), findsOneWidget);
     expect(find.byType(TileLayer), findsOneWidget);

--- a/test/layer/circle_layer_test.dart
+++ b/test/layer/circle_layer_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../test_utils/mocks.dart';
+import '../test_utils/test_app.dart';
+
+void main() {
+  setupMocks();
+
+  testWidgets('test circle marker key', (tester) async {
+    const key = Key('c-1');
+
+    final circles = <CircleMarker>[
+      CircleMarker(
+        key: key,
+        point: LatLng(51.5, -0.09),
+        color: Colors.blue.withOpacity(0.7),
+        borderStrokeWidth: 2,
+        useRadiusInMeter: true,
+        radius: 2000,
+      ),
+    ];
+
+    await tester.pumpWidget(TestApp(circles: circles));
+    expect(find.byType(FlutterMap), findsOneWidget);
+    expect(find.byType(CircleLayer), findsWidgets);
+    expect(find.byKey(key), findsOneWidget);
+  });
+}

--- a/test/layer/marker_layer_test.dart
+++ b/test/layer/marker_layer_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../test_utils/mocks.dart';
+import '../test_utils/test_app.dart';
+
+void main() {
+  setupMocks();
+
+  testWidgets('test marker key', (tester) async {
+    const key = Key('m-1');
+
+    final markers = <Marker>[
+      Marker(
+        key: key,
+        width: 80,
+        height: 80,
+        point: LatLng(45.5231, -122.6765),
+        builder: (_) => const FlutterLogo(),
+      ),
+    ];
+
+    await tester.pumpWidget(TestApp(markers: markers));
+    expect(find.byType(FlutterMap), findsOneWidget);
+    expect(find.byType(MarkerLayer), findsWidgets);
+    expect(find.byKey(key), findsOneWidget);
+  });
+}

--- a/test/layer/polygon_layer_test.dart
+++ b/test/layer/polygon_layer_test.dart
@@ -1,9 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
 
+import '../test_utils/mocks.dart';
 import '../test_utils/test_app.dart';
 
 void main() {
+  setupMocks();
+
   testWidgets('test polygon key', (tester) async {
-    await tester.pumpWidget(const TestApp());
+    final filledPoints = <LatLng>[
+      LatLng(55.5, -0.09),
+      LatLng(54.3498, -6.2603),
+      LatLng(52.8566, 2.3522),
+    ];
+
+    const key = Key('p-1');
+
+    final polygon = Polygon(
+      key: key,
+      points: filledPoints,
+      isFilled: true,
+      color: Colors.purple,
+      borderColor: Colors.purple,
+      borderStrokeWidth: 4,
+    );
+
+    await tester.pumpWidget(TestApp(polygons: [polygon]));
+    expect(find.byType(FlutterMap), findsOneWidget);
+    expect(find.byType(PolygonLayer), findsOneWidget);
+    expect(find.byKey(key), findsOneWidget);
   });
 }

--- a/test/layer/polygon_layer_test.dart
+++ b/test/layer/polygon_layer_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../test_utils/test_app.dart';
+
+void main() {
+  testWidgets('test polygon key', (tester) async {
+    await tester.pumpWidget(const TestApp());
+  });
+}

--- a/test/layer/polyline_layer_test.dart
+++ b/test/layer/polyline_layer_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../test_utils/mocks.dart';
+import '../test_utils/test_app.dart';
+
+void main() {
+  setupMocks();
+
+  testWidgets('test polyline key', (tester) async {
+    const key = Key('p-1');
+
+    final polylines = <Polyline>[
+      Polyline(
+        key: key,
+        points: [
+          LatLng(50.5, -0.09),
+          LatLng(51.3498, -6.2603),
+          LatLng(53.8566, 2.3522),
+        ],
+        strokeWidth: 4,
+        color: Colors.amber,
+      ),
+    ];
+
+    await tester.pumpWidget(TestApp(polylines: polylines));
+    expect(find.byType(FlutterMap), findsOneWidget);
+    expect(find.byType(PolylineLayer), findsWidgets);
+    expect(find.byKey(key), findsOneWidget);
+  });
+}

--- a/test/test_utils/mocks.dart
+++ b/test/test_utils/mocks.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+class MockHttpClientResponse extends Mock implements HttpClientResponse {
+  final _stream = readFile();
+
+  @override
+  int get statusCode => HttpStatus.ok;
+
+  @override
+  int get contentLength => File('test/res/map.png').lengthSync();
+
+  @override
+  HttpClientResponseCompressionState get compressionState =>
+      HttpClientResponseCompressionState.notCompressed;
+
+  @override
+  StreamSubscription<List<int>> listen(void Function(List<int> event)? onData,
+      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+    return _stream.listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
+
+  static Stream<List<int>> readFile() => File('test/res/map.png').openRead();
+}
+
+class MockHttpHeaders extends Mock implements HttpHeaders {}
+
+class MockHttpClientRequest extends Mock implements HttpClientRequest {
+  @override
+  HttpHeaders get headers => MockHttpHeaders();
+
+  @override
+  Future<HttpClientResponse> close() => Future.value(MockHttpClientResponse());
+}
+
+class MockClient extends Mock implements HttpClient {
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) {
+    return Future.value(MockHttpClientRequest());
+  }
+}
+
+class MockHttpOverrides extends HttpOverrides {
+  @override
+  HttpClient createHttpClient(SecurityContext? securityContext) => MockClient();
+}
+
+void setupMocks() {
+  setUpAll(() {
+    HttpOverrides.global = MockHttpOverrides();
+  });
+}

--- a/test/test_utils/mocks.dart
+++ b/test/test_utils/mocks.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
 
 class MockHttpClientResponse extends Mock implements HttpClientResponse {
   final _stream = readFile();

--- a/test/test_utils/test_app.dart
+++ b/test/test_utils/test_app.dart
@@ -7,10 +7,12 @@ class TestApp extends StatelessWidget {
     super.key,
     this.controller,
     this.markers = const [],
+    this.polygons = const [],
   });
 
   final MapController? controller;
   final List<Marker> markers;
+  final List<Polygon> polygons;
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +33,7 @@ class TestApp extends StatelessWidget {
                 TileLayer(
                   urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                 ),
+                if (polygons.isNotEmpty) PolygonLayer(polygons: polygons),
                 if (markers.isNotEmpty) MarkerLayer(markers: markers),
               ],
             ),

--- a/test/test_utils/test_app.dart
+++ b/test/test_utils/test_app.dart
@@ -9,12 +9,14 @@ class TestApp extends StatelessWidget {
     this.markers = const [],
     this.polygons = const [],
     this.polylines = const [],
+    this.circles = const [],
   });
 
   final MapController? controller;
   final List<Marker> markers;
   final List<Polygon> polygons;
   final List<Polyline> polylines;
+  final List<CircleMarker> circles;
 
   @override
   Widget build(BuildContext context) {
@@ -37,6 +39,7 @@ class TestApp extends StatelessWidget {
                 ),
                 if (polylines.isNotEmpty) PolylineLayer(polylines: polylines),
                 if (polygons.isNotEmpty) PolygonLayer(polygons: polygons),
+                if (circles.isNotEmpty) CircleLayer(circles: circles),
                 if (markers.isNotEmpty) MarkerLayer(markers: markers),
               ],
             ),

--- a/test/test_utils/test_app.dart
+++ b/test/test_utils/test_app.dart
@@ -8,11 +8,13 @@ class TestApp extends StatelessWidget {
     this.controller,
     this.markers = const [],
     this.polygons = const [],
+    this.polylines = const [],
   });
 
   final MapController? controller;
   final List<Marker> markers;
   final List<Polygon> polygons;
+  final List<Polyline> polylines;
 
   @override
   Widget build(BuildContext context) {
@@ -33,6 +35,7 @@ class TestApp extends StatelessWidget {
                 TileLayer(
                   urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                 ),
+                if (polylines.isNotEmpty) PolylineLayer(polylines: polylines),
                 if (polygons.isNotEmpty) PolygonLayer(polygons: polygons),
                 if (markers.isNotEmpty) MarkerLayer(markers: markers),
               ],

--- a/test/test_utils/test_app.dart
+++ b/test/test_utils/test_app.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+class TestApp extends StatelessWidget {
+  const TestApp({
+    super.key,
+    this.controller,
+    this.markers = const [],
+  });
+
+  final MapController? controller;
+  final List<Marker> markers;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          // ensure that map is always of the same size
+          child: SizedBox(
+            width: 200,
+            height: 200,
+            child: FlutterMap(
+              mapController: controller,
+              options: MapOptions(
+                center: LatLng(45.5231, -122.6765),
+                zoom: 13,
+              ),
+              children: [
+                TileLayer(
+                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                ),
+                if (markers.isNotEmpty) MarkerLayer(markers: markers),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
I've added a key property to `Polyline` and `CircleMarker` classes. Moreover I've written some basic tests and made reusable test utilities.

I've replaced the `dev_dependency` to `mockito` by `mocktail` as it's easier to use and doesn't rely on code generation which might be cumbersome when testing.
The API is almost the same and doesn't change the current usage in `MockHttpClientResponse`, `MockHttpHeaders`, etc.