### PR TITLE
Fixed `TileLayer.reset` failing to load new tiles

### DIFF
--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -150,7 +150,7 @@ class OverlayImageLayer extends StatelessWidget {
     return ClipRect(
       child: Stack(
         children: <Widget>[
-          for (var overlayImage in overlayImages)
+          for (final overlayImage in overlayImages)
             overlayImage.buildPositionedForOverlay(map),
         ],
       ),

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -320,11 +320,10 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     super.initState();
 
     if (widget.reset != null) {
-      _resetSub = widget.reset?.listen(
-        (_) => _tileImageManager.removeAll(
-          widget.evictErrorTileStrategy,
-        ),
-      );
+      _resetSub = widget.reset?.listen((_) {
+        _tileImageManager.removeAll(widget.evictErrorTileStrategy);
+        _loadAndPruneInVisibleBounds(MapCamera.of(context));
+      });
     }
 
     _tileRangeCalculator = TileRangeCalculator(tileSize: widget.tileSize);


### PR DESCRIPTION
Fixes #1619, replaces part of #1586.