### PR TITLE
Fixed `keepAlive` behaviour

### DIFF
--- a/lib/src/map/widget.dart
+++ b/lib/src/map/widget.dart
@@ -44,7 +44,8 @@ class FlutterMap extends StatefulWidget {
   State<FlutterMap> createState() => FlutterMapStateContainer();
 }
 
-class FlutterMapStateContainer extends State<FlutterMap> {
+class FlutterMapStateContainer extends State<FlutterMap>
+    with AutomaticKeepAliveClientMixin {
   bool _initialCameraFitApplied = false;
 
   late final FlutterMapInternalController _flutterMapInternalController;
@@ -89,6 +90,8 @@ class FlutterMapStateContainer extends State<FlutterMap> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
+
     return LayoutBuilder(
       builder: (context, constraints) {
         _updateAndEmitSizeIfConstraintsChanged(constraints);
@@ -197,4 +200,7 @@ class FlutterMapStateContainer extends State<FlutterMap> {
   bool _parentConstraintsAreSet(
           BuildContext context, BoxConstraints constraints) =>
       constraints.maxWidth != 0 || MediaQuery.sizeOf(context) != Size.zero;
+
+  @override
+  bool get wantKeepAlive => widget.options.keepAlive;
 }


### PR DESCRIPTION
Fixes #1650.

Mixed `AutomaticKeepAliveClientMixin` back into `FlutterMapStateContainer` and added `FlutterMapStateContainer.wantKeepAlive` field which redirects to `MapOptions.keepAlive`.