### PR TITLE
Change: rethrow exception if no fallback url is defined (FlutterMapNetworkImageProvider)

### DIFF
--- a/lib/src/layer/tile_layer/tile_provider/network_image_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/network_image_provider.dart
@@ -69,7 +69,7 @@ class FlutterMapNetworkImageProvider
         headers: headers,
       );
     } catch (_) {
-      if (useFallback) rethrow;
+      if (useFallback || fallbackUrl == null) rethrow;
       return _loadAsync(key, chunkEvents, decode, useFallback: true);
     }
 


### PR DESCRIPTION
This MR should fix https://github.com/fleaflet/flutter_map/issues/1554.

Reason:
If no tile image exists, then retry only if a fallback url is defined. Otherwise rethrow the exception.