### PR TITLE
fix: remove flutter_map text attribution when `showFlutterMapAttribution` is `false`

### DIFF
--- a/lib/src/layer/attribution_layer/rich/widget.dart
+++ b/lib/src/layer/attribution_layer/rich/widget.dart
@@ -254,11 +254,12 @@ class _RichAttributionWidgetState extends State<RichAttributionWidget> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       ...widget.attributions.whereType<TextSourceAttribution>(),
-                      const TextSourceAttribution(
-                        "Made with 'flutter_map'",
-                        prependCopyright: false,
-                        textStyle: TextStyle(fontStyle: FontStyle.italic),
-                      ),
+                      if (widget.showFlutterMapAttribution)
+                        const TextSourceAttribution(
+                          "Made with 'flutter_map'",
+                          prependCopyright: false,
+                          textStyle: TextStyle(fontStyle: FontStyle.italic),
+                        ),
                       SizedBox(height: (widget.permanentHeight - 24) + 32),
                     ],
                   ),


### PR DESCRIPTION
When `showFlutterMapAttribution` is false, there is still a text "Made with 'flutter_map' that is displayed. This PR removes it.

![bild](https://github.com/fleaflet/flutter_map/assets/118986082/ec601b65-ed5b-4a5b-a286-c665f4652a29)
