### PR TITLE
Changed `TileLayer`'s default (native) zoom levels

### DIFF
--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -57,23 +57,40 @@ class TileLayer extends StatefulWidget {
   /// Default is 256
   final double tileSize;
 
-  // The minimum zoom level down to which this layer will be
-  // displayed (inclusive).
+  /// The minimum zoom level down to which this layer will be displayed
+  /// (inclusive)
+  ///
+  /// This should usually be 0 (as default).
   final double minZoom;
 
   /// The maximum zoom level up to which this layer will be displayed
-  /// (inclusive). In most tile providers goes from 0 to 19.
+  /// (inclusive).
+  ///
+  /// Prefer [maxNativeZoom] for setting the maximum zoom level supported by the
+  /// tile source. The main usage for this is to display a different [TileLayer]
+  /// when zoomed far in.
+  ///
+  /// Otherwise, this should usually be infinite (as default), so that there are
+  /// tiles always displayed.
   final double maxZoom;
 
-  /// Minimum zoom number the tile source has available. If it is specified, the
-  /// tiles on all zoom levels lower than minNativeZoom will be loaded from
-  /// minNativeZoom level and auto-scaled.
-  final int? minNativeZoom;
+  /// Minimum zoom level supported by the tile source
+  ///
+  /// Tiles from below this zoom level will not be displayed, instead tiles at
+  /// this zoom level will be displayed and scaled.
+  ///
+  /// This should usually be 0 (as default), as most tile sources will support
+  /// zoom levels onwards from this.
+  final int minNativeZoom;
 
-  /// Maximum zoom number the tile source has available. If it is specified, the
-  /// tiles on all zoom levels higher than maxNativeZoom will be loaded from
-  /// maxNativeZoom level and auto-scaled.
-  final int? maxNativeZoom;
+  /// Maximum zoom number supported by the tile source has available.
+  ///
+  /// Tiles from above this zoom level will not be displayed, instead tiles at
+  /// this zoom level will be displayed and scaled.
+  ///
+  /// Most tile servers support up to zoom level 19, which is the default.
+  /// Otherwise, this should be specified.
+  final int maxNativeZoom;
 
   /// If set to true, the zoom number used in tile URLs will be reversed
   /// (`maxZoom - zoom` instead of `zoom`)
@@ -231,11 +248,11 @@ class TileLayer extends StatefulWidget {
     super.key,
     this.urlTemplate,
     this.fallbackUrl,
-    double tileSize = 256.0,
-    double minZoom = 0.0,
-    double maxZoom = 18.0,
-    this.minNativeZoom,
-    this.maxNativeZoom,
+    double tileSize = 256,
+    double minZoom = 0,
+    double maxZoom = double.infinity,
+    this.minNativeZoom = 0,
+    this.maxNativeZoom = 19,
     this.zoomReverse = false,
     double zoomOffset = 0.0,
     this.additionalOptions = const {},
@@ -639,18 +656,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
 
   /// Rounds the zoom to the nearest int and clamps it to the native zoom limits
   /// if there are any.
-  int _clampToNativeZoom(double zoom) {
-    var result = zoom.round();
-
-    if (widget.minNativeZoom != null) {
-      result = max(result, widget.minNativeZoom!);
-    }
-    if (widget.maxNativeZoom != null) {
-      result = min(result, widget.maxNativeZoom!);
-    }
-
-    return result;
-  }
+  int _clampToNativeZoom(double zoom) =>
+      zoom.round().clamp(widget.minNativeZoom, widget.maxNativeZoom);
 
   void _onTileLoadError(TileImage tile, Object error, StackTrace? stackTrace) {
     debugPrint(error.toString());


### PR DESCRIPTION
Fixes #1625.

The issue was already apparently resolved in v6 'master', however, it did not appear that way due to a likely conflict between the default `maxZoom` and specified `maxNativeZoom`, where the `maxZoom`'s effect took priority.

Changes have been made to the defaults, as follows:
* `minZoom`: 0
* `maxZoom`: double.infinity
* `minNativeZoom`: 0 (non-nullable)
* `maxNativeZoom`: 19 (non-nullable)

Changes have also been made to the documentation to reflect more appropriate usage recommendations and remove/correct confusing information.

The internal `_clampToNativeZoom` implementation has also been massively simplified to use Dart's native `clamp` method.