### PR TITLE
fix: repair `TileLayer.tileBounds`

### DIFF
--- a/lib/src/layer/tile_layer/tile_bounds/tile_bounds.dart
+++ b/lib/src/layer/tile_layer/tile_bounds/tile_bounds.dart
@@ -107,7 +107,7 @@ class WrappedTileBounds extends TileBounds {
   ) : super._();
 
   @override
-  WrappedTileBoundsAtZoom atZoom(int zoom) {
+  TileBoundsAtZoom atZoom(int zoom) {
     return _tileBoundsAtZoomCache.putIfAbsent(
         zoom, () => _tileBoundsAtZoomImpl(zoom));
   }
@@ -125,15 +125,13 @@ class WrappedTileBounds extends TileBounds {
       );
     }
 
-    final tzDouble = zoom.toDouble();
-
     (int, int)? wrapX;
     if (crs.wrapLng case final wrapLng?) {
       final wrapXMin =
-          (crs.latLngToPoint(LatLng(0, wrapLng.$1), tzDouble).x / _tileSize)
+          (crs.latLngToPoint(LatLng(0, wrapLng.$1), zoomDouble).x / _tileSize)
               .floor();
       final wrapXMax =
-          (crs.latLngToPoint(LatLng(0, wrapLng.$2), tzDouble).x / _tileSize)
+          (crs.latLngToPoint(LatLng(0, wrapLng.$2), zoomDouble).x / _tileSize)
               .ceil();
       wrapX = (wrapXMin, wrapXMax - 1);
     }
@@ -141,10 +139,10 @@ class WrappedTileBounds extends TileBounds {
     (int, int)? wrapY;
     if (crs.wrapLat case final wrapLat?) {
       final wrapYMin =
-          (crs.latLngToPoint(LatLng(wrapLat.$1, 0), tzDouble).y / _tileSize)
+          (crs.latLngToPoint(LatLng(wrapLat.$1, 0), zoomDouble).y / _tileSize)
               .floor();
       final wrapYMax =
-          (crs.latLngToPoint(LatLng(wrapLat.$2, 0), tzDouble).y / _tileSize)
+          (crs.latLngToPoint(LatLng(wrapLat.$2, 0), zoomDouble).y / _tileSize)
               .ceil();
       wrapY = (wrapYMin, wrapYMax - 1);
     }

--- a/lib/src/layer/tile_layer/tile_bounds/tile_bounds_at_zoom.dart
+++ b/lib/src/layer/tile_layer/tile_bounds/tile_bounds_at_zoom.dart
@@ -119,7 +119,7 @@ class WrappedTileBoundsAtZoom extends TileBoundsAtZoom {
 
   bool _wrappedXInRange(TileCoordinates coordinates) {
     final wrappedX = _wrapInt(coordinates.x, wrapX!);
-    return wrappedX >= tileRange.min.x && wrappedX <= tileRange.max.y;
+    return wrappedX >= tileRange.min.x && wrappedX <= tileRange.max.x;
   }
 
   bool _wrappedYInRange(TileCoordinates coordinates) {

--- a/lib/src/map/options/options.dart
+++ b/lib/src/map/options/options.dart
@@ -117,7 +117,7 @@ class MapOptions {
   /// map themselves. Without this, only the top layer may handle gestures.
   ///
   /// Note that layers that are visually obscured behind another layer will
-  /// recieve events, if this is enabled.
+  /// receive events, if this is enabled.
   ///
   /// Technically, layers become invisible to the parent `Stack` when hit
   /// testing (and thus `Stack` will keep bubbling gestures down all layers), but


### PR DESCRIPTION
This pull request fixes the TileLayer.tileBounds property (issue https://github.com/fleaflet/flutter_map/issues/1710).
It was such a small bug that I overlooked it multiple times. 🥲

Additionally it fixes a typo and removes a duplicate variable.

<details>
  <summary>See a minimal example here</summary>
  
```dart
import 'package:flutter/material.dart';
import 'package:flutter_map/flutter_map.dart';
import 'package:latlong2/latlong.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
        home: TileBoundsTest(),
    );
  }
}

class TileBoundsTest extends StatelessWidget {
  const TileBoundsTest({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: const Text('Tile bounds test')),
      body: Padding(
        padding: const EdgeInsets.all(8),
        child: Column(
          children: [
            Flexible(
              child: FlutterMap(
                options: const MapOptions(
                  initialCenter: LatLng(53.189206, -1.821145),
                  initialZoom: 5,
                ),
                children: [
                  TileLayer(
                    urlTemplate:
                    'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                    userAgentPackageName: 'dev.fleaflet.flutter_map.example',
                    tileBounds: LatLngBounds(
                      const LatLng(58.429514, -13.084017),
                      const LatLng(50.221127, 1.802305),
                    ), // uk bounds
                  ),
                ],
              ),
            ),
          ],
        ),
      ),
    );
  }
}
```
</details>