### PR TITLE
Changed `FlutterMapInternalController.fitCamera`'s `source` to `MapEventSource.mapController`

### DIFF
--- a/lib/src/map/internal_controller.dart
+++ b/lib/src/map/internal_controller.dart
@@ -238,7 +238,7 @@ class FlutterMapInternalController extends ValueNotifier<_InternalState> {
       fitted.zoom,
       offset: offset,
       hasGesture: false,
-      source: MapEventSource.fitCamera,
+      source: MapEventSource.mapController,
       id: null,
     );
   }


### PR DESCRIPTION
Fixes #1563. However, this is a quick fix, and does not resolve the root of the problem. I'm not sure why `MapEventSource.mapController` acts differently to `MapEventSource.fitCamera`.