### PR TITLE
Normalize num type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [4.0.0] - 2022/04/XX
+## [4.0.0] - 2022/05/XX
 
 **"Out With The Old, In With The New"**
 
@@ -22,6 +22,7 @@ Contains the following bug fixes:
 - Prevented scrolling of list and simultaneous panning of map on some platforms - [#1453](https://github.com/fleaflet/flutter_map/pull/1453)
 - Improved `LatLngBounds`'s null safety situation to improve stability - [#1431](https://github.com/fleaflet/flutter_map/pull/1431)
 - Migrated from multiple deprecated APIs - [#1438](https://github.com/fleaflet/flutter_map/pull/1438)
+- Fixed size calculation bugs - [#1470](https://github.com/fleaflet/flutter_map/pull/1470)
 
 Contains the following performance and stability improvements:
 
@@ -30,11 +31,14 @@ Contains the following performance and stability improvements:
 
 Many thanks to these contributors (in no particular order):
 
-- @pablojimpas
-- @augustweinbren
-- @ignatz
 - @rorystephenson
+- @augustweinbren
 - @ianthetechie
+- @pablojimpas
+- @tlserver
+- @Zzerr0r
+- @dumabg
+- @ignatz
 - ... and all the maintainers
 
 And an additional special thanks to @rorystephenson & @ignatz for investing so much of their time into this project recently - we appreciate it!

--- a/example/lib/pages/custom_crs/custom_crs.dart
+++ b/example/lib/pages/custom_crs/custom_crs.dart
@@ -56,8 +56,8 @@ class _CustomCrsPageState extends State<CustomCrsPage> {
     ];
 
     final epsg3413Bounds = Bounds<double>(
-      const CustomPoint<double>(-4511619.0, -4511336.0),
-      const CustomPoint<double>(4510883.0, 4510996.0),
+      const CustomPoint<double>(-4511619, -4511336),
+      const CustomPoint<double>(4510883, 4510996),
     );
 
     maxZoom = (resolutions.length - 1).toDouble();

--- a/example/lib/pages/epsg3413_crs.dart
+++ b/example/lib/pages/epsg3413_crs.dart
@@ -37,8 +37,8 @@ class _EPSG3413PageState extends State<EPSG3413Page> {
     ];
 
     final epsg3413Bounds = Bounds<double>(
-      const CustomPoint<double>(-4511619.0, -4511336.0),
-      const CustomPoint<double>(4510883.0, 4510996.0),
+      const CustomPoint<double>(-4511619, -4511336),
+      const CustomPoint<double>(4510883, 4510996),
     );
 
     maxZoom = (resolutions.length - 1).toDouble();

--- a/example/lib/pages/latlng_to_screen_point.dart
+++ b/example/lib/pages/latlng_to_screen_point.dart
@@ -18,7 +18,7 @@ class LatLngScreenPointTestPage extends StatefulWidget {
 class _LatLngScreenPointTestPageState extends State<LatLngScreenPointTestPage> {
   late final MapController _mapController;
 
-  CustomPoint _textPos = const CustomPoint(10.0, 10.0);
+  CustomPoint<double> _textPos = const CustomPoint(10, 10);
 
   @override
   void initState() {

--- a/example/lib/pages/scale_layer_plugin_option.dart
+++ b/example/lib/pages/scale_layer_plugin_option.dart
@@ -63,7 +63,7 @@ class ScaleLayerWidget extends StatelessWidget {
     final displayDistance = distance > 999
         ? '${(distance / 1000).toStringAsFixed(0)} km'
         : '${distance.toStringAsFixed(0)} m';
-    final width = (end.x - (start.x as double));
+    final width = end.x - start.x;
 
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints bc) {
@@ -85,6 +85,7 @@ class ScaleLayerWidget extends StatelessWidget {
 class ScalePainter extends CustomPainter {
   ScalePainter(this.width, this.text,
       {this.padding, this.textStyle, this.lineWidth, this.lineColor});
+
   final double width;
   final EdgeInsets? padding;
   final String text;

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -143,7 +143,7 @@ abstract class MapController {
 
   LatLng? pointToLatLng(CustomPoint point);
 
-  CustomPoint? latLngToScreenPoint(LatLng latLng);
+  CustomPoint<double>? latLngToScreenPoint(LatLng latLng);
 
   factory MapController() => MapControllerImpl();
 }

--- a/lib/src/core/point.dart
+++ b/lib/src/core/point.dart
@@ -3,84 +3,86 @@ import 'dart:math' as math;
 /// Data represenation of point located on map instance
 /// where [x] is horizontal and [y] is vertical pixel value
 class CustomPoint<T extends num> extends math.Point<T> {
-  const CustomPoint(num x, num y) : super(x as T, y as T);
+  const CustomPoint(super.x, super.y);
 
-  /// Create new [CustomPoint] whose [x] and [y] values are divided by [factor]
-  CustomPoint<T> operator /(num /*T|int*/ factor) {
-    return CustomPoint<T>(x / factor, y / factor);
-  }
-
-  /// Create new [CustomPoint] whose [x] and [y] values are rounded up
-  /// to int
-  CustomPoint<T> ceil() {
-    return CustomPoint(x.ceil(), y.ceil());
-  }
-
-  /// Create new [CustomPoint] whose [x] and [y] values are rounded down
-  /// to int
-  CustomPoint<T> floor() {
-    return CustomPoint<T>(x.floor(), y.floor());
-  }
-
-  /// Create new [CustomPoint] whose [x] and [y] values are divided by
-  /// other [point] values
-  CustomPoint<T> unscaleBy(CustomPoint<T> point) {
-    return CustomPoint<T>(x / point.x, y / point.y);
-  }
-
-  /// Create new [CustomPoint] where [other] point values [x] and [y] are added
+  /// Create new [CustomPoint] where [x] and [y] values are added to [other]
+  /// point [x] and [y] values
   @override
-  CustomPoint<T> operator +(math.Point<T> other) {
-    return CustomPoint<T>(x + other.x, y + other.y);
+  CustomPoint<T> operator +(math.Point other) {
+    return CustomPoint<T>((x + other.x) as T, (y + other.y) as T);
   }
 
   /// Create new [CustomPoint] where [x] and [y] values are subtracted from
   /// [other] point [x] and [y] values
   @override
-  CustomPoint<T> operator -(math.Point<T> other) {
-    return CustomPoint<T>(x - other.x, y - other.y);
+  CustomPoint<T> operator -(math.Point other) {
+    return CustomPoint<T>((x - other.x) as T, (y - other.y) as T);
   }
 
-  /// Create new [CustomPoint] where [x] and [y] are multiplied by [factor]
+  /// Create new [CustomPoint] where [x] and [y] values are scaled by [point]
+  /// values
+  CustomPoint<T> scaleBy(CustomPoint<T> point) {
+    return CustomPoint<T>((x * point.x) as T, (y * point.y) as T);
+  }
+
+  /// Create new [CustomPoint] whose [x] and [y] values are divided by other
+  /// [point] values
+  CustomPoint<double> unscaleBy(CustomPoint<T> point) {
+    return CustomPoint<double>(x / point.x, y / point.y);
+  }
+
+  /// Create new [CustomPoint] where [x] and [y] values are multiplied by
+  /// [factor]
   @override
-  CustomPoint<T> operator *(num /*T|int*/ factor) {
-    return CustomPoint<T>((x * factor), (y * factor));
+  CustomPoint<T> operator *(num factor) {
+    return CustomPoint<T>((x * factor) as T, (y * factor) as T);
   }
 
-  /// Create new [CustomPoint] where [x] and [y] are scaled by [point] values
-  CustomPoint scaleBy(CustomPoint point) {
-    return CustomPoint(x * point.x, y * point.y);
+  /// Create new [CustomPoint] where [x] and [y] values are divided by [factor]
+  CustomPoint<T> operator /(num factor) {
+    return CustomPoint<T>((x / factor) as T, (y / factor) as T);
   }
 
   /// Create new [CustomPoint] where [x] and [y] is rounded to int
-  CustomPoint round() {
-    final x = this.x is double ? this.x.round() : this.x;
-    final y = this.y is double ? this.y.round() : this.y;
-    return CustomPoint(x, y);
+  CustomPoint<int> round() {
+    return CustomPoint<int>(x.round(), y.round());
   }
 
-  /// Create new [CustomPoint] with [x] and [y] multiplied by [n]
-  CustomPoint multiplyBy(num n) {
-    return CustomPoint(x * n, y * n);
+  /// Create new [CustomPoint] where [x] and [y] values are rounded up to int
+  CustomPoint<int> ceil() {
+    return CustomPoint<int>(x.ceil(), y.ceil());
+  }
+
+  /// Create new [CustomPoint] where [x] and [y] values are rounded down to int
+  CustomPoint<int> floor() {
+    return CustomPoint<int>(x.floor(), y.floor());
   }
 
   /// Create new [CustomPoint] whose [x] and [y] values are rotated by [radians]
   /// in clockwise fashion
-  CustomPoint rotate(num radians) {
+  CustomPoint<double> rotate(num radians) {
     if (radians != 0.0) {
       final cos = math.cos(radians);
       final sin = math.sin(radians);
       final nx = (cos * x) + (sin * y);
       final ny = (cos * y) - (sin * x);
 
-      return CustomPoint(nx, ny);
+      return CustomPoint<double>(nx, ny);
     }
 
-    return this;
+    return CustomPoint(x.toDouble(), y.toDouble());
   }
 
-  CustomPoint<U> cast<U extends num>() => CustomPoint<U>(x as U, y as U);
+  CustomPoint<int> toIntPoint() => CustomPoint<int>(x.toInt(), y.toInt());
+
+  CustomPoint<double> toDoublePoint() =>
+      CustomPoint<double>(x.toDouble(), y.toDouble());
 
   @override
   String toString() => 'CustomPoint ($x, $y)';
+
+  /// Create new [CustomPoint] with [x] and [y] multiplied by [n]
+  CustomPoint<T> multiplyBy(num n) {
+    return this * n;
+  }
 }

--- a/lib/src/geo/crs/crs.dart
+++ b/lib/src/geo/crs/crs.dart
@@ -23,7 +23,7 @@ abstract class Crs {
 
   /// Converts a point on the sphere surface (with a certain zoom) in a
   /// map point.
-  CustomPoint latLngToPoint(LatLng latlng, double zoom) {
+  CustomPoint<double> latLngToPoint(LatLng latlng, double zoom) {
     try {
       final projectedPoint = projection.project(latlng);
       final scale = this.scale(zoom);
@@ -236,7 +236,7 @@ class Proj4Crs extends Crs {
   /// Converts a point on the sphere surface (with a certain zoom) in a
   /// map point.
   @override
-  CustomPoint latLngToPoint(LatLng latlng, double zoom) {
+  CustomPoint<double> latLngToPoint(LatLng latlng, double zoom) {
     try {
       final projectedPoint = projection.project(latlng);
       final scale = this.scale(zoom);
@@ -346,7 +346,7 @@ abstract class Projection {
 
   Bounds<double>? get bounds;
 
-  CustomPoint project(LatLng latlng);
+  CustomPoint<double> project(LatLng latlng);
 
   LatLng unproject(CustomPoint point);
 
@@ -379,7 +379,7 @@ class _LonLat extends Projection {
   Bounds<double> get bounds => _bounds;
 
   @override
-  CustomPoint project(LatLng latlng) {
+  CustomPoint<double> project(LatLng latlng) {
     return CustomPoint(latlng.longitude, latlng.latitude);
   }
 
@@ -405,7 +405,7 @@ class SphericalMercator extends Projection {
   Bounds<double> get bounds => _bounds;
 
   @override
-  CustomPoint project(LatLng latlng) {
+  CustomPoint<double> project(LatLng latlng) {
     const d = math.pi / 180;
     const max = maxLatitude;
     final lat = math.max(math.min(max, latlng.latitude), -max);
@@ -439,7 +439,7 @@ class _Proj4Projection extends Projection {
   }) : epsg4326 = proj4.Projection.WGS84;
 
   @override
-  CustomPoint project(LatLng latlng) {
+  CustomPoint<double> project(LatLng latlng) {
     final point = epsg4326.transform(
         proj4Projection, proj4.Point(x: latlng.longitude, y: latlng.latitude));
 
@@ -463,14 +463,14 @@ class Transformation {
 
   const Transformation(this.a, this.b, this.c, this.d);
 
-  CustomPoint transform(CustomPoint<num> point, double? scale) {
+  CustomPoint<double> transform(CustomPoint point, double? scale) {
     scale ??= 1.0;
     final x = scale * (a * point.x + b);
     final y = scale * (c * point.y + d);
     return CustomPoint(x, y);
   }
 
-  CustomPoint untransform(CustomPoint point, double? scale) {
+  CustomPoint<double> untransform(CustomPoint point, double? scale) {
     scale ??= 1.0;
     final x = (point.x / scale - b) / a;
     final y = (point.y / scale - d) / c;

--- a/lib/src/geo/crs/crs.dart
+++ b/lib/src/geo/crs/crs.dart
@@ -29,7 +29,7 @@ abstract class Crs {
       final scale = this.scale(zoom);
       return transformation.transform(projectedPoint, scale.toDouble());
     } catch (e) {
-      return const CustomPoint(0.0, 0.0);
+      return const CustomPoint(0, 0);
     }
   }
 
@@ -244,7 +244,7 @@ class Proj4Crs extends Crs {
 
       return transformation.transform(projectedPoint, scale.toDouble());
     } catch (e) {
-      return const CustomPoint(0.0, 0.0);
+      return const CustomPoint(0, 0);
     }
   }
 
@@ -370,8 +370,7 @@ abstract class Projection {
 
 class _LonLat extends Projection {
   static final Bounds<double> _bounds = Bounds<double>(
-      const CustomPoint<double>(-180.0, -90.0),
-      const CustomPoint<double>(180.0, 90.0));
+      const CustomPoint<double>(-180, -90), const CustomPoint<double>(180, 90));
 
   const _LonLat() : super();
 

--- a/lib/src/geo/crs/crs.dart
+++ b/lib/src/geo/crs/crs.dart
@@ -46,8 +46,8 @@ abstract class Crs {
   }
 
   /// Zoom to Scale function.
-  num scale(double zoom) {
-    return 256 * math.pow(2, zoom);
+  double scale(double zoom) {
+    return 256.0 * math.pow(2, zoom);
   }
 
   /// Scale to Zoom function.
@@ -280,7 +280,7 @@ class Proj4Crs extends Crs {
 
   /// Zoom to Scale function.
   @override
-  num scale(double zoom) {
+  double scale(double zoom) {
     final iZoom = zoom.floor();
     if (zoom == iZoom) {
       return _scales[iZoom];

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -818,7 +818,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
     closeFlingAnimationController(event.source);
   }
 
-  CustomPoint _offsetToPoint(Offset offset) {
+  CustomPoint<double> _offsetToPoint(Offset offset) {
     return CustomPoint(offset.dx, offset.dy);
   }
 

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -555,7 +555,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
 
     final direction = details.velocity.pixelsPerSecond / magnitude;
     final distance = (Offset.zero &
-            Size(mapState.nonrotatedSize!.x, mapState.nonrotatedSize!.y))
+            Size(mapState.nonrotatedSize.x, mapState.nonrotatedSize.y))
         .shortestSide;
 
     final flingOffset = _focalStartLocal - _lastFocalLocal;
@@ -648,7 +648,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
   LatLng _offsetToCrs(Offset offset, [double? zoom]) {
     final focalStartPt =
         mapState.project(mapState.center, zoom ?? mapState.zoom);
-    final point = (_offsetToPoint(offset) - (mapState.nonrotatedSize! / 2.0))
+    final point = (_offsetToPoint(offset) - (mapState.nonrotatedSize / 2.0))
         .rotate(mapState.rotationRad);
 
     final newCenterPt = focalStartPt + point;
@@ -678,7 +678,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
   List<dynamic> _getNewEventCenterZoomPosition(
       CustomPoint cursorPos, double newZoom) {
     // Calculate offset of mouse cursor from viewport center
-    final viewCenter = mapState.nonrotatedSize! / 2;
+    final viewCenter = mapState.nonrotatedSize / 2;
     final offset = (cursorPos - viewCenter).rotate(mapState.rotationRad);
     // Match new center coordinate to mouse cursor position
     final scale = mapState.getZoomScale(newZoom, mapState.zoom);

--- a/lib/src/layer/tile_layer/tile_range.dart
+++ b/lib/src/layer/tile_layer/tile_range.dart
@@ -33,13 +33,12 @@ class DiscreteTileRange extends TileRange {
   }) {
     final Bounds<int> bounds;
     if (pixelBounds.min == pixelBounds.max) {
-      final minAndMax = (pixelBounds.min / tileSize).floor().cast<int>();
+      final minAndMax = (pixelBounds.min / tileSize).floor();
       bounds = Bounds<int>(minAndMax, minAndMax);
     } else {
       bounds = Bounds<int>(
-        (pixelBounds.min / tileSize).floor().cast<int>(),
-        (pixelBounds.max / tileSize).ceil().cast<int>() -
-            const CustomPoint(1, 1),
+        (pixelBounds.min / tileSize).floor(),
+        (pixelBounds.max / tileSize).ceil() - const CustomPoint(1, 1),
       );
     }
 

--- a/lib/src/layer/tile_layer/tile_range_calculator.dart
+++ b/lib/src/layer/tile_layer/tile_range_calculator.dart
@@ -33,7 +33,7 @@ class TileRangeCalculator {
     );
   }
 
-  Bounds _calculatePixelBounds(
+  Bounds<double> _calculatePixelBounds(
     FlutterMapState mapState,
     LatLng center,
     double viewingZoom,
@@ -41,7 +41,8 @@ class TileRangeCalculator {
   ) {
     final tileZoomDouble = tileZoom.toDouble();
     final scale = mapState.getZoomScale(viewingZoom, tileZoomDouble);
-    final pixelCenter = mapState.project(center, tileZoomDouble).floor();
+    final pixelCenter =
+        mapState.project(center, tileZoomDouble).floor().toDoublePoint();
     final halfSize = mapState.size / (scale * 2);
 
     return Bounds(pixelCenter - halfSize, pixelCenter + halfSize);

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -270,7 +270,7 @@ class FlutterMapState extends MapGestureMixin
   // Extended size of the map where rotation is calculated
   CustomPoint<double>? _size;
 
-  CustomPoint<double> get size => _size ?? const CustomPoint(0.0, 0.0);
+  CustomPoint<double> get size => _size ?? const CustomPoint(0, 0);
 
   void _updateSizeByOriginalSizeAndRotation() {
     final originalWidth = _nonrotatedSize!.x;
@@ -469,7 +469,7 @@ class FlutterMapState extends MapGestureMixin
     final se = bounds.southEast;
     var size = this.size - padding;
     // Prevent negative size which results in NaN zoom value later on in the calculation
-    size = CustomPoint(math.max(0.0, size.x), math.max(0.0, size.y));
+    size = CustomPoint(math.max(0, size.x), math.max(0, size.y));
     final boundsSize = Bounds(project(se, zoom), project(nw, zoom)).size;
     final scaleX = size.x / boundsSize.x;
     final scaleY = size.y / boundsSize.y;

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -223,20 +223,25 @@ class FlutterMapState extends MapGestureMixin
 
   double get rotationRad => degToRadian(_rotation);
 
-  late CustomPoint _pixelOrigin;
-  CustomPoint get pixelOrigin => _pixelOrigin;
+  late CustomPoint<int> _pixelOrigin;
+
+  CustomPoint<int> get pixelOrigin => _pixelOrigin;
 
   late LatLng _center;
+
   LatLng get center => _center;
 
   late LatLngBounds _bounds;
+
   LatLngBounds get bounds => _bounds;
 
-  late Bounds _pixelBounds;
-  Bounds get pixelBounds => _pixelBounds;
+  late Bounds<double> _pixelBounds;
+
+  Bounds<double> get pixelBounds => _pixelBounds;
 
   // Original size of the map where rotation isn't calculated
   CustomPoint<double>? _nonrotatedSize;
+
   CustomPoint<double>? get nonrotatedSize => _nonrotatedSize;
 
   void setSize(double width, double height) {
@@ -274,10 +279,8 @@ class FlutterMapState extends MapGestureMixin
     if (_rotation != 0.0) {
       final cosAngle = math.cos(rotationRad).abs();
       final sinAngle = math.sin(rotationRad).abs();
-      final num width =
-          (originalWidth * cosAngle) + (originalHeight * sinAngle);
-      final num height =
-          (originalHeight * cosAngle) + (originalWidth * sinAngle);
+      final width = (originalWidth * cosAngle) + (originalHeight * sinAngle);
+      final height = (originalHeight * cosAngle) + (originalWidth * sinAngle);
 
       _size = CustomPoint<double>(width, height);
     } else {
@@ -481,7 +484,7 @@ class FlutterMapState extends MapGestureMixin
     return math.max(min, math.min(max, zoom));
   }
 
-  CustomPoint project(LatLng latlng, [double? zoom]) {
+  CustomPoint<double> project(LatLng latlng, [double? zoom]) {
     zoom ??= _zoom;
     return options.crs.latLngToPoint(latlng, zoom);
   }
@@ -516,15 +519,15 @@ class FlutterMapState extends MapGestureMixin
     return Offset(delta.x.toDouble(), delta.y.toDouble());
   }
 
-  CustomPoint getNewPixelOrigin(LatLng center, [double? zoom]) {
+  CustomPoint<int> getNewPixelOrigin(LatLng center, [double? zoom]) {
     final viewHalf = size / 2.0;
     return (project(center, zoom) - viewHalf).round();
   }
 
-  Bounds getPixelBounds(double zoom) {
+  Bounds<double> getPixelBounds(double zoom) {
     final mapZoom = zoom;
     final scale = getZoomScale(mapZoom, zoom);
-    final pixelCenter = project(center, zoom).floor();
+    final pixelCenter = project(center, zoom).floor().toDoublePoint();
     final halfSize = size / (scale * 2);
     return Bounds(pixelCenter - halfSize, pixelCenter + halfSize);
   }
@@ -594,7 +597,7 @@ class FlutterMapState extends MapGestureMixin
 
   // This will convert a latLng to a position that we could use with a widget
   // outside of FlutterMap layer space. Eg using a Positioned Widget.
-  CustomPoint latLngToScreenPoint(LatLng latLng) {
+  CustomPoint<double> latLngToScreenPoint(LatLng latLng) {
     final nonRotatedPixelOrigin =
         (project(_center, zoom) - nonrotatedSize! / 2.0).round();
 
@@ -631,8 +634,7 @@ class FlutterMapState extends MapGestureMixin
   // it needs to be reversed (pointToLatLng), and sometimes we want to use
   // the same rotation to create a new position (latLngToScreenpoint).
   // counterRotation just makes allowances this for this.
-  CustomPoint<num> rotatePoint(
-      CustomPoint<num> mapCenter, CustomPoint<num> point,
+  CustomPoint<double> rotatePoint(CustomPoint mapCenter, CustomPoint point,
       {bool counterRotation = true}) {
     final counterRotationFactor = counterRotation ? -1 : 1;
 

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -75,7 +75,7 @@ class MapControllerImpl implements MapController {
   }
 
   @override
-  CustomPoint latLngToScreenPoint(LatLng latLng) {
+  CustomPoint<double> latLngToScreenPoint(LatLng latLng) {
     return _state.latLngToScreenPoint(latLng);
   }
 
@@ -84,8 +84,7 @@ class MapControllerImpl implements MapController {
     return _state.pointToLatLng(localPoint);
   }
 
-  CustomPoint<num> rotatePoint(
-      CustomPoint<num> mapCenter, CustomPoint<num> point,
+  CustomPoint<double> rotatePoint(CustomPoint mapCenter, CustomPoint point,
       {bool counterRotation = true}) {
     return _state.rotatePoint(mapCenter, point,
         counterRotation: counterRotation);

--- a/test/core/bounds_test.dart
+++ b/test/core/bounds_test.dart
@@ -9,8 +9,7 @@ void main() {
     test(
         'should create bounds with minimum point equal to minimum argument '
         'if maximum argument point is positioned higher', () {
-      final bounds =
-          Bounds(const CustomPoint(1.0, 2.0), const CustomPoint(3.0, 4.0));
+      final bounds = Bounds(const CustomPoint(1, 2), const CustomPoint(3, 4));
 
       expect(bounds.min.x, equals(1.0));
       expect(bounds.min.y, equals(2.0));
@@ -19,8 +18,7 @@ void main() {
     test(
         'should create bounds with minimum point equal to maximum argument '
         'if maximum argument point is positioned lower', () {
-      final bounds =
-          Bounds(const CustomPoint(3.0, 4.0), const CustomPoint(1.0, 2.0));
+      final bounds = Bounds(const CustomPoint(3, 4), const CustomPoint(1, 2));
 
       expect(bounds.min.x, equals(1.0));
       expect(bounds.min.y, equals(2.0));
@@ -30,7 +28,7 @@ void main() {
         'should create bounds with maximum point equal to minimum argument '
         'if maximum argument point is positioned lower', () {
       final bounds =
-          Bounds(const CustomPoint(1.0, 2.0), const CustomPoint(0.01, 0.02));
+          Bounds(const CustomPoint(1, 2), const CustomPoint(0.01, 0.02));
 
       expect(bounds.max.x, equals(1.0));
       expect(bounds.max.y, equals(2.0));
@@ -40,7 +38,7 @@ void main() {
         'should create bounds with maximum point equal to maximum argument '
         'if maximum argument point is positioned higher', () {
       final bounds =
-          Bounds(const CustomPoint(0.01, 0.02), const CustomPoint(1.0, 2.0));
+          Bounds(const CustomPoint(0.01, 0.02), const CustomPoint(1, 2));
 
       expect(bounds.max.x, equals(1.0));
       expect(bounds.max.y, equals(2.0));
@@ -104,7 +102,7 @@ void main() {
           'should create bounds with bottom left corner\'s y position '
           'using maximum point y position', () {
         expect(
-            Bounds(CustomPoint(randomDouble(), 1.0),
+            Bounds(CustomPoint(randomDouble(), 1),
                     CustomPoint(randomDouble(), 5.5))
                 .bottomLeft
                 .y,
@@ -115,7 +113,7 @@ void main() {
           'should create bounds with top right corner\'s x position '
           'using maximum point x position', () {
         expect(
-            Bounds(CustomPoint(1.0, randomDouble()),
+            Bounds(CustomPoint(1, randomDouble()),
                     CustomPoint(8.8, randomDouble()))
                 .topRight
                 .x,
@@ -127,7 +125,7 @@ void main() {
           'using minimum point y position', () {
         expect(
             Bounds(CustomPoint(randomDouble(), 9.9),
-                    CustomPoint(randomDouble(), 100.0))
+                    CustomPoint(randomDouble(), 100))
                 .topRight
                 .y,
             equals(9.9));
@@ -244,8 +242,8 @@ void main() {
       });
 
       test('should create new bounds and keep existing maximum y position', () {
-        final bounds = Bounds(CustomPoint(randomDouble(), 0.0),
-            CustomPoint(randomDouble(), 15.5));
+        final bounds = Bounds(
+            CustomPoint(randomDouble(), 0), CustomPoint(randomDouble(), 15.5));
         final extendedBounds = bounds.extend(CustomPoint(randomDouble(), 15.4));
 
         expect(extendedBounds.max.y, equals(bounds.max.y));
@@ -303,15 +301,15 @@ void main() {
 
       test('should contain given point within the bounds', () {
         expect(
-            Bounds(const CustomPoint(0.0, 50.0), const CustomPoint(50.0, 0.0))
-                .contains(const CustomPoint(25.0, 25.0)),
+            Bounds(const CustomPoint(0, 50), const CustomPoint(50, 0))
+                .contains(const CustomPoint(25, 25)),
             isTrue);
       });
 
       test('should NOT contain given point within the bounds', () {
         expect(
-            Bounds(const CustomPoint(0.0, 50.0), const CustomPoint(50.0, 0.0))
-                .contains(const CustomPoint(50.1, 50.1)),
+            Bounds(const CustomPoint(0, 50), const CustomPoint(50, 0))
+                .contains(const CustomPoint(51, 51)),
             isFalse);
       });
     });

--- a/test/layer/tile_layer/tile_bounds/crs_fakes.dart
+++ b/test/layer/tile_layer/tile_bounds/crs_fakes.dart
@@ -24,7 +24,7 @@ class FakeInfiniteCrs extends Crs {
 
   /// Any projection just to get non-zero coordiantes.
   @override
-  CustomPoint<num> latLngToPoint(LatLng latlng, double zoom) {
+  CustomPoint<double> latLngToPoint(LatLng latlng, double zoom) {
     return const Epsg3857().latLngToPoint(latlng, zoom);
   }
 }

--- a/test/layer/tile_layer/tile_range_test.dart
+++ b/test/layer/tile_layer/tile_range_test.dart
@@ -231,7 +231,7 @@ void main() {
           ),
         );
 
-        expect(tileRange.center, const CustomPoint(3.0, 3.0));
+        expect(tileRange.center, const CustomPoint(3, 3));
       });
 
       test('multiple tiles, even number of tiles', () {
@@ -257,7 +257,7 @@ void main() {
           ),
         );
 
-        expect(tileRange.center, const CustomPoint(4.0, 4.0));
+        expect(tileRange.center, const CustomPoint(4, 4));
       });
     });
 


### PR DESCRIPTION
1. `CustomPoint<int>` is not used in this plugin explicitly: change CustomPoint to always double to avoid potential error.
2. Some property are num and some are double, but seem having no good reason: change to double for consistency.
3. `mapState.nonrotatedSize` and `mapState.size` is always available after widget initlized: change its getter to non-nullable.
4. `CustomPoint.multiplyBy()` have same functionality as `operator *`: make as deprecated.