### PR TITLE
Prevent double scrolling

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '11.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -56,20 +56,26 @@ abstract class MapGestureMixin extends State<FlutterMap>
     if (pointerSignal is PointerScrollEvent &&
         mapState.options.enableScrollWheel &&
         pointerSignal.scrollDelta.dy != 0) {
-      // Calculate new zoom level
-      final minZoom = mapState.options.minZoom ?? 0.0;
-      final maxZoom = mapState.options.maxZoom ?? double.infinity;
-      final newZoom = (mapState.zoom -
-              pointerSignal.scrollDelta.dy *
-                  mapState.options.scrollWheelVelocity)
-          .clamp(minZoom, maxZoom);
-      // Calculate offset of mouse cursor from viewport center
-      final List<dynamic> newCenterZoom = _getNewEventCenterZoomPosition(
-          _offsetToPoint(pointerSignal.localPosition), newZoom);
+      // Prevent scrolling of parent/child widgets simultaneously. See
+      // [PointerSignalResolver] documentation for more information.
+      GestureBinding.instance.pointerSignalResolver.register(pointerSignal,
+          (pointerSignal) {
+        pointerSignal as PointerScrollEvent;
 
-      // Move to new center and zoom level
-      mapState.move(newCenterZoom[0] as LatLng, newCenterZoom[1] as double,
-          source: MapEventSource.scrollWheel);
+        final minZoom = mapState.options.minZoom ?? 0.0;
+        final maxZoom = mapState.options.maxZoom ?? double.infinity;
+        final newZoom = (mapState.zoom -
+                pointerSignal.scrollDelta.dy *
+                    mapState.options.scrollWheelVelocity)
+            .clamp(minZoom, maxZoom);
+        // Calculate offset of mouse cursor from viewport center
+        final List<dynamic> newCenterZoom = _getNewEventCenterZoomPosition(
+            _offsetToPoint(pointerSignal.localPosition), newZoom);
+
+        // Move to new center and zoom level
+        mapState.move(newCenterZoom[0] as LatLng, newCenterZoom[1] as double,
+            source: MapEventSource.scrollWheel);
+      });
     }
   }
 


### PR DESCRIPTION
Before this change the `PointerScrollEvent` handler was not registered with `PointerSignalResolver` which meant that if scrolling was enabled for `FlutterMap` and it was within a scrollable widget or had a scrollable child widget then they would both be scrolled simultaneously. This is only noticeable on web since on mobile a drag gesture is used to scroll/pan instead of mouse scrolling.