### PR TITLE
fix: multiple bugs when neither `wmsOptions` nor `urlTemplate` were provided

### DIFF
--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -338,7 +338,7 @@ class TileLayer extends StatefulWidget {
 
     // Retina Mode Setup
     resolvedRetinaMode = (retinaMode ?? false)
-        ? wmsOptions == null && urlTemplate!.contains('{r}')
+        ? wmsOptions == null && (urlTemplate?.contains('{r}') ?? false)
             ? RetinaMode.server
             : RetinaMode.simulation
         : RetinaMode.disabled;

--- a/lib/src/layer/tile_layer/tile_provider/base_tile_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/base_tile_provider.dart
@@ -215,16 +215,20 @@ abstract class TileProvider {
   /// 1. [populateTemplatePlaceholders]
   /// 2. [generateReplacementMap]
   /// 3. [getTileUrl] and/or [getTileFallbackUrl]
+  ///
+  /// Note to implementors: it is not safe to assume that at least one of
+  /// `wmsOptions` or `urlTemplate` will be non-null.
   /// {@endtemplate}
   String getTileUrl(TileCoordinates coordinates, TileLayer options) =>
       populateTemplatePlaceholders(
-        options.wmsOptions != null
-            ? options.wmsOptions!.getUrl(
-                coordinates,
-                options.tileSize.toInt(),
-                options.resolvedRetinaMode == RetinaMode.simulation,
-              )
-            : options.urlTemplate!,
+        options.wmsOptions?.getUrl(
+              coordinates,
+              options.tileSize.toInt(),
+              options.resolvedRetinaMode == RetinaMode.simulation,
+            ) ??
+            options.urlTemplate ??
+            (throw ArgumentError(
+                '`wmsOptions` or `urlTemplate` must be provided to generate a tile URL')),
         coordinates,
         options,
       );


### PR DESCRIPTION
- Fixed bug where not providing either `wmsOptions` nor `urlTemplate` caused a null exception in `getTileUrl`
- Fixed bug where not providing either `wmsOptions` nor `urlTemplate` caused a null exception when `retinaMode` was `true` Added in-code documentation for `TileProvider` authors
- Added in-code documentation for `TileProvider` authors