### PR TITLE
Fix bounds/fitBounds not working on first display.

### DIFF
--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -156,14 +156,16 @@ class FlutterMapState extends MapGestureMixin
       },
     );
 
-
     return LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
       //Update on layout change
       setSize(constraints.maxWidth, constraints.maxHeight);
 
-      if (options.bounds != null && !_hasFitInitialBounds && constraints.maxWidth != 0.0) {
-        final target = getBoundsCenterZoom(options.bounds!, options.boundsOptions);
+      if (options.bounds != null &&
+          !_hasFitInitialBounds &&
+          constraints.maxWidth != 0.0) {
+        final target =
+            getBoundsCenterZoom(options.bounds!, options.boundsOptions);
         _zoom = target.zoom;
         _center = target.center;
         _hasFitInitialBounds = true;

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -162,7 +162,7 @@ class FlutterMapState extends MapGestureMixin
       //Update on layout change
       setSize(constraints.maxWidth, constraints.maxHeight);
 
-      if (options.bounds != null && !_hasFitInitialBounds) {
+      if (options.bounds != null && !_hasFitInitialBounds && constraints.maxWidth != 0.0) {
         final target = getBoundsCenterZoom(options.bounds!, options.boundsOptions);
         _zoom = target.zoom;
         _center = target.center;


### PR DESCRIPTION
fitbounds doesn't work on initial frame when its on a fast device as it tries to display before it can get a size of the device, due to the nature of a layout builder. This tries to rectify one of the checks to toggle when a size is available for bounds checking.

Please test this thoroughly on mobile and on web. Pay especial attention for first frame adjustment flicker that could be annoying, checking that bounds in MapOptions behaves correctly.