### PR TITLE
Ignore gestures on closed `RichAnimationWidget` when using `FadeRAWA`

### DIFF
--- a/lib/src/layer/attribution_layer/animation.dart
+++ b/lib/src/layer/attribution_layer/animation.dart
@@ -179,6 +179,9 @@ class FadeRAWA implements RichAttributionWidgetAnimation {
         opacity: isExpanded ? 1 : 0,
         curve: isExpanded ? popupCurveOut : popupCurveIn,
         duration: buttonDuration,
-        child: child,
+        child: IgnorePointer(
+          ignoring: !isExpanded,
+          child: child,
+        ),
       );
 }


### PR DESCRIPTION
Fixes #1589.
Added `IgnorePointer` to `FadeRAWA.popupAnimationBuilder` to ignore gestures when closed. `ScaleRAWA` does not suffer from the same issue as the child becomes 0x0 px.