### PR TITLE
Remove absorbPanEventsOnScrollables option

### DIFF
--- a/example/lib/pages/map_inside_listview.dart
+++ b/example/lib/pages/map_inside_listview.dart
@@ -23,7 +23,6 @@ class MapInsideListViewPage extends StatelessWidget {
               height: 300,
               child: FlutterMap(
                 options: MapOptions(
-                  absorbPanEventsOnScrollables: true,
                   center: LatLng(51.5, -0.09),
                   zoom: 5,
                 ),

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -251,8 +251,6 @@ class MapOptions {
   /// see [InteractiveFlag] for custom settings
   final int interactiveFlags;
 
-  final bool absorbPanEventsOnScrollables;
-
   final TapCallback? onTap;
   final TapCallback? onSecondaryTap;
   final LongPressCallback? onLongPress;
@@ -293,7 +291,6 @@ class MapOptions {
   final bool keepAlive;
 
   MapOptions({
-    this.absorbPanEventsOnScrollables = true,
     this.crs = const Epsg3857(),
     LatLng? center,
     this.bounds,

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -113,9 +113,8 @@ class FlutterMapState extends MapGestureMixin
       },
     );
 
-    if (options.absorbPanEventsOnScrollables &&
-        InteractiveFlag.hasFlag(
-            options.interactiveFlags, InteractiveFlag.drag)) {
+    if (InteractiveFlag.hasFlag(
+        options.interactiveFlags, InteractiveFlag.drag)) {
       gestures[VerticalDragGestureRecognizer] =
           GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
         () => VerticalDragGestureRecognizer(debugOwner: this),

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -1,13 +1,14 @@
+import 'dart:math' as math;
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/core/bounds.dart';
 import 'package:flutter_map/src/gestures/gestures.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:flutter_map/src/map/map_state_widget.dart';
 import 'package:latlong2/latlong.dart';
-import 'dart:math' as math;
-import 'package:flutter_map/src/core/bounds.dart';
 
 class FlutterMapState extends MapGestureMixin
     with AutomaticKeepAliveClientMixin {
@@ -72,14 +73,6 @@ class FlutterMapState extends MapGestureMixin
           ..onTap = _positionedTapController.onTap
           ..onSecondaryTap = _positionedTapController.onSecondaryTap
           ..onSecondaryTapDown = _positionedTapController.onTapDown;
-        // ..onTapCancel = onTapCancel
-        // ..onSecondaryTapUp = onSecondaryTapUp
-        // ..onSecondaryTapCancel = onSecondaryTapCancel
-        // ..onTertiaryTapDown = onTertiaryTapDown
-        // ..onTertiaryTapUp = onTertiaryTapUp
-        // ..onTertiaryTapCancel = onTertiaryTapCancel
-        // ..gestureSettings = gestureSettings;
-        // instance.team = _team;
       },
     );
 
@@ -88,28 +81,6 @@ class FlutterMapState extends MapGestureMixin
       () => LongPressGestureRecognizer(debugOwner: this),
       (LongPressGestureRecognizer instance) {
         instance.onLongPress = _positionedTapController.onLongPress;
-        // ..onLongPressDown = onLongPressDown
-        // ..onLongPressCancel = onLongPressCancel
-        // ..onLongPressStart = onLongPressStart
-        // ..onLongPressMoveUpdate = onLongPressMoveUpdate
-        // ..onLongPressUp = onLongPressUp
-        // ..onLongPressEnd = onLongPressEnd
-        // ..onSecondaryLongPressDown = onSecondaryLongPressDown
-        // ..onSecondaryLongPressCancel = onSecondaryLongPressCancel
-        // ..onSecondaryLongPress = onSecondaryLongPress
-        // ..onSecondaryLongPressStart = onSecondaryLongPressStart
-        // ..onSecondaryLongPressMoveUpdate = onSecondaryLongPressMoveUpdate
-        // ..onSecondaryLongPressUp = onSecondaryLongPressUp
-        // ..onSecondaryLongPressEnd = onSecondaryLongPressEnd
-        // ..onTertiaryLongPressDown = onTertiaryLongPressDown
-        // ..onTertiaryLongPressCancel = onTertiaryLongPressCancel
-        // ..onTertiaryLongPress = onTertiaryLongPress
-        // ..onTertiaryLongPressStart = onTertiaryLongPressStart
-        // ..onTertiaryLongPressMoveUpdate = onTertiaryLongPressMoveUpdate
-        // ..onTertiaryLongPressUp = onTertiaryLongPressUp
-        // ..onTertiaryLongPressEnd = onTertiaryLongPressEnd
-        // ..gestureSettings = gestureSettings;
-        // instance.team = _team;
       },
     );
 
@@ -120,9 +91,8 @@ class FlutterMapState extends MapGestureMixin
         () => VerticalDragGestureRecognizer(debugOwner: this),
         (VerticalDragGestureRecognizer instance) {
           instance.onUpdate = (details) {
-            //Absorbing vertical drags
+            // Absorbing vertical drags
           };
-          // ..dragStartBehavior = dragStartBehavior
           instance.gestureSettings = gestureSettings;
           instance.team ??= _team;
         },
@@ -132,9 +102,8 @@ class FlutterMapState extends MapGestureMixin
         () => HorizontalDragGestureRecognizer(debugOwner: this),
         (HorizontalDragGestureRecognizer instance) {
           instance.onUpdate = (details) {
-            //Absorbing horizontal drags
+            // Absorbing horizontal drags
           };
-          // ..dragStartBehavior = dragStartBehavior
           instance.gestureSettings = gestureSettings;
           instance.team ??= _team;
         },


### PR DESCRIPTION
The only reason to disable absorbing of pan events is because some plugins which use drag gestures rely on it. It turns out if those plugins detect vertical/horizontal drag instead of pan this flag is not necessary.

Note that affected plugins need to be updated and this should be released in a major version bump as it is a breaking change.

See #1454 discussion leading to this PR.

## Before releasing

- [ ] Notify affected plugin authors of the required change.
- [ ] Create new major version with changelog entry to describe how other plugins must migrate.

## Understanding more

- When `absorbPanEventsOnScrollables` is true a horizontal & vertical drag gesture detector are added to FlutterMap and if they are triggered FlutterMap's scale gesture logic is triggered since the vertical/horizontal drag gesture and scale gesture are in the same `GestureArenaTeam` and the scale gesture is the captain of that team. Horizontal/vertical drag gestures are recognised faster than scale/pan gestures and therefore when there are competing gestures they will prevail.
- [Scrollable Flutter widgets detect horizontal/vertical drag gestures](https://github.com/flutter/flutter/blob/12cb4eb7a009f52b347b62ade7cb4854b926af72/packages/flutter/lib/src/widgets/scrollable.dart#L622-L662) which is why FlutterMap needs to detect them and then defer to its scale gesture if it wants to be pannable inside of a ListView.
- `flutter_map_dragmarker` and likely other plugins detect pan gestures instead of horizontal/vertical drag gestures. This means that when `absorbPanEventsOnScrollables` is enabled those plugins don't work because FlutterMap's horizontal/vertical drag gestures have precedence. This is a simple fix, affected code should listen to `onVerticalDrag(Start/Update/End)` and `onHorizontalDrag(Start/Update/End)` instead of `onPan(Start/Update/End)`.

## Demo

With `absabsorbPanEventsOnScrollables` removed such that horizontal/vertical gestures are always detected in FlutterMap (see this PR's code changes) and a modified `flutter_map_dragmarker` (detecting horizontal/vertical drag instead of pan) is used it is possible to have a pan-able FlutterMap inside of a ListView containing drag markers which can be dragged:


https://user-images.githubusercontent.com/3683599/222518631-4d350d44-eb50-4368-83a3-7a0a698312d3.mp4
