### PR TITLE
rotate about gesture center

### DIFF
--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -474,6 +474,12 @@ abstract class MapGestureMixin extends State<FlutterMap>
 
             if (_rotationStarted) {
               final rotationDiff = currentRotation - _lastRotation;
+              final oldCenterPt = mapState.project(mapState.center);
+              final rotationCenter  = mapState.project(_offsetToCrs(_lastFocalLocal));
+              final vector = oldCenterPt - rotationCenter;
+              final rotatedVector = vector.rotate(degToRadian(rotationDiff));
+              final newCenter = rotationCenter + rotatedVector;
+              mapMoved = mapState.move(mapState.unproject(newCenter), mapState.zoom, source: eventSource) || mapMoved;
               mapRotated = mapState.rotate(
                 mapState.rotation + rotationDiff,
                 hasGesture: true,


### PR DESCRIPTION
Currently, when rotating via pinch gesture, the map would rotate about the map center. The purpose of this PR is to change this behavior to rotate about the center of the gesture instead.
This has only been tested with a previous version of flutter_map, as it is quite the hassle to get a fork to work locally because you have to change all the imports (at least I didn't find another way) ,which I didn't want to do again for version 3.0.0. So please test before merging.
I didn't add an option for the behavior, as I think it is generally expected to work like this. I can add it though, if required.