### PR TITLE
fix: Revert "Adjusted default `MapOptions.cameraConstraint` to prevent out-of-bounds viewing"

### DIFF
--- a/lib/src/map/options/options.dart
+++ b/lib/src/map/options/options.dart
@@ -308,10 +308,7 @@ class MapOptions {
       _cameraConstraint ??
       (maxBounds != null
           ? CameraConstraint.contain(bounds: maxBounds!)
-          : CameraConstraint.contain(
-              bounds:
-                  LatLngBounds(const LatLng(-90, -180), const LatLng(90, 180)),
-            ));
+          : const CameraConstraint.unconstrained());
 
   @override
   bool operator ==(Object other) =>


### PR DESCRIPTION
Quick fix #1682
Quick fix #1699 (I'm assuming)

Needs a more permanent fix in future, as the zoom gesture handling code obviously doesn't work quite right. Zoom should never be 'trapped' (#1699), and it should handle rubbing against bounds.