### PR TITLE
Delete unused and broken LatLngBounds.pad() method.

### DIFF
--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -172,15 +172,6 @@ class LatLngBounds {
     return true;
   }
 
-  /// Expands bounds by decimal degrees unlike [extend] or [extendBounds]
-  void pad(double bufferRatio) {
-    final heightBuffer = (_sw!.latitude - _ne!.latitude).abs() * bufferRatio;
-    final widthBuffer = (_sw!.longitude - _ne!.longitude).abs() * bufferRatio;
-
-    _sw = LatLng(_sw!.latitude - heightBuffer, _sw!.longitude - widthBuffer);
-    _ne = LatLng(_ne!.latitude + heightBuffer, _ne!.longitude + widthBuffer);
-  }
-
   @override
   int get hashCode => _sw.hashCode + _ne.hashCode;
 


### PR DESCRIPTION
The method fails to deal correctly with LatLng wrap arounds. A more correct version would probably look more like:

    void pad(double bufferRatio) {
      final heightBuffer = (_sw!.latitude - _ne!.latitude).abs() * bufferRatio;
      final widthBuffer = (_sw!.longitude - _ne!.longitude).abs() * bufferRatio;

      final point1 = LatLng((90 + _sw!.latitude - heightBuffer) % 180 - 90,
          (180 + _sw!.longitude - widthBuffer) % 360 - 180);
      final point2 = LatLng((90 + _ne!.latitude + heightBuffer) % 180 - 90,
          (180 + _ne!.longitude + widthBuffer) % 360 - 180);

      final newBounds = LatLngBounds(point1, point2);
      _sw = newBounds.southWest;
      _ne = newBounds.northEast;
    }

On a tangent, it probably should be a factory rather than a mutable method and the `bufferRatio` parameter is hard to use correctly. For example, bufferRatio = 0.5 would increase the bounds to 4 times its original size.