### PR TITLE
Fix some polygon edge cases, avoid unecessary work, and tidy up the code

### DIFF
--- a/example/lib/pages/polygon.dart
+++ b/example/lib/pages/polygon.dart
@@ -98,7 +98,7 @@ class PolygonPage extends StatelessWidget {
                       points: filledPoints,
                       isFilled: true,
                       color: Colors.purple,
-                      borderColor: Colors.purple,
+                      borderColor: Colors.yellow,
                       borderStrokeWidth: 4,
                     ),
                     Polygon(
@@ -120,6 +120,8 @@ class PolygonPage extends StatelessWidget {
                     Polygon(
                       points: labelPoints,
                       borderStrokeWidth: 4,
+                      isFilled: false,
+                      color: Colors.pink,
                       borderColor: Colors.purple,
                       label: "Label!",
                     ),
@@ -132,11 +134,27 @@ class PolygonPage extends StatelessWidget {
                     ),
                     Polygon(
                       points: holeOuterPoints,
-                      //holePointsList: [],
+                      isFilled: true,
                       holePointsList: [holeInnerPoints],
                       borderStrokeWidth: 4,
                       borderColor: Colors.green,
                       color: Colors.pink.withOpacity(0.5),
+                    ),
+                    Polygon(
+                      points: holeOuterPoints
+                          .map((latlng) =>
+                              LatLng(latlng.latitude, latlng.longitude + 8))
+                          .toList(),
+                      isFilled: false,
+                      isDotted: true,
+                      holePointsList: [
+                        holeInnerPoints
+                            .map((latlng) =>
+                                LatLng(latlng.latitude, latlng.longitude + 8))
+                            .toList()
+                      ],
+                      borderStrokeWidth: 4,
+                      borderColor: Colors.orange,
                     ),
                   ]),
                 ],


### PR DESCRIPTION
Fix some polygon edge cases, e.g. double drawing on labels or not correctly setting the border color.

I also feel that the code re-organization really helped the separation of concerns and made it much clearer what each part is doing. Specifically:

* Fill and border are clearly separated.
* The loop is only responsible for batching paths. The Paint is now handled once during drawing.

![image](https://github.com/fleaflet/flutter_map/assets/111986/7dea8f1d-eebc-4168-87dd-fdd372a580ed)
