### PR TITLE
Change pixelOrigin from a rounded Point<int> to a Point<double>

### DIFF
--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -50,15 +50,15 @@ class OverlayImage extends BaseOverlayImage {
   @override
   Positioned buildPositionedForOverlay(MapCamera map) {
     // northWest is not necessarily upperLeft depending on projection
-    final bounds = Bounds<num>(
+    final bounds = Bounds<double>(
       map.project(this.bounds.northWest).subtract(map.pixelOrigin),
       map.project(this.bounds.southEast).subtract(map.pixelOrigin),
     );
     return Positioned(
-        left: bounds.topLeft.x.toDouble(),
-        top: bounds.topLeft.y.toDouble(),
-        width: bounds.size.x.toDouble(),
-        height: bounds.size.y.toDouble(),
+        left: bounds.topLeft.x,
+        top: bounds.topLeft.y,
+        width: bounds.size.x,
+        height: bounds.size.y,
         child: buildImageForOverlay());
   }
 }

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -497,11 +497,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       ),
     );
 
-    final currentPixelOrigin = Point<double>(
-      map.pixelOrigin.x.toDouble(),
-      map.pixelOrigin.y.toDouble(),
-    );
-
     _tileScaleCalculator.clearCacheUnlessZoomMatches(map.zoom);
 
     return _addBackgroundColor(
@@ -518,7 +513,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
                 map.zoom,
                 tileImage.coordinates.z,
               ),
-              currentPixelOrigin: currentPixelOrigin,
+              currentPixelOrigin: map.pixelOrigin,
               tileImage: tileImage,
               tileBuilder: widget.tileBuilder,
             );

--- a/lib/src/map/camera/camera.dart
+++ b/lib/src/map/camera/camera.dart
@@ -58,7 +58,7 @@ class MapCamera {
   LatLngBounds? _bounds;
 
   /// Lazily calculated field
-  Point<int>? _pixelOrigin;
+  Point<double>? _pixelOrigin;
 
   /// Lazily calculated field
   double? _rotationRad;
@@ -89,8 +89,8 @@ class MapCamera {
   /// The offset of the top-left corner of the bounding rectangle of this
   /// camera. This will not equal the offset of the top-left visible pixel when
   /// the map is rotated.
-  Point<int> get pixelOrigin =>
-      _pixelOrigin ??= (project(center, zoom) - size / 2.0).round();
+  Point<double> get pixelOrigin =>
+      _pixelOrigin ??= project(center, zoom) - size / 2.0;
 
   /// The camera of the closest [FlutterMap] ancestor. If this is called from a
   /// context with no [FlutterMap] ancestor null, is returned.
@@ -118,7 +118,7 @@ class MapCamera {
     Point<double>? size,
     Bounds<double>? pixelBounds,
     LatLngBounds? bounds,
-    Point<int>? pixelOrigin,
+    Point<double>? pixelOrigin,
     double? rotationRad,
   })  : _cameraSize = size,
         _pixelBounds = pixelBounds,
@@ -258,9 +258,9 @@ class MapCamera {
 
   /// Calculates the pixel origin of this [MapCamera] at the given
   /// [center]/[zoom].
-  Point<int> getNewPixelOrigin(LatLng center, [double? zoom]) {
+  Point<double> getNewPixelOrigin(LatLng center, [double? zoom]) {
     final halfSize = size / 2.0;
-    return (project(center, zoom) - halfSize).round();
+    return project(center, zoom) - halfSize;
   }
 
   /// Calculates the pixel bounds of this [MapCamera]. This value is cached.


### PR DESCRIPTION
In all cases pixelOrigin was used it was converted back to a double, and this little tweak ensures that pixel coordinates are kept doubles everywhere. Which also simplifies the code a little.