### PR TITLE
Fixed `MapOptions.backgroundColor` failing to update

### DIFF
--- a/lib/src/map/options.dart
+++ b/lib/src/map/options.dart
@@ -304,6 +304,7 @@ class MapOptions {
       boundsOptions == other.boundsOptions &&
       minZoom == other.minZoom &&
       maxZoom == other.maxZoom &&
+      backgroundColor == other.backgroundColor &&
       onTap == other.onTap &&
       onSecondaryTap == other.onSecondaryTap &&
       onLongPress == other.onLongPress &&
@@ -330,6 +331,7 @@ class MapOptions {
         boundsOptions,
         minZoom,
         maxZoom,
+        backgroundColor,
         onTap,
         onSecondaryTap,
         onLongPress,


### PR DESCRIPTION
Fixes #1646.

I noticed that internally `MapOptions` were only updated if they differed from the old ones. However, the `==` operator did not check for `backgroundColor`, and neither did `hashCode`.