### PR TITLE
renaming "add pins" in drawer to match file

### DIFF
--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -89,7 +89,7 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
         ),
         _buildMenuItem(
           context,
-          const Text('Add Pins'),
+          const Text('Tap to Add Pins'),
           TapToAddPage.route,
           currentRoute,
         ),


### PR DESCRIPTION
Tiny change to the drawer naming of `tap_to_add.dart` to match the file's App Bar. I believe this makes it easier to find the file within the example's `lib` directory after browsing through a built version of the Example.