### PR TITLE
Fixed bug where `null` `urlTemplate` caused exception in `TileLayer` construction

### DIFF
--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -306,7 +306,7 @@ class TileLayer extends StatefulWidget {
     }
     if (kDebugMode &&
         retinaMode == null &&
-        wmsOptions == null &&
+        urlTemplate != null &&
         urlTemplate!.contains('{r}')) {
       Logger(printer: PrettyPrinter(methodCount: 0)).w(
         '\x1B[1m\x1B[3mflutter_map\x1B[0m\nThe URL template includes a retina '


### PR DESCRIPTION
It's not necessarily safe to assume a URL template will be provided when WMS options are missing.
Some plugins, for example, (*cough *cough FMTC) use `TileLayer` to transport other useful information, but not the URL itself.