### PR TITLE
perf: reduce tile management overhead

### DIFF
--- a/lib/src/layer/tile_layer/tile_bounds/tile_bounds_at_zoom.dart
+++ b/lib/src/layer/tile_layer/tile_bounds/tile_bounds_at_zoom.dart
@@ -112,12 +112,11 @@ class WrappedTileBoundsAtZoom extends TileBoundsAtZoom {
   }
 
   bool _wrappedBothContains(TileCoordinates coordinates) {
-    return tileRange.contains(
-      Point(
-        _wrapInt(coordinates.x, wrapX!),
-        _wrapInt(coordinates.y, wrapY!),
-      ),
-    );
+    return tileRange.contains(TileCoordinates(
+      _wrapInt(coordinates.x, wrapX!),
+      _wrapInt(coordinates.y, wrapY!),
+      coordinates.z,
+    ));
   }
 
   bool _wrappedXInRange(TileCoordinates coordinates) {

--- a/lib/src/layer/tile_layer/tile_bounds/tile_bounds_at_zoom.dart
+++ b/lib/src/layer/tile_layer/tile_bounds/tile_bounds_at_zoom.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter_map/src/layer/tile_layer/tile_coordinates.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_range.dart';
 import 'package:meta/meta.dart';

--- a/lib/src/layer/tile_layer/tile_coordinates.dart
+++ b/lib/src/layer/tile_layer/tile_coordinates.dart
@@ -8,14 +8,11 @@ class TileCoordinates extends Point<int> {
 
   const TileCoordinates(super.x, super.y, this.z);
 
-  String get key => '$x:$y:$z';
-
   @override
   String toString() => 'TileCoordinate($x, $y, $z)';
 
   // Overridden because Point's distanceTo does not allow comparing with a point
   // of a different type.
-  @override
   double distanceTo(Point<num> other) {
     final dx = x - other.x;
     final dy = y - other.y;
@@ -24,7 +21,9 @@ class TileCoordinates extends Point<int> {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other)) return true;
+    if (identical(this, other)) {
+      return true;
+    }
     return other is TileCoordinates &&
         other.x == x &&
         other.y == y &&
@@ -32,5 +31,8 @@ class TileCoordinates extends Point<int> {
   }
 
   @override
-  int get hashCode => Object.hash(x.hashCode, y.hashCode, z.hashCode);
+  int get hashCode {
+    // NOTE: the odd numbers are due to JavaScript's integer precision of 53 bits.
+    return x | y << 24 | z << 48;
+  }
 }

--- a/lib/src/layer/tile_layer/tile_coordinates.dart
+++ b/lib/src/layer/tile_layer/tile_coordinates.dart
@@ -13,6 +13,7 @@ class TileCoordinates extends Point<int> {
 
   // Overridden because Point's distanceTo does not allow comparing with a point
   // of a different type.
+  @override
   double distanceTo(Point<num> other) {
     final dx = x - other.x;
     final dy = y - other.y;
@@ -21,9 +22,7 @@ class TileCoordinates extends Point<int> {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
+    if (identical(this, other)) return true;
     return other is TileCoordinates &&
         other.x == x &&
         other.y == y &&

--- a/lib/src/layer/tile_layer/tile_image.dart
+++ b/lib/src/layer/tile_layer/tile_image.dart
@@ -83,7 +83,7 @@ class TileImage extends ChangeNotifier {
 
   AnimationController? get animation => _animationController;
 
-  String get coordinatesKey => coordinates.key;
+  TileCoordinates get coordinatesKey => coordinates;
 
   /// Whether the tile is displayable. This means that either:
   ///   * Loading errored but an error image is configured.

--- a/lib/src/layer/tile_layer/tile_image_manager.dart
+++ b/lib/src/layer/tile_layer/tile_image_manager.dart
@@ -13,10 +13,10 @@ typedef TileCreator = TileImage Function(TileCoordinates coordinates);
 
 @immutable
 class TileImageManager {
-  final Map<String, TileImage> _tiles = {};
+  final Map<TileCoordinates, TileImage> _tiles = {};
 
   bool containsTileAt(TileCoordinates coordinates) =>
-      _tiles.containsKey(coordinates.key);
+      _tiles.containsKey(coordinates);
 
   bool get allLoaded =>
       _tiles.values.none((tile) => tile.loadFinishedAt == null);
@@ -44,7 +44,7 @@ class TileImageManager {
   }) {
     for (final coordinates in tileBoundsAtZoom.validCoordinatesIn(tileRange)) {
       _tiles.putIfAbsent(
-        coordinates.key,
+        coordinates,
         () => createTileImage(coordinates),
       );
     }
@@ -64,7 +64,7 @@ class TileImageManager {
 
     for (final coordinates in tileCoordinates) {
       final tile = _tiles.putIfAbsent(
-        coordinates.key,
+        coordinates,
         () => createTile(coordinates),
       );
 
@@ -83,7 +83,7 @@ class TileImageManager {
   /// All removals should be performed by calling this method to ensure that
   // disposal is performed correctly.
   void _remove(
-    String key, {
+    TileCoordinates key, {
     required bool Function(TileImage tileImage) evictImageFromCache,
   }) {
     final removed = _tiles.remove(key);
@@ -94,7 +94,7 @@ class TileImageManager {
   }
 
   void _removeWithEvictionStrategy(
-    String key,
+    TileCoordinates key,
     EvictErrorTileStrategy strategy,
   ) {
     _remove(
@@ -105,7 +105,7 @@ class TileImageManager {
   }
 
   void removeAll(EvictErrorTileStrategy evictStrategy) {
-    final keysToRemove = List<String>.from(_tiles.keys);
+    final keysToRemove = List<TileCoordinates>.from(_tiles.keys);
 
     for (final key in keysToRemove) {
       _removeWithEvictionStrategy(key, evictStrategy);

--- a/lib/src/layer/tile_layer/tile_image_view.dart
+++ b/lib/src/layer/tile_layer/tile_image_view.dart
@@ -5,12 +5,12 @@ import 'package:flutter_map/src/layer/tile_layer/tile_image.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_range.dart';
 
 class TileImageView {
-  final Map<String, TileImage> _tileImages;
+  final Map<TileCoordinates, TileImage> _tileImages;
   final DiscreteTileRange _visibleRange;
   final DiscreteTileRange _keepRange;
 
   TileImageView({
-    required Map<String, TileImage> tileImages,
+    required Map<TileCoordinates, TileImage> tileImages,
     required DiscreteTileRange visibleRange,
     required DiscreteTileRange keepRange,
   })  : _tileImages = UnmodifiableMapView(tileImages),
@@ -62,7 +62,7 @@ class TileImageView {
     final z2 = z - 1;
     final coords2 = TileCoordinates(x2, y2, z2);
 
-    final tile = _tileImages[coords2.key];
+    final tile = _tileImages[coords2];
     if (tile != null) {
       if (tile.readyToDisplay) {
         retain.add(tile);
@@ -92,7 +92,7 @@ class TileImageView {
       for (var j = 2 * y; j < 2 * y + 2; j++) {
         final coords = TileCoordinates(i, j, z + 1);
 
-        final tile = _tileImages[coords.key];
+        final tile = _tileImages[coords];
         if (tile != null) {
           if (tile.readyToDisplay || tile.loadFinishedAt != null) {
             retain.add(tile);

--- a/test/layer/tile_layer/tile_image_view_test.dart
+++ b/test/layer/tile_layer/tile_image_view_test.dart
@@ -13,18 +13,18 @@ import 'package:test/test.dart';
 import '../../test_utils/test_tile_image.dart';
 
 void main() {
-  Map<String, TileImage> tileImagesMappingFrom(List<TileImage> tileImages) => {
-        for (final tileImage in tileImages) tileImage.coordinates.key: tileImage
-      };
+  Map<TileCoordinates, TileImage> tileImagesMappingFrom(
+          List<TileImage> tileImages) =>
+      {for (final tileImage in tileImages) tileImage.coordinates: tileImage};
 
   Matcher containsTileImage(
-    Map<String, TileImage> tileImages,
+    Map<TileCoordinates, TileImage> tileImages,
     TileCoordinates coordinates,
   ) =>
-      contains(tileImages[coordinates.key]);
+      contains(tileImages[coordinates]);
 
   Matcher doesNotContainTileImage(
-    Map<String, TileImage> tileImages,
+    Map<TileCoordinates, TileImage> tileImages,
     TileCoordinates coordinates,
   ) =>
       isNot(containsTileImage(tileImages, coordinates));


### PR DESCRIPTION
Consumed some single digit percent frame time for me. Improved contributions: 

* Don't compute hash of hashes.
 * Cheap custom hash.
 * Avoid string interpolation.

Also as a drive-by get rid of the TileCoordinates extends Point + zoom coordinate in favor of more consistent composition.