### PR TITLE
Batch canvas draw operations and minimize redraws on map pans for the polygon and polyline layers to significantly improve performance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [3.2.0] - 2022/02/XX
+
+Contains the following additions/removals:
+
+- Removed `LatLngBounds.pad` (unused and broken) method - [#1427](https://github.com/fleaflet/flutter_map/pull/1427)
+- Migrated `LatLngBounds` to proper null safety - [#1431](https://github.com/fleaflet/flutter_map/pull/1431)
+- Minor example application improvements - [#1440](https://github.com/fleaflet/flutter_map/pull/1440)
+
+Contains the following bug fixes:
+
+- Fixed deprecations - [#1438](https://github.com/fleaflet/flutter_map/pull/1438)
+
+Many thanks to these contributors (in no particular order):
+
+- @pablojimpas
+- @augustweinbren
+- @ignatz
+- ... and all the maintainers
+
 ## [3.1.0] - 2022/12/21
 
 Contains the following additions/removals:

--- a/example/lib/pages/polygon.dart
+++ b/example/lib/pages/polygon.dart
@@ -49,6 +49,20 @@ class PolygonPage extends StatelessWidget {
       LatLng(59.77, -10.28),
     ];
 
+    final holeOuterPoints = <LatLng>[
+      LatLng(50.0, -18.0),
+      LatLng(50.0, -14.0),
+      LatLng(54.0, -14.0),
+      LatLng(54.0, -18.0),
+    ];
+
+    final holeInnerPoints = <LatLng>[
+      LatLng(51.0, -17.0),
+      LatLng(51.0, -16.0),
+      LatLng(52.0, -16.0),
+      LatLng(52.0, -17.0),
+    ];
+
     return Scaffold(
       appBar: AppBar(title: const Text('Polygons')),
       drawer: buildDrawer(context, PolygonPage.route),
@@ -92,6 +106,7 @@ class PolygonPage extends StatelessWidget {
                       isDotted: true,
                       borderColor: Colors.green,
                       borderStrokeWidth: 4,
+                      color: Colors.yellow,
                     ),
                     Polygon(
                       points: filledDotedPoints,
@@ -99,7 +114,7 @@ class PolygonPage extends StatelessWidget {
                       isDotted: true,
                       borderStrokeWidth: 4,
                       borderColor: Colors.lightBlue,
-                      color: Colors.lightBlue,
+                      color: Colors.yellow,
                     ),
                     Polygon(
                       points: labelPoints,
@@ -108,11 +123,20 @@ class PolygonPage extends StatelessWidget {
                       label: "Label!",
                     ),
                     Polygon(
-                        points: labelRotatedPoints,
-                        borderStrokeWidth: 4,
-                        borderColor: Colors.purple,
-                        label: "Rotated!",
-                        rotateLabel: true),
+                      points: labelRotatedPoints,
+                      borderStrokeWidth: 4,
+                      borderColor: Colors.purple,
+                      label: "Rotated!",
+                      rotateLabel: true,
+                    ),
+                    Polygon(
+                      points: holeOuterPoints,
+                      //holePointsList: [],
+                      holePointsList: [holeInnerPoints],
+                      borderStrokeWidth: 4,
+                      borderColor: Colors.green,
+                      color: Colors.pink.withOpacity(0.5),
+                    ),
                   ]),
                 ],
               ),

--- a/example/lib/pages/polygon.dart
+++ b/example/lib/pages/polygon.dart
@@ -43,24 +43,25 @@ class PolygonPage extends StatelessWidget {
     ];
 
     final labelRotatedPoints = <LatLng>[
+      LatLng(59.77, -10.28),
       LatLng(58.21, -10.28),
       LatLng(58.21, -7.01),
       LatLng(59.77, -7.01),
-      LatLng(59.77, -10.28),
+      LatLng(60.77, -6.01),
     ];
 
     final holeOuterPoints = <LatLng>[
-      LatLng(50.0, -18.0),
-      LatLng(50.0, -14.0),
-      LatLng(54.0, -14.0),
-      LatLng(54.0, -18.0),
+      LatLng(50, -18),
+      LatLng(50, -14),
+      LatLng(54, -14),
+      LatLng(54, -18),
     ];
 
     final holeInnerPoints = <LatLng>[
-      LatLng(51.0, -17.0),
-      LatLng(51.0, -16.0),
-      LatLng(52.0, -16.0),
-      LatLng(52.0, -17.0),
+      LatLng(51, -17),
+      LatLng(51, -16),
+      LatLng(52, -16),
+      LatLng(52, -17),
     ];
 
     return Scaffold(

--- a/example/lib/pages/polyline.dart
+++ b/example/lib/pages/polyline.dart
@@ -23,7 +23,7 @@ class _PolylinePageState extends State<PolylinePage> {
           LatLng(51.3498, -6.2603),
           LatLng(53.8566, 2.3522),
         ],
-        strokeWidth: 4,
+        strokeWidth: 50,
         color: Colors.amber,
       ),
     ];

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -333,10 +333,13 @@ class MapOptions {
 class FitBoundsOptions {
   final EdgeInsets padding;
   final double maxZoom;
-  @Deprecated(
-      'This property is unused and will be removed in the next major release.')
 
-  /// TODO: remove this property in the next major release.
+  /// This property is deprecated and unused internally. It will be removed in a
+  /// future major update
+  // TODO: remove this property
+  @Deprecated(
+    'This property is unused internally and will be removed in a future major update',
+  )
   final double? zoom;
   final bool inside;
 

--- a/lib/src/layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:ui' as ui;
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -12,11 +13,9 @@ enum PolygonLabelPlacement {
 }
 
 class Polygon {
-  final Key? key;
   final List<LatLng> points;
-  final List<Offset> offsets = [];
   final List<List<LatLng>>? holePointsList;
-  final List<List<Offset>>? holeOffsetsList;
+
   final Color color;
   final double borderStrokeWidth;
   final Color borderColor;
@@ -25,15 +24,19 @@ class Polygon {
   final bool isFilled;
   final StrokeCap strokeCap;
   final StrokeJoin strokeJoin;
-  late final LatLngBounds boundingBox;
   final String? label;
   final TextStyle labelStyle;
   final PolygonLabelPlacement labelPlacement;
   final bool rotateLabel;
 
+  LatLngBounds? _boundingBox;
+  LatLngBounds get boundingBox {
+    _boundingBox ??= LatLngBounds.fromPoints(points);
+    return _boundingBox!;
+  }
+
   Polygon({
     required this.points,
-    this.key,
     this.holePointsList,
     this.color = const Color(0xFF00FF00),
     this.borderStrokeWidth = 0.0,
@@ -47,9 +50,19 @@ class Polygon {
     this.labelStyle = const TextStyle(),
     this.labelPlacement = PolygonLabelPlacement.centroid,
     this.rotateLabel = false,
-  }) : holeOffsetsList = null == holePointsList || holePointsList.isEmpty
-            ? null
-            : List.generate(holePointsList.length, (_) => []);
+  });
+
+  /// Used to batch draw calls to the canvas.
+  int get renderHashCode => Object.hash(
+      holePointsList?.length ?? 0,
+      color,
+      borderStrokeWidth,
+      borderColor,
+      isDotted,
+      isFilled,
+      strokeCap,
+      strokeJoin,
+      labelStyle);
 }
 
 class PolygonLayer extends StatelessWidget {
@@ -58,133 +71,169 @@ class PolygonLayer extends StatelessWidget {
   /// screen space culling of polygons based on bounding box
   final bool polygonCulling;
 
-  PolygonLayer({
+  const PolygonLayer({
     super.key,
     this.polygons = const [],
     this.polygonCulling = false,
-  }) {
-    if (polygonCulling) {
-      for (final polygon in polygons) {
-        polygon.boundingBox = LatLngBounds.fromPoints(polygon.points);
-      }
-    }
-  }
+  });
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints bc) {
-        final map = FlutterMapState.maybeOf(context)!;
         final size = Size(bc.maxWidth, bc.maxHeight);
-        final polygonsWidget = <Widget>[];
+        final map = FlutterMapState.maybeOf(context)!;
 
-        for (final polygon in polygons) {
-          polygon.offsets.clear();
+        final Iterable<Polygon> pgons = polygonCulling
+            ? polygons.where((p) {
+                return p.boundingBox.isOverlapping(map.bounds);
+              })
+            : polygons;
 
-          if (null != polygon.holeOffsetsList) {
-            for (final offsets in polygon.holeOffsetsList!) {
-              offsets.clear();
-            }
-          }
-
-          if (polygonCulling &&
-              !polygon.boundingBox.isOverlapping(map.bounds)) {
-            // skip this polygon as it's offscreen
-            continue;
-          }
-
-          _fillOffsets(polygon.offsets, polygon.points, map);
-
-          if (null != polygon.holePointsList) {
-            final len = polygon.holePointsList!.length;
-            for (var i = 0; i < len; ++i) {
-              _fillOffsets(
-                  polygon.holeOffsetsList![i], polygon.holePointsList![i], map);
-            }
-          }
-
-          polygonsWidget.add(
-            CustomPaint(
-              key: polygon.key,
-              painter: PolygonPainter(polygon, map.rotationRad),
-              size: size,
-            ),
-          );
-        }
-
-        return Stack(
-          children: polygonsWidget,
+        return CustomPaint(
+          key: UniqueKey(),
+          painter: PolygonPainter(pgons, map),
+          size: size,
         );
       },
     );
   }
-
-  void _fillOffsets(final List<Offset> offsets, final List<LatLng> points,
-      FlutterMapState map) {
-    final len = points.length;
-    for (var i = 0; i < len; ++i) {
-      final point = points[i];
-      final offset = map.getOffsetFromOrigin(point);
-      offsets.add(offset);
-    }
-  }
 }
 
 class PolygonPainter extends CustomPainter {
-  final Polygon polygonOpt;
-  final double rotationRad;
+  final Iterable<Polygon> polygons;
+  final FlutterMapState map;
 
-  PolygonPainter(this.polygonOpt, this.rotationRad);
+  const PolygonPainter(this.polygons, this.map);
 
   @override
   void paint(Canvas canvas, Size size) {
-    if (polygonOpt.offsets.isEmpty) {
-      return;
-    }
     final rect = Offset.zero & size;
-    _paintPolygon(canvas, rect);
-  }
 
-  void _paintBorder(Canvas canvas) {
-    if (polygonOpt.borderStrokeWidth > 0.0) {
-      final borderPaint = Paint()
-        ..color = polygonOpt.borderColor
-        ..strokeWidth = polygonOpt.borderStrokeWidth;
+    var path = ui.Path();
+    var paint = Paint();
+    var borderPath = ui.Path();
+    Paint? borderPaint;
+    int? lastHash;
 
-      if (polygonOpt.isDotted) {
-        final borderRadius = (polygonOpt.borderStrokeWidth / 2);
+    void drawPaths() {
+      canvas.drawPath(path, paint);
+      path = ui.Path();
+      paint = Paint();
 
-        final spacing = polygonOpt.borderStrokeWidth * 1.5;
-        _paintDottedLine(
-            canvas, polygonOpt.offsets, borderRadius, spacing, borderPaint);
+      if (borderPaint != null) {
+        canvas.drawPath(borderPath, borderPaint!);
+        borderPath = ui.Path();
+        borderPaint = null;
+      }
+    }
 
-        if (!polygonOpt.disableHolesBorder &&
-            null != polygonOpt.holeOffsetsList) {
-          for (final offsets in polygonOpt.holeOffsetsList!) {
-            _paintDottedLine(
-                canvas, offsets, borderRadius, spacing, borderPaint);
-          }
+    for (final polygon in polygons) {
+      final offsets = _getOffsets(polygon.points, map);
+      if (offsets.isEmpty) {
+        continue;
+      }
+
+      final hash = polygon.renderHashCode;
+      if (lastHash != null && lastHash != hash) {
+        drawPaths();
+      }
+      lastHash = hash;
+
+      final holeOffsetsList = List<List<Offset>>.generate(
+          polygon.holePointsList?.length ?? 0,
+          (i) => _getOffsets(polygon.holePointsList![i], map));
+
+      if (holeOffsetsList.isEmpty) {
+        if (polygon.isFilled) {
+          paint = Paint()
+            ..style = PaintingStyle.fill
+            ..strokeWidth = polygon.borderStrokeWidth
+            ..strokeCap = polygon.strokeCap
+            ..strokeJoin = polygon.strokeJoin
+            ..color = polygon.isFilled ? polygon.color : polygon.borderColor;
+
+          path.addPolygon(offsets, true);
         }
       } else {
-        borderPaint
-          ..style = PaintingStyle.stroke
-          ..strokeCap = polygonOpt.strokeCap
-          ..strokeJoin = polygonOpt.strokeJoin;
+        paint = Paint()
+          ..style = PaintingStyle.fill
+          ..color = polygon.color;
 
-        _paintLine(canvas, polygonOpt.offsets, borderPaint);
+        // Ideally we'd use `Path.combine(PathOperation.difference, ...)`
+        // instead of evenOdd fill-type, however it creates visual artifacts
+        // using the web renderer.
+        path.fillType = PathFillType.evenOdd;
 
-        if (!polygonOpt.disableHolesBorder &&
-            null != polygonOpt.holeOffsetsList) {
-          for (final offsets in polygonOpt.holeOffsetsList!) {
-            _paintLine(canvas, offsets, borderPaint);
-          }
+        path.addPolygon(offsets, true);
+        for (final holeOffsets in holeOffsetsList) {
+          path.addPolygon(holeOffsets, true);
+        }
+      }
+
+      // Only draw the  border explicitly if it isn't alrady a stroke-style
+      // polygon.
+      if (polygon.borderStrokeWidth > 0.0) {
+        borderPaint = _getBorderPaint(polygon);
+        _paintBorder(borderPath, polygon, offsets, holeOffsetsList);
+      }
+
+      if (polygon.label != null) {
+        // Labels are expensive they mess with draw batching.
+        drawPaths();
+
+        Label.paintText(
+          canvas,
+          offsets,
+          polygon.label,
+          polygon.labelStyle,
+          map.rotationRad,
+          rotate: polygon.rotateLabel,
+          labelPlacement: polygon.labelPlacement,
+        );
+      }
+    }
+
+    drawPaths();
+    canvas.clipRect(rect);
+  }
+
+  Paint _getBorderPaint(Polygon polygon) {
+    final isDotted = polygon.isDotted;
+    return Paint()
+      ..color = polygon.borderColor
+      ..strokeWidth = polygon.borderStrokeWidth
+      ..strokeCap = polygon.strokeCap
+      ..strokeJoin = polygon.strokeJoin
+      ..style = isDotted ? PaintingStyle.fill : PaintingStyle.stroke;
+  }
+
+  void _paintBorder(ui.Path path, Polygon polygon, List<Offset> offsets,
+      List<List<Offset>> holeOffsetsList) {
+    if (polygon.isDotted) {
+      final borderRadius = (polygon.borderStrokeWidth / 2);
+      final spacing = polygon.borderStrokeWidth * 1.5;
+
+      _paintDottedLine(path, offsets, borderRadius, spacing);
+
+      if (!polygon.disableHolesBorder) {
+        for (final offsets in holeOffsetsList) {
+          _paintDottedLine(path, offsets, borderRadius, spacing);
+        }
+      }
+    } else {
+      _paintLine(path, offsets);
+
+      if (!polygon.disableHolesBorder) {
+        for (final offsets in holeOffsetsList) {
+          _paintLine(path, offsets);
         }
       }
     }
   }
 
-  void _paintDottedLine(Canvas canvas, List<Offset> offsets, double radius,
-      double stepLength, Paint paint) {
+  void _paintDottedLine(
+      ui.Path path, List<Offset> offsets, double radius, double stepLength) {
     var startDistance = 0.0;
     for (var i = 0; i < offsets.length; i++) {
       final o0 = offsets[i % offsets.length];
@@ -195,87 +244,35 @@ class PolygonPainter extends CustomPainter {
         final f1 = distance / totalDistance;
         final f0 = 1.0 - f1;
         final offset = Offset(o0.dx * f0 + o1.dx * f1, o0.dy * f0 + o1.dy * f1);
-        canvas.drawCircle(offset, radius, paint);
+        path.addOval(Rect.fromCircle(center: offset, radius: radius));
         distance += stepLength;
       }
       startDistance = distance < totalDistance
           ? stepLength - (totalDistance - distance)
           : distance - totalDistance;
     }
-    canvas.drawCircle(offsets.last, radius, paint);
+    path.addOval(Rect.fromCircle(center: offsets.last, radius: radius));
   }
 
-  void _paintLine(Canvas canvas, List<Offset> offsets, Paint paint) {
+  void _paintLine(ui.Path path, List<Offset> offsets) {
     if (offsets.isEmpty) {
       return;
     }
-    final path = Path()..addPolygon(offsets, true);
-    canvas.drawPath(path, paint);
-  }
-
-  void _paintPolygon(Canvas canvas, Rect rect) {
-    final paint = Paint();
-
-    if (null != polygonOpt.holeOffsetsList) {
-      canvas.saveLayer(rect, paint);
-      paint.style = PaintingStyle.fill;
-
-      for (final offsets in polygonOpt.holeOffsetsList!) {
-        final path = Path();
-        path.addPolygon(offsets, true);
-        canvas.drawPath(path, paint);
-      }
-
-      paint
-        ..color = polygonOpt.color
-        ..blendMode = BlendMode.srcOut;
-
-      final path = Path();
-      path.addPolygon(polygonOpt.offsets, true);
-      canvas.drawPath(path, paint);
-
-      _paintBorder(canvas);
-
-      canvas.restore();
-    } else {
-      canvas.clipRect(rect);
-      paint
-        ..style =
-            polygonOpt.isFilled ? PaintingStyle.fill : PaintingStyle.stroke
-        ..color = polygonOpt.color;
-
-      final path = Path();
-      path.addPolygon(polygonOpt.offsets, true);
-      canvas.drawPath(path, paint);
-
-      _paintBorder(canvas);
-
-      if (polygonOpt.label != null) {
-        Label.paintText(
-          canvas,
-          polygonOpt.offsets,
-          polygonOpt.label,
-          polygonOpt.labelStyle,
-          rotationRad,
-          rotate: polygonOpt.rotateLabel,
-          labelPlacement: polygonOpt.labelPlacement,
-        );
-      }
-    }
+    path.addPolygon(offsets, true);
   }
 
   @override
-  bool shouldRepaint(PolygonPainter oldDelegate) => false;
+  bool shouldRepaint(PolygonPainter oldDelegate) => true;
+}
 
-  double _dist(Offset v, Offset w) {
-    return sqrt(_dist2(v, w));
-  }
+List<Offset> _getOffsets(List<LatLng> points, FlutterMapState map) {
+  return points.map((pos) => map.getOffsetFromOrigin(pos)).toList();
+}
 
-  double _dist2(Offset v, Offset w) {
-    return _sqr(v.dx - w.dx) + _sqr(v.dy - w.dy);
-  }
+double _dist(Offset v, Offset w) {
+  return sqrt(_sqr(v.dx - w.dx) + _sqr(v.dy - w.dy));
+}
 
-  double _sqr(double x) {
-    return x * x;
-  }
+double _sqr(double x) {
+  return x * x;
 }

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -1,4 +1,3 @@
-import 'dart:math';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -93,7 +92,6 @@ class PolylineLayer extends StatelessWidget {
     final paint = CustomPaint(
       painter: PolylinePainter(lines, saveLayers, map),
       size: size,
-      willChange: false,
       isComplex: true,
     );
 
@@ -130,7 +128,9 @@ class PolylinePainter extends CustomPainter {
   int? _hash;
 
   List<Offset> getOffsets(List<LatLng> points) {
-    return points.map((pos) => getOffset(pos)).toList();
+    return List.generate(points.length, (index) {
+      return getOffset(points[index]);
+    }, growable: false);
   }
 
   Offset getOffset(LatLng point) {
@@ -262,7 +262,7 @@ class PolylinePainter extends CustomPainter {
     for (var i = 0; i < offsets.length - 1; i++) {
       final o0 = offsets[i];
       final o1 = offsets[i + 1];
-      final totalDistance = _dist(o0, o1);
+      final totalDistance = (o0 - o1).distance;
       var distance = startDistance;
       while (distance < totalDistance) {
         final f1 = distance / totalDistance;
@@ -311,12 +311,4 @@ class PolylinePainter extends CustomPainter {
         oldDelegate.rotation != rotation ||
         oldDelegate.hash != hash;
   }
-}
-
-double _dist(Offset v, Offset w) {
-  return sqrt(_sqr(v.dx - w.dx) + _sqr(v.dy - w.dy));
-}
-
-double _sqr(double x) {
-  return x * x;
 }

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -352,9 +352,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     if (widget.reset != null) {
       _resetSub = widget.reset?.listen((_) => _resetTiles());
     }
-
-    //TODO fix
-    // _initThrottleUpdate();
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_map
 description: A versatile mapping package for Flutter, based off leaflet.js,
   that's simple and easy to learn, yet completely customizable and configurable.
-version: 3.1.0
+version: 3.2.0
 repository: https://github.com/fleaflet/flutter_map
 issue_tracker: https://github.com/fleaflet/flutter_map/issues
 documentation: https://docs.fleaflet.dev

--- a/test/layer/polygon_layer_test.dart
+++ b/test/layer/polygon_layer_test.dart
@@ -9,27 +9,32 @@ import '../test_utils/test_app.dart';
 void main() {
   setupMocks();
 
-  testWidgets('test polygon key', (tester) async {
-    final filledPoints = <LatLng>[
-      LatLng(55.5, -0.09),
-      LatLng(54.3498, -6.2603),
-      LatLng(52.8566, 2.3522),
+  testWidgets('test polygon layer', (tester) async {
+    final polygons = <Polygon>[
+      for (int i = 0; i < 1; ++i)
+        Polygon(
+          isFilled: true,
+          color: Colors.purple,
+          borderColor: Colors.purple,
+          borderStrokeWidth: 4,
+          label: '$i',
+          points: <LatLng>[
+            LatLng(55.5, -0.09),
+            LatLng(54.3498, -6.2603),
+            LatLng(52.8566, 2.3522),
+          ],
+        ),
     ];
 
-    const key = Key('p-1');
-
-    final polygon = Polygon(
-      key: key,
-      points: filledPoints,
-      isFilled: true,
-      color: Colors.purple,
-      borderColor: Colors.purple,
-      borderStrokeWidth: 4,
-    );
-
-    await tester.pumpWidget(TestApp(polygons: [polygon]));
+    await tester.pumpWidget(TestApp(polygons: polygons));
     expect(find.byType(FlutterMap), findsOneWidget);
     expect(find.byType(PolygonLayer), findsOneWidget);
-    expect(find.byKey(key), findsOneWidget);
+
+    // Assert that batching works and all polygons are drawn into the same
+    // CustomPaint/Canvas.
+    expect(
+        find.descendant(
+            of: find.byType(PolygonLayer), matching: find.byType(CustomPaint)),
+        findsOneWidget);
   });
 }

--- a/test/layer/polyline_layer_test.dart
+++ b/test/layer/polyline_layer_test.dart
@@ -9,25 +9,29 @@ import '../test_utils/test_app.dart';
 void main() {
   setupMocks();
 
-  testWidgets('test polyline key', (tester) async {
-    const key = Key('p-1');
-
+  testWidgets('test polyline layer', (tester) async {
     final polylines = <Polyline>[
-      Polyline(
-        key: key,
-        points: [
-          LatLng(50.5, -0.09),
-          LatLng(51.3498, -6.2603),
-          LatLng(53.8566, 2.3522),
-        ],
-        strokeWidth: 4,
-        color: Colors.amber,
-      ),
+      for (int i = 0; i < 10; i++)
+        Polyline(
+          points: [
+            LatLng(50.5 + i, -0.09),
+            LatLng(51.3498 + i, -6.2603),
+            LatLng(53.8566 + i, 2.3522),
+          ],
+          strokeWidth: 4,
+          color: Colors.amber,
+        ),
     ];
 
     await tester.pumpWidget(TestApp(polylines: polylines));
     expect(find.byType(FlutterMap), findsOneWidget);
     expect(find.byType(PolylineLayer), findsWidgets);
-    expect(find.byKey(key), findsOneWidget);
+
+    // Assert that batching works and all Polylines are drawn into the same
+    // CustomPaint/Canvas.
+    expect(
+        find.descendant(
+            of: find.byType(PolylineLayer), matching: find.byType(CustomPaint)),
+        findsOneWidget);
   });
 }


### PR DESCRIPTION
The batching is based on @MooNag 's proposal.

Based on a makeshift benchmark and my phone, I'm seeing:

* On the raster thread:
  * max: 2521ms => 8ms  (314x improvement)
  * avg: 1219ms => 6ms  (202x improvement)
* On the UI thread:
  * max: 49.6ms => 3.6ms (12.7x improvement)
  * avg: 19.2ms => 2.0ms (8.6x improvement)

* Before: 
![image](https://user-images.githubusercontent.com/111986/216788198-516f9fe1-9487-4ff3-97ad-b220c22af9d2.png)
* After: 
![image](https://user-images.githubusercontent.com/111986/216788215-34937987-a3c4-47a1-937e-ec9f95a43d7a.png)


