### PR TITLE
Add panBuffer feature to include extended tilerange

### DIFF
--- a/example/lib/pages/tile_builder_example.dart
+++ b/example/lib/pages/tile_builder_example.dart
@@ -17,6 +17,7 @@ class _TileBuilderPageState extends State<TileBuilderPage> {
   bool loadingTime = false;
   bool showCoords = false;
   bool grid = false;
+  int panBuffer = 0;
 
   // mix of [coordinateDebugTileBuilder] and [loadingTimeDebugTileBuilder] from tile_builder.dart
   Widget tileBuilder(BuildContext context, Widget tileWidget, Tile tile) {
@@ -102,6 +103,18 @@ class _TileBuilderPageState extends State<TileBuilderPage> {
             icon: Icon(darkMode ? Icons.brightness_high : Icons.brightness_2),
             onPressed: () => setState(() => darkMode = !darkMode),
           ),
+          const SizedBox(height: 8),
+          FloatingActionButton.extended(
+            heroTag: 'panBuffer',
+            label: Text(
+              panBuffer == 0 ? 'panBuffer off' : 'panBuffer on',
+              textAlign: TextAlign.center,
+            ),
+            icon: Icon(grid ? Icons.grid_off : Icons.grid_on),
+            onPressed: () => setState(() {
+              panBuffer = panBuffer == 0 ? 1 : 0;
+            }),
+          ),
         ],
       ),
       body: Padding(
@@ -118,6 +131,7 @@ class _TileBuilderPageState extends State<TileBuilderPage> {
               tileBuilder: tileBuilder,
               tilesContainerBuilder:
                   darkMode ? darkModeTilesContainerBuilder : null,
+              panBuffer: panBuffer,
             ),
             MarkerLayer(
               markers: <Marker>[

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -597,12 +597,14 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
 
     // Increase the tilerange if we have panBuffer set, but make sure we
     // don't use values outside valid tiles, eg (0,-1).
-    tileRange = tileRange.extend(CustomPoint(
-        math.max(_globalTileRange.min.x, tileRange.min.x - panBuffer),
-        math.max(_globalTileRange.min.y, tileRange.min.y - panBuffer)));
-    tileRange = tileRange.extend(CustomPoint(
-        math.min(_globalTileRange.max.x, tileRange.max.x + panBuffer),
-        math.min(_globalTileRange.max.y, tileRange.max.y + panBuffer)));
+    if (panBuffer != 0) {
+      tileRange = tileRange.extend(CustomPoint(
+          math.max(_globalTileRange.min.x, tileRange.min.x - panBuffer),
+          math.max(_globalTileRange.min.y, tileRange.min.y - panBuffer)));
+      tileRange = tileRange.extend(CustomPoint(
+          math.min(_globalTileRange.max.x, tileRange.max.x + panBuffer),
+          math.min(_globalTileRange.max.y, tileRange.max.y + panBuffer)));
+    }
 
     final tileCenter = tileRange.center;
     final queue = <Coords<double>>[];

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -138,6 +138,12 @@ class TileLayer extends StatefulWidget {
   /// unloading them.
   final int keepBuffer;
 
+  /// When panning the map, extend the tilerange by this many tiles in each
+  /// direction.
+  /// Will cause extra tile loads, and impact performance.
+  /// Be careful increasing this beyond 0 or 1.
+  final int panBuffer;
+
   /// Tile image to show in place of the tile that failed to load.
   final ImageProvider? errorImage;
 
@@ -254,6 +260,7 @@ class TileLayer extends StatefulWidget {
     Map<String, String>? additionalOptions,
     this.subdomains = const <String>[],
     this.keepBuffer = 2,
+    this.panBuffer = 0,
     this.backgroundColor = const Color(0xFFE0E0E0),
     this.errorImage,
     TileProvider? tileProvider,
@@ -584,7 +591,19 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     center ??= map.center;
 
     final pixelBounds = _getTiledPixelBounds(map, center);
-    final tileRange = _pxBoundsToTileRange(pixelBounds);
+    Bounds tileRange = _pxBoundsToTileRange(pixelBounds);
+
+    final panBuffer = widget.panBuffer;
+
+    // Increase the tilerange if we have panBuffer set, but make sure we
+    // don't use values outside valid tiles, eg (0,-1).
+    tileRange = tileRange.extend(CustomPoint(
+        math.max(_globalTileRange.min.x, tileRange.min.x - panBuffer),
+        math.max(_globalTileRange.min.y, tileRange.min.y - panBuffer)));
+    tileRange = tileRange.extend(CustomPoint(
+        math.min(_globalTileRange.max.x, tileRange.max.x + panBuffer),
+        math.min(_globalTileRange.max.y, tileRange.max.y + panBuffer)));
+
     final tileCenter = tileRange.center;
     final queue = <Coords<double>>[];
     final margin = widget.keepBuffer;


### PR DESCRIPTION
This is a possible example for https://github.com/fleaflet/flutter_map/issues/1337 (nice PR number btw :D) if I'm understanding it correct. (preloading can be slightly ambiguous).

Note, this extends the tilerange in each direction by an integer, and will affect performance, maybe good in one sense, for preloading for panning, but the extra tileloads will have some extra impact in terms of waiting for tile loads, decoding, potential costs etc. So this needs some extra thought and testing if it's really what we want.

If this is purely for panning only, it could be more efficient to only load tiles ahead of the direction that's being panned (lets say we pan +X,-Y we don't need to extend -X,+Y), but that would probably add some extra complexity.

Needs proper testing :).