### PR TITLE
Fixed crash on uncaught "Invalid image data" exception

### DIFF
--- a/lib/src/layer/tile_layer/tile_provider/network_image_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/network_image_provider.dart
@@ -84,12 +84,12 @@ class FlutterMapNetworkImageProvider
         Uri.parse(useFallback ? fallbackUrl ?? '' : url),
         headers: headers,
       );
+
+      return decode(await ImmutableBuffer.fromUint8List(bytes));
     } catch (_) {
       if (useFallback || fallbackUrl == null) rethrow;
       return _loadAsync(key, chunkEvents, decode, useFallback: true);
     }
-
-    return decode(await ImmutableBuffer.fromUint8List(bytes));
   }
 
   @override

--- a/lib/src/layer/tile_layer/tile_provider/network_image_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/network_image_provider.dart
@@ -78,14 +78,15 @@ class FlutterMapNetworkImageProvider
     ImageDecoderCallback decode, {
     bool useFallback = false,
   }) async {
-    final Uint8List bytes;
     try {
-      bytes = await httpClient.readBytes(
-        Uri.parse(useFallback ? fallbackUrl ?? '' : url),
-        headers: headers,
+      return decode(
+        await ImmutableBuffer.fromUint8List(
+          await httpClient.readBytes(
+            Uri.parse(useFallback ? fallbackUrl ?? '' : url),
+            headers: headers,
+          ),
+        ),
       );
-
-      return decode(await ImmutableBuffer.fromUint8List(bytes));
     } catch (_) {
       if (useFallback || fallbackUrl == null) rethrow;
       return _loadAsync(key, chunkEvents, decode, useFallback: true);


### PR DESCRIPTION

When running a custom tile server, in the case of a missing tile we can get back zero bytes. Resulting in the **decode** function failure in **_loadAsync** of FlutterMapNetworkImageProvider.

Looking at the **_loadAsync** implementation, the call to the **decode** function was left out of the try/catch block. Simply moving the **decode** function call inside the try block fixes the issue - the app no longer crashes on a missing tile.