### PR TITLE
Feature: Add a polyline Tap

### DIFF
--- a/example/lib/pages/polyline.dart
+++ b/example/lib/pages/polyline.dart
@@ -13,6 +13,8 @@ class PolylinePage extends StatefulWidget {
 }
 
 class _PolylinePageState extends State<PolylinePage> {
+  bool isDotted = false;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -39,14 +41,21 @@ class _PolylinePageState extends State<PolylinePage> {
                     userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                   ),
                   PolylineLayer(
+                    onTap: (polyline) {
+                      setState(() {
+                        isDotted = !isDotted;
+                      });
+                    },
                     polylines: [
                       Polyline(
                         points: [
                           const LatLng(51.5, -0.09),
                           const LatLng(53.3498, -6.2603),
                           const LatLng(48.8566, 2.3522),
+                          const LatLng(52.8566, 2.3522),
                         ],
-                        strokeWidth: 4,
+                        strokeWidth: 10,
+                        useStrokeWidthInMeter: true,
                         color: Colors.purple,
                       ),
                       Polyline(
@@ -57,17 +66,21 @@ class _PolylinePageState extends State<PolylinePage> {
                         ],
                         strokeWidth: 4,
                         gradientColors: [
+                          const Color(0xff007E2D),
                           const Color(0xffE40203),
                           const Color(0xffFEED00),
-                          const Color(0xff007E2D),
                         ],
+                        isDotted: isDotted,
                       ),
                       Polyline(
+                        tag: '1',
                         points: [
                           const LatLng(50.5, -0.09),
                           const LatLng(51.3498, 6.2603),
                           const LatLng(53.8566, 2.3522),
+                          const LatLng(54.3498, -6.2603),
                         ],
+                        isDotted: isDotted,
                         strokeWidth: 20,
                         color: Colors.blue.withOpacity(0.6),
                         borderStrokeWidth: 20,
@@ -83,28 +96,32 @@ class _PolylinePageState extends State<PolylinePage> {
                         color: Colors.black.withOpacity(0.2),
                         borderStrokeWidth: 20,
                         borderColor: Colors.white30,
+                        isDotted: isDotted,
                       ),
                       Polyline(
-                        points: [
-                          const LatLng(49.1, -0.06),
-                          const LatLng(52.15, -1.4),
-                          const LatLng(55.5, 0.8),
-                        ],
-                        strokeWidth: 10,
-                        color: Colors.yellow,
-                        borderStrokeWidth: 10,
-                        borderColor: Colors.blue.withOpacity(0.5),
-                      ),
+                          points: [
+                            const LatLng(49.1, -0.06),
+                            const LatLng(52.15, -1.4),
+                            const LatLng(55.5, 0.8),
+                          ],
+                          strokeWidth: 10,
+                          color: Colors.yellow,
+                          borderStrokeWidth: 10,
+                          borderColor: Colors.blue.withOpacity(0.5),
+                          isDotted: isDotted),
                       Polyline(
                         points: [
                           const LatLng(48.1, -0.03),
                           const LatLng(50.5, -7.8),
                           const LatLng(56.5, 0.4),
+                          const LatLng(55.5, 0.8),
+                          const LatLng(52.15, -1.4),
                         ],
                         strokeWidth: 10,
                         color: Colors.amber,
                         borderStrokeWidth: 10,
                         borderColor: Colors.blue.withOpacity(0.5),
+                        isDotted: isDotted,
                       ),
                     ],
                   ),

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -9,7 +9,7 @@ import 'package:flutter_map/src/layer/general/mobile_layer_transformer.dart';
 import 'package:flutter_map/src/map/camera/camera.dart';
 import 'package:latlong2/latlong.dart';
 
-class Polyline {
+class Polyline<T extends Object> {
   final List<LatLng> points;
   final double strokeWidth;
   final Color color;
@@ -21,7 +21,20 @@ class Polyline {
   final StrokeCap strokeCap;
   final StrokeJoin strokeJoin;
   final bool useStrokeWidthInMeter;
-  final String? tag;
+
+  /// The tag of the polyline
+  ///
+  /// Tag is used to identify a [Polyline] or group of [Polyline]
+  /// Tag does not have to be unique
+  /// ```dart
+  /// PolylineLayer<T>{
+  ///   onTap: (polyline) {
+  ///     if(polyline.tag == 'polylineTag')
+  ///     myTap();
+  ///   }
+  /// }
+  /// ```
+  final T? tag;
 
   LatLngBounds? _boundingBox;
 
@@ -59,10 +72,10 @@ class Polyline {
 }
 
 @immutable
-class PolylineLayer extends StatelessWidget {
-  final List<Polyline> polylines;
+class PolylineLayer<T extends Object> extends StatelessWidget {
+  final List<Polyline<T>> polylines;
   final bool polylineCulling;
-  final void Function(Polyline polyline)? onTap;
+  final void Function(Polyline<T> polyline)? onTap;
 
   const PolylineLayer({
     super.key,
@@ -89,7 +102,7 @@ class PolylineLayer extends StatelessWidget {
                 (polyline) => GestureDetector(
                   onTap: maybeTap != null ? () => maybeTap(polyline) : null,
                   child: CustomPaint(
-                    painter: PolylinePainter(
+                    painter: PolylinePainter<T>(
                       polyline,
                       map,
                     ),
@@ -103,8 +116,8 @@ class PolylineLayer extends StatelessWidget {
   }
 }
 
-class PolylinePainter extends CustomPainter {
-  final Polyline polyline;
+class PolylinePainter<T extends Object> extends CustomPainter {
+  final Polyline<T> polyline;
 
   final MapCamera map;
   final LatLngBounds bounds;
@@ -308,17 +321,17 @@ class PolylinePainter extends CustomPainter {
     path.addPolygon(offsets, false);
   }
 
-  ui.Gradient _paintGradient(Polyline polyline, List<Offset> offsets) =>
+  ui.Gradient _paintGradient(Polyline<T> polyline, List<Offset> offsets) =>
       ui.Gradient.linear(offsets.first, offsets.last, polyline.gradientColors!,
           _getColorsStop(polyline));
 
-  List<double>? _getColorsStop(Polyline polyline) =>
+  List<double>? _getColorsStop(Polyline<T> polyline) =>
       (polyline.colorsStop != null &&
               polyline.colorsStop!.length == polyline.gradientColors!.length)
           ? polyline.colorsStop
           : _calculateColorsStop(polyline);
 
-  List<double> _calculateColorsStop(Polyline polyline) {
+  List<double> _calculateColorsStop(Polyline<T> polyline) {
     final colorsStopInterval = 1.0 / polyline.gradientColors!.length;
     return polyline.gradientColors!
         .map((gradientColor) =>
@@ -331,7 +344,7 @@ class PolylinePainter extends CustomPainter {
   bool hitTest(Offset position) => _touchablePath.contains(position);
 
   @override
-  bool shouldRepaint(PolylinePainter oldDelegate) {
+  bool shouldRepaint(PolylinePainter<T> oldDelegate) {
     return oldDelegate.bounds != bounds || oldDelegate.hash != hash;
   }
 }

--- a/test/layer/polyline_layer_test.dart
+++ b/test/layer/polyline_layer_test.dart
@@ -24,12 +24,5 @@ void main() {
     await tester.pumpWidget(TestApp(polylines: polylines));
     expect(find.byType(FlutterMap), findsOneWidget);
     expect(find.byType(PolylineLayer), findsWidgets);
-
-    // Assert that batching works and all Polylines are drawn into the same
-    // CustomPaint/Canvas.
-    expect(
-        find.descendant(
-            of: find.byType(PolylineLayer), matching: find.byType(CustomPaint)),
-        findsOneWidget);
   });
 }


### PR DESCRIPTION
Add a polyline tap that can be specific to each polyline in the the Layer. Also now the layer does not take the size of the all map but a tap outside a polyline is directly passed to the map onTap.
This PR is linked to this [issue](https://github.com/fleaflet/flutter_map/issues/1685)