### PR TITLE
Refactored `FlutterMapState`'s `maybeOf` method

### DIFF
--- a/example/lib/pages/scale_layer_plugin_option.dart
+++ b/example/lib/pages/scale_layer_plugin_option.dart
@@ -52,7 +52,7 @@ class ScaleLayerWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final map = FlutterMapState.maybeOf(context)!;
+    final map = FlutterMapState.of(context);
     final zoom = map.zoom;
     final distance = scale[max(0, min(20, zoom.round() + 2))].toDouble();
     final center = map.center;

--- a/example/lib/pages/zoombuttons_plugin_option.dart
+++ b/example/lib/pages/zoombuttons_plugin_option.dart
@@ -34,7 +34,7 @@ class FlutterMapZoomButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final map = FlutterMapState.maybeOf(context)!;
+    final map = FlutterMapState.of(context);
     return Align(
       alignment: alignment,
       child: Column(

--- a/lib/src/layer/attribution_layer/rich.dart
+++ b/lib/src/layer/attribution_layer/rich.dart
@@ -235,7 +235,7 @@ class RichAttributionWidgetState extends State<RichAttributionWidget> {
                 context,
                 () {
                   setState(() => popupExpanded = true);
-                  mapEventSubscription = FlutterMapState.maybeOf(context)!
+                  mapEventSubscription = FlutterMapState.of(context)
                       .mapController
                       .mapEventStream
                       .listen((e) {

--- a/lib/src/layer/circle_layer.dart
+++ b/lib/src/layer/circle_layer.dart
@@ -36,7 +36,7 @@ class CircleLayer extends StatelessWidget {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints bc) {
         final size = Size(bc.maxWidth, bc.maxHeight);
-        final map = FlutterMapState.maybeOf(context)!;
+        final map = FlutterMapState.of(context);
         final circleWidgets = <Widget>[];
         for (final circle in circles) {
           circle.offset = map.getOffsetFromOrigin(circle.point);

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -159,7 +159,7 @@ class MarkerLayer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final map = FlutterMapState.maybeOf(context)!;
+    final map = FlutterMapState.of(context);
     final markerWidgets = <Widget>[];
 
     for (final marker in markers) {

--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -136,7 +136,7 @@ class OverlayImageLayer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final map = FlutterMapState.maybeOf(context)!;
+    final map = FlutterMapState.of(context);
     return ClipRect(
       child: Stack(
         children: <Widget>[

--- a/lib/src/layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer.dart
@@ -78,7 +78,7 @@ class PolygonLayer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final map = FlutterMapState.maybeOf(context)!;
+    final map = FlutterMapState.of(context);
     final size = Size(map.size.x, map.size.y);
 
     final List<Polygon> pgons = polygonCulling

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -77,7 +77,7 @@ class PolylineLayer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final map = FlutterMapState.maybeOf(context)!;
+    final map = FlutterMapState.of(context);
     final size = Size(map.size.x, map.size.y);
 
     final List<Polyline> lines = polylineCulling

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -411,7 +411,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
-    final map = FlutterMapState.maybeOf(context)!;
+    final map = FlutterMapState.of(context);
 
     //Handle movement
     final tileZoom = _clampZoom(map.zoom.roundToDouble());

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -761,9 +761,7 @@ class FlutterMapState extends MapGestureMixin
       ?.mapState;
 
   static FlutterMapState of(BuildContext context) =>
-      context
-          .dependOnInheritedWidgetOfExactType<MapStateInheritedWidget>()
-          ?.mapState ??
+      maybeOf(context) ??
       (throw StateError(
           '`FlutterMapState.of()` should not be called outside a `FlutterMap` and its children'));
 }

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -756,15 +756,16 @@ class FlutterMapState extends MapGestureMixin
   double _calculateScreenHeightInDegrees() =>
       options.screenSize!.height * 170.102258 / math.pow(2, zoom + 8);
 
-  static FlutterMapState? maybeOf(BuildContext context, {bool nullOk = false}) {
-    final widget =
-        context.dependOnInheritedWidgetOfExactType<MapStateInheritedWidget>();
-    if (nullOk || widget != null) {
-      return widget?.mapState;
-    }
-    throw FlutterError(
-        'MapState.of() called with a context that does not contain a FlutterMap.');
-  }
+  static FlutterMapState? maybeOf(BuildContext context) => context
+      .dependOnInheritedWidgetOfExactType<MapStateInheritedWidget>()
+      ?.mapState;
+
+  static FlutterMapState of(BuildContext context) =>
+      context
+          .dependOnInheritedWidgetOfExactType<MapStateInheritedWidget>()
+          ?.mapState ??
+      (throw StateError(
+          '`FlutterMapState.of()` should not be called outside a `FlutterMap` and its children'));
 }
 
 class _SafeArea {


### PR DESCRIPTION
Refactored `FlutterMapState`'s `maybeOf` method into itself and `of` to meet good practise guidelines and avoid unnecessary nullable return types.
Also changed the error that `of` throws from `FlutterError` to `StateError`.