### PR TITLE
Fix jitter of polygon/polyline after reverting from 2-step positioning

### DIFF
--- a/lib/src/layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer.dart
@@ -98,12 +98,9 @@ class PolygonLayer extends StatelessWidget {
 class PolygonPainter extends CustomPainter {
   final List<Polygon> polygons;
   final FlutterMapState map;
-  final double zoom;
-  final double rotation;
+  final LatLngBounds bounds;
 
-  PolygonPainter(this.polygons, this.map)
-      : zoom = map.zoom,
-        rotation = map.rotation;
+  PolygonPainter(this.polygons, this.map) : bounds = map.bounds;
 
   int get hash {
     _hash ??= Object.hashAll(polygons);
@@ -273,8 +270,7 @@ class PolygonPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(PolygonPainter oldDelegate) {
-    return oldDelegate.zoom != zoom ||
-        oldDelegate.rotation != rotation ||
+    return oldDelegate.bounds != bounds ||
         oldDelegate.polygons.length != polygons.length ||
         oldDelegate.hash != hash;
   }

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -104,12 +104,10 @@ class PolylinePainter extends CustomPainter {
   final bool saveLayers;
 
   final FlutterMapState map;
-  final double zoom;
-  final double rotation;
+  final LatLngBounds bounds;
 
   PolylinePainter(this.polylines, this.saveLayers, this.map)
-      : zoom = map.zoom,
-        rotation = map.rotation;
+      : bounds = map.bounds;
 
   int get hash {
     _hash ??= Object.hashAll(polylines);
@@ -296,8 +294,7 @@ class PolylinePainter extends CustomPainter {
 
   @override
   bool shouldRepaint(PolylinePainter oldDelegate) {
-    return oldDelegate.zoom != zoom ||
-        oldDelegate.rotation != rotation ||
+    return oldDelegate.bounds != bounds ||
         oldDelegate.polylines.length != polylines.length ||
         oldDelegate.hash != hash;
   }


### PR DESCRIPTION
Previously, the canvas was positioned in two steps using a Positioned widget, which was removed due to its own precision issues. Now the canvas needs to be redrawn whenever the viewport changes, not just rotations and zooming but also panning.