### PR TITLE
Added `MapController.fitCoordinates` method

### DIFF
--- a/lib/src/gestures/map_events.dart
+++ b/lib/src/gestures/map_events.dart
@@ -20,6 +20,7 @@ enum MapEventSource {
   doubleTapZoomAnimationController,
   interactiveFlagsChanged,
   fitBounds,
+  fitCoordinates,
   custom,
   scrollWheel,
   nonRotatedSizeChange,

--- a/lib/src/map/controller.dart
+++ b/lib/src/map/controller.dart
@@ -126,6 +126,22 @@ abstract class MapController {
     FitBoundsOptions? options,
   });
 
+  /// Move and zoom the map to perfectly fit [coordinates], with additional
+  /// configurable [options]
+  ///
+  /// For information about return value meaning and emitted events, see [move]'s
+  /// documentation.
+  bool fitCoordinates(List<LatLng> coordinates, {FitBoundsOptions? options});
+
+  /// Calculates the appropriate center and zoom level for the map to perfectly
+  /// fit [coordinates], with additional configurable [options]
+  ///
+  /// Does not move/zoom the map: see [fitCoordinates].
+  CenterZoom centerZoomFitCoordinates(
+    List<LatLng> coordinates, {
+    FitBoundsOptions? options,
+  });
+
   /// Convert a screen point (x/y) to its corresponding map coordinate (lat/lng),
   /// based on the map's current properties
   LatLng pointToLatLng(CustomPoint screenPoint);
@@ -240,6 +256,22 @@ class MapControllerImpl implements MapController {
         const FitBoundsOptions(padding: EdgeInsets.all(12)),
   }) =>
       _state.centerZoomFitBounds(bounds, options!);
+
+  @override
+  bool fitCoordinates(
+    List<LatLng> coordinates, {
+    FitBoundsOptions? options =
+        const FitBoundsOptions(padding: EdgeInsets.all(12)),
+  }) =>
+      _state.fitCoordinates(coordinates, options!);
+
+  @override
+  CenterZoom centerZoomFitCoordinates(
+    List<LatLng> coordinates, {
+    FitBoundsOptions? options =
+        const FitBoundsOptions(padding: EdgeInsets.all(12)),
+  }) =>
+      _state.getCoordinatesCenterZoom(coordinates, options!);
 
   @override
   LatLng pointToLatLng(CustomPoint localPoint) =>

--- a/lib/src/misc/private/bounds.dart
+++ b/lib/src/misc/private/bounds.dart
@@ -14,6 +14,35 @@ class Bounds<T extends num> {
     return bounds2.extend(b);
   }
 
+  static Bounds<double> containing(Iterable<CustomPoint<double>> points) {
+    var maxX = double.negativeInfinity;
+    var maxY = double.negativeInfinity;
+    var minX = double.infinity;
+    var minY = double.infinity;
+
+    for (final point in points) {
+      if (point.x > maxX) {
+        maxX = point.x;
+      }
+      if (point.x < minX) {
+        minX = point.x;
+      }
+      if (point.y > maxY) {
+        maxY = point.y;
+      }
+      if (point.y < minY) {
+        minY = point.y;
+      }
+    }
+
+    final bounds = Bounds._(
+      CustomPoint(minX, minY),
+      CustomPoint(maxX, maxY),
+    );
+
+    return bounds;
+  }
+
   const Bounds._(this.min, this.max);
 
   /// Creates a new [Bounds] obtained by expanding the current ones with a new

--- a/test/flutter_map_controller_test.dart
+++ b/test/flutter_map_controller_test.dart
@@ -597,4 +597,210 @@ void main() {
       expectedZoom: 5.368867444131886,
     );
   });
+
+  testWidgets('test fit coordinates methods', (tester) async {
+    final controller = MapController();
+    const coordinates = [
+      LatLng(4.214943, 33.925781),
+      LatLng(3.480523, 30.844116),
+      LatLng(-1.362176, 29.575195),
+      LatLng(-0.999705, 33.925781),
+    ];
+
+    await tester.pumpWidget(TestApp(controller: controller));
+
+    Future<void> testFitCoordinates({
+      required double rotation,
+      required FitBoundsOptions options,
+      required LatLng expectedCenter,
+      required double expectedZoom,
+    }) async {
+      controller.rotate(rotation);
+
+      final fit = controller.centerZoomFitCoordinates(
+        coordinates,
+        options: options,
+      );
+      controller.move(fit.center, fit.zoom);
+      await tester.pump();
+      expect(
+        controller.center.latitude,
+        moreOrLessEquals(expectedCenter.latitude),
+      );
+      expect(
+        controller.center.longitude,
+        moreOrLessEquals(expectedCenter.longitude),
+      );
+      expect(controller.zoom, moreOrLessEquals(expectedZoom));
+
+      controller.fitCoordinates(coordinates, options: options);
+      await tester.pump();
+      expect(
+        controller.center.latitude,
+        moreOrLessEquals(expectedCenter.latitude),
+      );
+      expect(
+        controller.center.longitude,
+        moreOrLessEquals(expectedCenter.longitude),
+      );
+      expect(controller.zoom, moreOrLessEquals(expectedZoom));
+    }
+
+    // Tests with no padding
+
+    await testFitCoordinates(
+      rotation: 45,
+      options: const FitBoundsOptions(),
+      expectedCenter: const LatLng(1.0175550985081283, 32.16110216543986),
+      expectedZoom: 5.323677289246632,
+    );
+    await testFitCoordinates(
+      rotation: 90,
+      options: const FitBoundsOptions(),
+      expectedCenter: const LatLng(1.4280748738291353, 31.75048799999998),
+      expectedZoom: 5.655171629288528,
+    );
+    await testFitCoordinates(
+      rotation: 135,
+      options: const FitBoundsOptions(),
+      expectedCenter: const LatLng(1.0175550985081538, 32.16110216543989),
+      expectedZoom: 5.323677289246641,
+    );
+    await testFitCoordinates(
+      rotation: 180,
+      options: const FitBoundsOptions(),
+      expectedCenter: const LatLng(1.4280748738291353, 31.75048799999998),
+      expectedZoom: 5.655171629288529,
+    );
+    await testFitCoordinates(
+      rotation: 225,
+      options: const FitBoundsOptions(),
+      expectedCenter: const LatLng(1.0175550985080901, 32.16110216543997),
+      expectedZoom: 5.323677289246641,
+    );
+    await testFitCoordinates(
+      rotation: 270,
+      options: const FitBoundsOptions(),
+      expectedCenter: const LatLng(1.4280748738291353, 31.75048799999998),
+      expectedZoom: 5.655171629288529,
+    );
+    await testFitCoordinates(
+      rotation: 315,
+      options: const FitBoundsOptions(),
+      expectedCenter: const LatLng(1.0175550985081538, 32.16110216543989),
+      expectedZoom: 5.323677289246641,
+    );
+    await testFitCoordinates(
+      rotation: 360,
+      options: const FitBoundsOptions(),
+      expectedCenter: const LatLng(1.4280748738291353, 31.75048799999998),
+      expectedZoom: 5.655171629288529,
+    );
+
+    // Tests with symmetric padding
+
+    const symmetricPadding = EdgeInsets.all(12);
+
+    await testFitCoordinates(
+      rotation: 45,
+      options: const FitBoundsOptions(padding: symmetricPadding),
+      expectedCenter: const LatLng(1.0175550985081538, 32.16110216543986),
+      expectedZoom: 5.139252718109209,
+    );
+    await testFitCoordinates(
+      rotation: 90,
+      options: const FitBoundsOptions(padding: symmetricPadding),
+      expectedCenter: const LatLng(1.4280748738291353, 31.75048799999998),
+      expectedZoom: 5.470747058151099,
+    );
+    await testFitCoordinates(
+      rotation: 135,
+      options: const FitBoundsOptions(padding: symmetricPadding),
+      expectedCenter: const LatLng(1.0175550985081538, 32.161102165439935),
+      expectedZoom: 5.139252718109208,
+    );
+    await testFitCoordinates(
+      rotation: 180,
+      options: const FitBoundsOptions(padding: symmetricPadding),
+      expectedCenter: const LatLng(1.4280748738291353, 31.75048799999998),
+      expectedZoom: 5.470747058151097,
+    );
+    await testFitCoordinates(
+      rotation: 225,
+      options: const FitBoundsOptions(padding: symmetricPadding),
+      expectedCenter: const LatLng(1.0175550985081157, 32.16110216543997),
+      expectedZoom: 5.13925271810921,
+    );
+    await testFitCoordinates(
+      rotation: 270,
+      options: const FitBoundsOptions(padding: symmetricPadding),
+      expectedCenter: const LatLng(1.4280748738291353, 31.75048799999998),
+      expectedZoom: 5.470747058151099,
+    );
+    await testFitCoordinates(
+      rotation: 315,
+      options: const FitBoundsOptions(padding: symmetricPadding),
+      expectedCenter: const LatLng(1.0175550985081538, 32.16110216543986),
+      expectedZoom: 5.13925271810921,
+    );
+    await testFitCoordinates(
+      rotation: 360,
+      options: const FitBoundsOptions(padding: symmetricPadding),
+      expectedCenter: const LatLng(1.4280748738291353, 31.75048799999998),
+      expectedZoom: 5.470747058151099,
+    );
+
+    // Tests with asymmetric padding
+
+    const asymmetricPadding = EdgeInsets.fromLTRB(12, 12, 24, 24);
+
+    await testFitCoordinates(
+      rotation: 45,
+      options: const FitBoundsOptions(padding: asymmetricPadding),
+      expectedCenter: const LatLng(1.0175550985081665, 32.524454855645835),
+      expectedZoom: 5.037373104089995,
+    );
+    await testFitCoordinates(
+      rotation: 90,
+      options: const FitBoundsOptions(padding: asymmetricPadding),
+      expectedCenter: const LatLng(1.63218686735705, 31.954672909718134),
+      expectedZoom: 5.36886744413189,
+    );
+    await testFitCoordinates(
+      rotation: 135,
+      options: const FitBoundsOptions(padding: asymmetricPadding),
+      expectedCenter: const LatLng(1.3808275978186646, 32.16110216543989),
+      expectedZoom: 5.037373104089992,
+    );
+    await testFitCoordinates(
+      rotation: 180,
+      options: const FitBoundsOptions(padding: asymmetricPadding),
+      expectedCenter: const LatLng(1.63218686735705, 31.546303090281786),
+      expectedZoom: 5.3688674441318875,
+    );
+    await testFitCoordinates(
+      rotation: 225,
+      options: const FitBoundsOptions(padding: asymmetricPadding),
+      expectedCenter: const LatLng(1.0175550985081283, 31.797749475233953),
+      expectedZoom: 5.037373104089987,
+    );
+    await testFitCoordinates(
+      rotation: 270,
+      options: const FitBoundsOptions(padding: asymmetricPadding),
+      expectedCenter: const LatLng(1.2239447514276816, 31.546303090281786),
+      expectedZoom: 5.368867444131882,
+    );
+    await testFitCoordinates(
+      rotation: 315,
+      options: const FitBoundsOptions(padding: asymmetricPadding),
+      expectedCenter: const LatLng(0.6542416853021571, 32.16110216543989),
+      expectedZoom: 5.037373104089994,
+    );
+    await testFitCoordinates(
+      rotation: 360,
+      options: const FitBoundsOptions(padding: asymmetricPadding),
+      expectedCenter: const LatLng(1.223944751427707, 31.954672909718177),
+      expectedZoom: 5.368867444131889,
+    );
+  });
 }


### PR DESCRIPTION
Hi all! With this PR I'm proposing to add a new map controller method called `fitCoordinates`. 

When we have a list of lat/lng coordinates and want to fit the map viewport to those coordinates, the current best practice is to first calculate a `LatLngBounds`, and then use `fitBounds`:
```
final coordinates = <LatLng>[...];
final bounds = LatLngBounds.fromPoints(coordinates);
mapController.fitBounds(bounds);
```

With this PR, we can instead write:
```
mapController.fitCoordinates(coordinates);
```

The origin of this PR is that I was trying to implement a fix for https://github.com/fleaflet/flutter_map/issues/1342 to make `fitBounds` work correctly when the map is rotated. I implemented [this fix](https://github.com/fleaflet/flutter_map/issues/1342#issuecomment-1298082024) which was proposed by @JosefWN but the result was a bit surprising to me:

<img width="456" alt="fitBounds with rotation" src="https://github.com/fleaflet/flutter_map/assets/824653/7446f2a9-96f3-4e05-9178-163565c5ffb9">

I was puzzled by the additional padding to the left of the green marker, until I remembered `fitBounds` is fitting the `LatLngBounds`, _not_ the 4 coordinates themselves. Given `LatLngBounds` can only represent a rectangle bounds in a north-up orientation, then what is happening here is correct; that extra margin on the left is required to fit the northwestern most point of the bounds. If we draw a black rectangle polyline that represents the `LatLngBounds` of the four points, then we can see it's working as it should:

<img width="456" alt="fitBounds with rotation and bounding box" src="https://github.com/fleaflet/flutter_map/assets/824653/bbe4cb65-5354-4c5a-b7fa-b254545ef9c3">

So I realized `fitBounds`, even if corrected to work with rotation, is not what I actually need, and is probably not what most users of this package need when trying to fit a list of coordinates in the viewport when the map is rotated. Rather, I needed a method like `fitCoordinates` that fits specific coordinate points, regardless of rotation. With `fitCoordinates`, the result looks like this:

<img width="456" alt="fitCoordinates with rotation" src="https://github.com/fleaflet/flutter_map/assets/824653/9b56098e-d5b6-4bc9-bd07-e11faa90862b">

Rather than fitting a north-up bounding box of the coordinates, `fitCoordinates` fits the coordinates themselves.

I plan to add tests and make some minor tweaks to the code to avoid some duplicate computations, but I wanted to post this PR before putting in too much more work so I can get feedback from the experienced maintainers of this package about this idea. Am I correct that `fitCoordinates` does something useful and different than `fitBounds` when the map is rotated?