### PR TITLE
perf!: remove unnecessary rounding and surrounding features, and produce less garbage

### DIFF
--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -4,7 +4,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_map/src/layer/general/mobile_layer_transformer.dart';
 import 'package:flutter_map/src/map/camera/camera.dart';
 import 'package:flutter_map/src/misc/bounds.dart';
-import 'package:flutter_map/src/misc/point_extensions.dart';
 import 'package:latlong2/latlong.dart';
 
 /// A container for a [child] widget located at a geographic coordinate [point]
@@ -126,7 +125,7 @@ class MarkerLayer extends StatelessWidget {
             )) continue;
 
             // Apply map camera to marker position
-            final pos = pxPoint.subtract(map.pixelOrigin);
+            final pos = pxPoint - map.pixelOrigin;
 
             yield Positioned(
               key: m.key,

--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -66,8 +66,8 @@ class OverlayImage extends BaseOverlayImage {
   }) {
     // northWest is not necessarily upperLeft depending on projection
     final bounds = Bounds<double>(
-      camera.project(this.bounds.northWest).subtract(camera.pixelOrigin),
-      camera.project(this.bounds.southEast).subtract(camera.pixelOrigin),
+      camera.project(this.bounds.northWest) - camera.pixelOrigin,
+      camera.project(this.bounds.southEast) - camera.pixelOrigin,
     );
 
     return Positioned(
@@ -111,12 +111,10 @@ class RotatedOverlayImage extends BaseOverlayImage {
     required Image child,
     required MapCamera camera,
   }) {
-    final pxTopLeft =
-        camera.project(topLeftCorner).subtract(camera.pixelOrigin);
+    final pxTopLeft = camera.project(topLeftCorner) - camera.pixelOrigin;
     final pxBottomRight =
-        camera.project(bottomRightCorner).subtract(camera.pixelOrigin);
-    final pxBottomLeft =
-        camera.project(bottomLeftCorner).subtract(camera.pixelOrigin);
+        camera.project(bottomRightCorner) - camera.pixelOrigin;
+    final pxBottomLeft = camera.project(bottomLeftCorner) - camera.pixelOrigin;
 
     /// calculate pixel coordinate of top-right corner by calculating the
     /// vector from bottom-left to top-left and adding it to bottom-right
@@ -129,7 +127,7 @@ class RotatedOverlayImage extends BaseOverlayImage {
 
     final vectorX = (pxTopRight - pxTopLeft) / bounds.size.x;
     final vectorY = (pxBottomLeft - pxTopLeft) / bounds.size.y;
-    final offset = pxTopLeft.subtract(bounds.topLeft);
+    final offset = pxTopLeft - bounds.topLeft;
 
     final a = vectorX.x;
     final b = vectorX.y;

--- a/lib/src/layer/polygon_layer/label.dart
+++ b/lib/src/layer/polygon_layer/label.dart
@@ -6,13 +6,6 @@ import 'package:flutter_map/src/layer/polygon_layer/polygon_layer.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:polylabel/polylabel.dart';
 
-class PolygonBounds {
-  final Offset min;
-  final Offset max;
-
-  const PolygonBounds(this.min, this.max);
-}
-
 void Function(Canvas canvas)? buildLabelTextPainter({
   required math.Point<double> mapSize,
   required Offset placementPoint,

--- a/lib/src/layer/polygon_layer/label.dart
+++ b/lib/src/layer/polygon_layer/label.dart
@@ -6,6 +6,13 @@ import 'package:flutter_map/src/layer/polygon_layer/polygon_layer.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:polylabel/polylabel.dart';
 
+class PolygonBounds {
+  final Offset min;
+  final Offset max;
+
+  const PolygonBounds(this.min, this.max);
+}
+
 void Function(Canvas canvas)? buildLabelTextPainter({
   required math.Point<double> mapSize,
   required Offset placementPoint,

--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -5,7 +5,6 @@ import 'package:flutter_map/src/geo/latlng_bounds.dart';
 import 'package:flutter_map/src/layer/general/mobile_layer_transformer.dart';
 import 'package:flutter_map/src/layer/polygon_layer/label.dart';
 import 'package:flutter_map/src/map/camera/camera.dart';
-import 'package:flutter_map/src/misc/bounds.dart';
 import 'package:flutter_map/src/misc/point_extensions.dart';
 import 'package:latlong2/latlong.dart' hide Path; // conflict with Path from UI
 

--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -5,6 +5,8 @@ import 'package:flutter_map/src/geo/latlng_bounds.dart';
 import 'package:flutter_map/src/layer/general/mobile_layer_transformer.dart';
 import 'package:flutter_map/src/layer/polygon_layer/label.dart';
 import 'package:flutter_map/src/map/camera/camera.dart';
+import 'package:flutter_map/src/misc/bounds.dart';
+import 'package:flutter_map/src/misc/point_extensions.dart';
 import 'package:latlong2/latlong.dart' hide Path; // conflict with Path from UI
 
 enum PolygonLabelPlacement {
@@ -160,20 +162,24 @@ class PolygonPainter extends CustomPainter {
 
   int? _hash;
 
-  ({Offset min, Offset max}) getBounds(Polygon polygon) {
+  ({Offset min, Offset max}) getBounds(Offset origin, Polygon polygon) {
     final bbox = polygon.boundingBox;
     return (
-      min: map.getOffsetFromOrigin(bbox.southWest),
-      max: map.getOffsetFromOrigin(bbox.northEast),
+      min: getOffset(origin, bbox.southWest),
+      max: getOffset(origin, bbox.northEast),
     );
   }
 
-  List<Offset> getOffsets(List<LatLng> points) {
+  Offset getOffset(Offset origin, LatLng point) {
+    // Critically create as little garbage as possible. This is called on every frame.
+    final projected = map.project(point);
+    return Offset(projected.x - origin.dx, projected.y - origin.dy);
+  }
+
+  List<Offset> getOffsets(Offset origin, List<LatLng> points) {
     return List.generate(
       points.length,
-      (index) {
-        return map.getOffsetFromOrigin(points[index]);
-      },
+      (index) => getOffset(origin, points[index]),
       growable: false,
     );
   }
@@ -213,12 +219,14 @@ class PolygonPainter extends CustomPainter {
       lastHash = null;
     }
 
+    final origin = (map.project(map.center) - map.size / 2).toOffset();
+
     // Main loop constructing batched fill and border paths from given polygons.
     for (final polygon in polygons) {
       if (polygon.points.isEmpty) {
         continue;
       }
-      final offsets = getOffsets(polygon.points);
+      final offsets = getOffsets(origin, polygon.points);
 
       // The hash is based on the polygons visual properties. If the hash from
       // the current and the previous polygon no longer match, we need to flush
@@ -248,7 +256,7 @@ class PolygonPainter extends CustomPainter {
 
         final holeOffsetsList = List<List<Offset>>.generate(
           holePointsList.length,
-          (i) => getOffsets(holePointsList[i]),
+          (i) => getOffsets(origin, holePointsList[i]),
           growable: false,
         );
 
@@ -274,7 +282,7 @@ class PolygonPainter extends CustomPainter {
         final painter = buildLabelTextPainter(
           mapSize: map.size,
           placementPoint: map.getOffsetFromOrigin(polygon.labelPosition),
-          bounds: getBounds(polygon),
+          bounds: getBounds(origin, polygon),
           textPainter: polygon.textPainter!,
           rotationRad: map.rotationRad,
           rotate: polygon.rotateLabel,
@@ -301,8 +309,9 @@ class PolygonPainter extends CustomPainter {
         if (textPainter != null) {
           final painter = buildLabelTextPainter(
             mapSize: map.size,
-            placementPoint: map.getOffsetFromOrigin(polygon.labelPosition),
-            bounds: getBounds(polygon),
+            placementPoint:
+                map.project(polygon.labelPosition).toOffset() - origin,
+            bounds: getBounds(origin, polygon),
             textPainter: textPainter,
             rotationRad: map.rotationRad,
             rotate: polygon.rotateLabel,

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_map/src/geo/latlng_bounds.dart';
 import 'package:flutter_map/src/layer/general/mobile_layer_transformer.dart';
 import 'package:flutter_map/src/map/camera/camera.dart';
+import 'package:flutter_map/src/misc/point_extensions.dart';
 import 'package:latlong2/latlong.dart';
 
 class Polyline {
@@ -97,13 +98,19 @@ class PolylinePainter extends CustomPainter {
 
   int? _hash;
 
-  List<Offset> getOffsets(List<LatLng> points) {
-    return List.generate(points.length, (index) {
-      return getOffset(points[index]);
-    }, growable: false);
+  Offset getOffset(Offset origin, LatLng point) {
+    // Critically create as little garbage as possible. This is called on every frame.
+    final projected = map.project(point);
+    return Offset(projected.x - origin.dx, projected.y - origin.dy);
   }
 
-  Offset getOffset(LatLng point) => map.getOffsetFromOrigin(point);
+  List<Offset> getOffsets(Offset origin, List<LatLng> points) {
+    return List.generate(
+      points.length,
+      (index) => getOffset(origin, points[index]),
+      growable: false,
+    );
+  }
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -144,8 +151,10 @@ class PolylinePainter extends CustomPainter {
       paint = Paint();
     }
 
+    final origin = map.project(map.center).toOffset() - map.size.toOffset() / 2;
+
     for (final polyline in polylines) {
-      final offsets = getOffsets(polyline.points);
+      final offsets = getOffsets(origin, polyline.points);
       if (offsets.isEmpty) {
         continue;
       }
@@ -167,7 +176,7 @@ class PolylinePainter extends CustomPainter {
           polyline.strokeWidth,
           180,
         );
-        final delta = firstOffset - getOffset(r);
+        final delta = firstOffset - getOffset(origin, r);
 
         strokeWidth = delta.distance;
       } else {

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -25,7 +25,6 @@ import 'package:flutter_map/src/layer/tile_layer/tile_update_transformer.dart';
 import 'package:flutter_map/src/map/camera/camera.dart';
 import 'package:flutter_map/src/map/controller/map_controller.dart';
 import 'package:flutter_map/src/misc/bounds.dart';
-import 'package:flutter_map/src/misc/point_extensions.dart';
 import 'package:http/retry.dart';
 import 'package:logger/logger.dart';
 
@@ -533,8 +532,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     );
 
     final currentPixelOrigin = Point<double>(
-      map.pixelOrigin.x.toDouble(),
-      map.pixelOrigin.y.toDouble(),
+      map.pixelOrigin.x,
+      map.pixelOrigin.y,
     );
 
     _tileScaleCalculator.clearCacheUnlessZoomMatches(map.zoom);

--- a/lib/src/layer/tile_layer/wms_tile_layer_options.dart
+++ b/lib/src/layer/tile_layer/wms_tile_layer_options.dart
@@ -69,9 +69,8 @@ class WMSTileLayerOptions {
   }
 
   String getUrl(TileCoordinates coords, int tileSize, bool retinaMode) {
-    final tileSizePoint = Point(tileSize, tileSize);
-    final nwPoint = coords.scaleBy(tileSizePoint);
-    final sePoint = nwPoint + tileSizePoint;
+    final nwPoint = coords * tileSize;
+    final sePoint = nwPoint + Point<int>(tileSize, tileSize);
     final nwCoords = crs.pointToLatLng(nwPoint, coords.z.toDouble());
     final seCoords = crs.pointToLatLng(sePoint, coords.z.toDouble());
     final nw = crs.projection.project(nwCoords);

--- a/lib/src/map/camera/camera.dart
+++ b/lib/src/map/camera/camera.dart
@@ -281,8 +281,7 @@ class MapCamera {
   /// This will convert a latLng to a position that we could use with a widget
   /// outside of FlutterMap layer space. Eg using a Positioned Widget.
   Point<double> latLngToScreenPoint(LatLng latLng) {
-    final nonRotatedPixelOrigin =
-        (project(center, zoom) - nonRotatedSize / 2.0).round();
+    final nonRotatedPixelOrigin = project(center, zoom) - nonRotatedSize / 2.0;
 
     var point = crs.latLngToPoint(latLng, zoom);
 
@@ -292,7 +291,7 @@ class MapCamera {
       point = rotatePoint(mapCenter, point, counterRotation: false);
     }
 
-    return point.subtract(nonRotatedPixelOrigin);
+    return point - nonRotatedPixelOrigin;
   }
 
   LatLng pointToLatLng(Point localPoint) {

--- a/lib/src/map/camera/camera.dart
+++ b/lib/src/map/camera/camera.dart
@@ -58,7 +58,7 @@ class MapCamera {
   LatLngBounds? _bounds;
 
   /// Lazily calculated field
-  Point<int>? _pixelOrigin;
+  Point<double>? _pixelOrigin;
 
   /// Lazily calculated field
   double? _rotationRad;
@@ -89,8 +89,8 @@ class MapCamera {
   /// The offset of the top-left corner of the bounding rectangle of this
   /// camera. This will not equal the offset of the top-left visible pixel when
   /// the map is rotated.
-  Point<int> get pixelOrigin =>
-      _pixelOrigin ??= (project(center, zoom) - size / 2.0).round();
+  Point<double> get pixelOrigin =>
+      _pixelOrigin ??= project(center, zoom) - size / 2.0;
 
   /// The camera of the closest [FlutterMap] ancestor. If this is called from a
   /// context with no [FlutterMap] ancestor null, is returned.
@@ -118,7 +118,7 @@ class MapCamera {
     Point<double>? size,
     Bounds<double>? pixelBounds,
     LatLngBounds? bounds,
-    Point<int>? pixelOrigin,
+    Point<double>? pixelOrigin,
     double? rotationRad,
   })  : _cameraSize = size,
         _pixelBounds = pixelBounds,
@@ -254,7 +254,7 @@ class MapCamera {
 
   /// Calculates the [Offset] from the [pos] to this camera's [pixelOrigin].
   Offset getOffsetFromOrigin(LatLng pos) =>
-      project(pos).subtract(pixelOrigin).toOffset();
+      (project(pos) - pixelOrigin).toOffset();
 
   /// Calculates the pixel origin of this [MapCamera] at the given
   /// [center]/[zoom].

--- a/lib/src/misc/point_extensions.dart
+++ b/lib/src/misc/point_extensions.dart
@@ -67,53 +67,11 @@ extension PointExtension<T extends num> on Point<T> {
 /// Point<int>(1, 2).subtract(1.5) would cause a runtime error because the
 /// resulting x/y values are doubles and the return value is a Point<int> since
 /// the method returns Point<T>.
-///
-/// Note that division methods (unscaleBy and the / operator) are defined on
-/// Point<T extends num> with a Point<double> return argument because division
-/// always returns a double.
 extension DoublePointExtension on Point<double> {
   /// Subtract [other] from this Point.
+  @Deprecated('camera.pixelOrigin is now a Point<double>. Prefer operator-.')
   Point<double> subtract(Point<num> other) {
     return Point(x - other.x, y - other.y);
-  }
-
-  /// Add [other] to this Point.
-  Point<double> add(Point<num> other) {
-    return Point(x + other.x, y + other.y);
-  }
-
-  /// Create a new [Point] where [x] and [y] values are scaled by the respective
-  /// values in [other].
-  Point<double> scaleBy(Point<num> other) {
-    return Point<double>(x * other.x, y * other.y);
-  }
-}
-
-/// This extension contains methods which, if defined on Point<T extends num>,
-/// could cause a runtime error when called on a Point<int> with a non-int
-/// argument. An example:
-///
-/// Point<int>(1, 2).subtract(1.5) would cause a runtime error because the
-/// resulting x/y values are doubles and the return value is a Point<int> since
-/// the method returns Point<T>.
-///
-/// The methods in this extension only take Point<int> arguments to prevent
-/// this.
-extension IntegerPointExtension on Point<int> {
-  /// Subtract [other] from this Point.
-  Point<int> subtract(Point<int> other) {
-    return Point(x - other.x, y - other.y);
-  }
-
-  /// Add [other] to this Point.
-  Point<int> add(Point<int> other) {
-    return Point(x + other.x, y + other.y);
-  }
-
-  /// Create a new [Point] where [x] and [y] values are scaled by the respective
-  /// values in [other].
-  Point<int> scaleBy(Point<int> other) {
-    return Point<int>(x * other.x, y * other.y);
   }
 }
 


### PR DESCRIPTION
Sorry, this combines a bunch of things that could be pulled apart. This is the result of me going on a spree trying to speed up Polygons, which are still the slowest experience in my App.

In a nutshell:
1. Cleaned up some internals in CRS. Addressed a couple potential sources for exceptions why may have been the reason for the whole try/catch. Arguably the recovery in the catch doesn't make much sense.
2. Then I noticed that pixelOrigin is rounding, which is plain wrong because Flutter operates on virtual pixels which can be fractional. So this rounding can introduce visual artifacts at no benefits.
3. Then I noticed that there's an entire family of Point extensions just to cover up the erroneous rounding. So I removed those (mostly). Also `scaleBy` is not a vector scaling operation. I don't know what it is or what it would ever be used for. So I removed it as well.
4. Finally, actually speed up polylines and polygons by doing less work, producing less garbage, and culling labels for polygons.

This is were @JaffaKetchup is hopefully going to say: "(2) and (3) break public APIs" :)

I'd argue that (2) is a bug that needs fixing. Whereas (3) is negotiable. Note that I left the `Point<double>.subtract` method, which I presume is the only one ever used to deal with (2). I definitely don't think we're setting a good example by helping dig a hole into type-safety :).