### PR TITLE
Center zoom on pinch zoom gesture (not just on move gesture)

### DIFF
--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -435,7 +435,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
                 }
               }
 
-              if (_pinchMoveStarted) {
+              if (_pinchZoomStarted || _pinchMoveStarted) {
                 final oldCenterPt = mapState.project(mapState.center, newZoom);
                 final newFocalLatLong = _offsetToCrs(_focalStartLocal, newZoom);
                 final newFocalPt = mapState.project(newFocalLatLong, newZoom);


### PR DESCRIPTION
This should fix the last issue tracked in https://github.com/fleaflet/flutter_map/issues/1354. https://github.com/fleaflet/flutter_map/pull/1081 seems to omit the pinch to zoom case. I tried adding it and it seems to be working on MacOS now, but I haven't tested extensively to see if this change breaks anything else.