### PR TITLE
Add test to ensure gestures always work

### DIFF
--- a/lib/src/gestures/flutter_map_interactive_viewer.dart
+++ b/lib/src/gestures/flutter_map_interactive_viewer.dart
@@ -39,6 +39,7 @@ class FlutterMapInteractiveViewerState
     extends State<FlutterMapInteractiveViewer> with TickerProviderStateMixin {
   static const int _kMinFlingVelocity = 800;
   static const _kDoubleTapZoomDuration = 200;
+  static const doubleTapDelay = Duration(milliseconds: 350);
 
   final _positionedTapController = PositionedTapController();
   final _gestureArenaTeam = GestureArenaTeam();
@@ -85,6 +86,7 @@ class FlutterMapInteractiveViewerState
   MapCamera get _camera => widget.controller.camera;
 
   MapOptions get _options => widget.controller.options;
+
   InteractionOptions get _interactionOptions => _options.interactionOptions;
 
   @override
@@ -766,8 +768,7 @@ class FlutterMapInteractiveViewerState
     _doubleTapHoldMaxDelay?.cancel();
 
     if (++_tapUpCounter == 1) {
-      _doubleTapHoldMaxDelay =
-          Timer(const Duration(milliseconds: 350), _resetDoubleTapHold);
+      _doubleTapHoldMaxDelay = Timer(doubleTapDelay, _resetDoubleTapHold);
     }
   }
 

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -108,7 +108,7 @@ class TileLayer extends StatefulWidget {
     'This property has been removed simplify interaction when using multiple `TileLayer`s. '
     'This property is deprecated since v6.',
   )
-  final Color backgroundColor;
+  final Color? backgroundColor;
 
   /// Provider with which to load map tiles
   ///
@@ -235,7 +235,7 @@ class TileLayer extends StatefulWidget {
     this.subdomains = const <String>[],
     this.keepBuffer = 2,
     this.panBuffer = 0,
-    this.backgroundColor = Colors.transparent,
+    this.backgroundColor,
     this.errorImage,
     TileProvider? tileProvider,
     this.tms = false,
@@ -478,10 +478,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
 
     _tileScaleCalculator.clearCacheUnlessZoomMatches(map.zoom);
 
-    return ColoredBox(
-      // ignore: deprecated_member_use_from_same_package
-      color: widget.backgroundColor,
-      child: Stack(
+    return _addBackgroundColor(
+      Stack(
         children: [
           ..._tileImageManager
               .inRenderOrder(widget.maxZoom, tileZoom)
@@ -502,6 +500,14 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
         ],
       ),
     );
+  }
+
+  // This can be removed once the deprecated backgroundColor option is removed.
+  Widget _addBackgroundColor(Widget child) {
+    // ignore: deprecated_member_use_from_same_package
+    final color = widget.backgroundColor;
+
+    return color == null ? child : ColoredBox(color: color, child: child);
   }
 
   TileImage _createTileImage(


### PR DESCRIPTION
Recently a change was made to move the TileLayer backgroundColor option to become an option of FlutterMap. This accidentally fixed an issue where gestures would stop working when going beyond a TileLayer's max zoom because FlutterMap's gesture detectors' HitTestBehaviour is the default deferToChild and when above a TileLayer's maxZoom potentially there would be no hit-testable children of FlutterMap.

Moving the color option to FlutterMap means that there is always a ColoredBox child widget which is hit testable. To avoid accidentally breaking hit testing again in the future this commit adds a test which ensures it always works.

In passing I made TileLayer only wrap its tiles in a ColoredBox widget if the user defines a backgroundColor (which is deprecated).