### PR TITLE
Ensure the RichAttributionWidgetState doesn't fail if its removed from widget tree.

### DIFF
--- a/lib/src/layer/attribution_layer/rich.dart
+++ b/lib/src/layer/attribution_layer/rich.dart
@@ -153,7 +153,6 @@ class RichAttributionWidget extends StatefulWidget {
 class RichAttributionWidgetState extends State<RichAttributionWidget> {
   StreamSubscription<MapEvent>? mapEventSubscription;
 
-  final persistentAttributionKey = GlobalKey();
   Size? persistentAttributionSize;
 
   late bool popupExpanded = widget.popupInitialDisplayDuration != Duration.zero;
@@ -177,12 +176,9 @@ class RichAttributionWidgetState extends State<RichAttributionWidget> {
     WidgetsBinding.instance.addPostFrameCallback(
       (_) => WidgetsBinding.instance.addPostFrameCallback(
         (_) {
-          assert(
-            persistentAttributionKey.currentContext?.findRenderObject() != null,
-            'persistentAttributionKey is not in the widget tree',
-          );
-          final renderObject =
-              persistentAttributionKey.currentContext?.findRenderObject();
+          if (!mounted) return;
+
+          final renderObject = context.findRenderObject();
           if (renderObject is RenderBox) {
             setState(() => persistentAttributionSize = renderObject.size);
           }
@@ -313,7 +309,6 @@ class RichAttributionWidgetState extends State<RichAttributionWidget> {
                 ),
               ),
             MouseRegion(
-              key: persistentAttributionKey,
               onEnter: (_) => setState(() => persistentHovered = true),
               onExit: (_) => setState(() => persistentHovered = false),
               cursor: SystemMouseCursors.click,


### PR DESCRIPTION
While there was an assertion to check for this, a Widget being removed ~1-2 frames after its added is perfectly valid, and thus we should easily check if the widget is still mounted. While we are at it, it seemed a GlobalKey was being used to track the context. In later versions of flutter Stateful widgets have a context property for this purpose.