### PR TITLE
Update base_tile_provider.dart to use retinaMode option

### DIFF
--- a/lib/src/layer/tile_layer/tile_provider/base_tile_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/base_tile_provider.dart
@@ -197,7 +197,7 @@ abstract class TileProvider {
           ? ''
           : options.subdomains[
               (coordinates.x + coordinates.y) % options.subdomains.length],
-      'r': '@2x',
+      'r': options.retinaMode ? '@2x' : '',
       ...options.additionalOptions,
     };
   }


### PR DESCRIPTION
It seems if a `urlTemplate` contained a `{r}` it was always populated with a '@2x', instead of optionally setting that if the `TileLayer` `retina` argument was set to true.