### PR TITLE
perf!: reduce work to build and fix bugs in `TileLayer`, and improve culling of off-screen tiles

### DIFF
--- a/lib/src/geo/crs.dart
+++ b/lib/src/geo/crs.dart
@@ -39,14 +39,14 @@ abstract class Crs {
   double zoom(double scale) => math.log(scale / 256) / math.ln2;
 
   /// Rescales the bounds to a given zoom value.
-  Bounds? getProjectedBounds(double zoom) {
+  Bounds<double>? getProjectedBounds(double zoom) {
     if (infinite) return null;
 
     final b = projection.bounds!;
     final s = scale(zoom);
     final min = transformation.transform(b.min, s);
     final max = transformation.transform(b.max, s);
-    return Bounds(min, max);
+    return Bounds<double>(min, max);
   }
 
   bool get infinite;
@@ -239,7 +239,7 @@ class Proj4Crs extends Crs {
 
   /// Rescales the bounds to a given zoom value.
   @override
-  Bounds? getProjectedBounds(double zoom) {
+  Bounds<double>? getProjectedBounds(double zoom) {
     if (infinite) return null;
 
     final b = projection.bounds!;
@@ -249,7 +249,7 @@ class Proj4Crs extends Crs {
 
     final min = transformation.transform(b.min, s);
     final max = transformation.transform(b.max, s);
-    return Bounds(min, max);
+    return Bounds<double>(min, max);
   }
 
   /// Zoom to Scale function.

--- a/lib/src/layer/tile_layer/tile_bounds/tile_bounds.dart
+++ b/lib/src/layer/tile_layer/tile_bounds/tile_bounds.dart
@@ -3,7 +3,6 @@ import 'package:flutter_map/src/geo/latlng_bounds.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_bounds/tile_bounds_at_zoom.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_range.dart';
 import 'package:flutter_map/src/misc/bounds.dart';
-import 'package:flutter_map/src/misc/point_extensions.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:meta/meta.dart';
 
@@ -76,13 +75,13 @@ class DiscreteTileBounds extends TileBounds {
   TileBoundsAtZoom _tileBoundsAtZoomImpl(int zoom) {
     final zoomDouble = zoom.toDouble();
 
-    final Bounds<num> pixelBounds;
+    final Bounds<double> pixelBounds;
     if (_latLngBounds == null) {
       pixelBounds = crs.getProjectedBounds(zoomDouble)!;
     } else {
-      pixelBounds = Bounds(
-        crs.latLngToPoint(_latLngBounds!.southWest, zoomDouble).floor(),
-        crs.latLngToPoint(_latLngBounds!.northEast, zoomDouble).ceil(),
+      pixelBounds = Bounds<double>(
+        crs.latLngToPoint(_latLngBounds!.southWest, zoomDouble),
+        crs.latLngToPoint(_latLngBounds!.northEast, zoomDouble),
       );
     }
 
@@ -115,13 +114,13 @@ class WrappedTileBounds extends TileBounds {
   WrappedTileBoundsAtZoom _tileBoundsAtZoomImpl(int zoom) {
     final zoomDouble = zoom.toDouble();
 
-    final Bounds<num> pixelBounds;
+    final Bounds<double> pixelBounds;
     if (_latLngBounds == null) {
       pixelBounds = crs.getProjectedBounds(zoomDouble)!;
     } else {
-      pixelBounds = Bounds(
-        crs.latLngToPoint(_latLngBounds!.southWest, zoomDouble).floor(),
-        crs.latLngToPoint(_latLngBounds!.northEast, zoomDouble).ceil(),
+      pixelBounds = Bounds<double>(
+        crs.latLngToPoint(_latLngBounds!.southWest, zoomDouble),
+        crs.latLngToPoint(_latLngBounds!.northEast, zoomDouble),
       );
     }
 

--- a/lib/src/layer/tile_layer/tile_coordinates.dart
+++ b/lib/src/layer/tile_layer/tile_coordinates.dart
@@ -11,13 +11,10 @@ class TileCoordinates extends Point<int> {
   @override
   String toString() => 'TileCoordinate($x, $y, $z)';
 
-  // Overridden because Point's distanceTo does not allow comparing with a point
-  // of a different type.
-  @override
-  double distanceTo(Point<num> other) {
+  double distanceToSq(Point<double> other) {
     final dx = x - other.x;
     final dy = y - other.y;
-    return sqrt(dx * dx + dy * dy);
+    return dx * dx + dy * dy;
   }
 
   @override
@@ -32,6 +29,6 @@ class TileCoordinates extends Point<int> {
   @override
   int get hashCode {
     // NOTE: the odd numbers are due to JavaScript's integer precision of 53 bits.
-    return x | y << 24 | z << 48;
+    return x ^ y << 24 ^ z << 48;
   }
 }

--- a/lib/src/layer/tile_layer/tile_coordinates.dart
+++ b/lib/src/layer/tile_layer/tile_coordinates.dart
@@ -11,10 +11,13 @@ class TileCoordinates extends Point<int> {
   @override
   String toString() => 'TileCoordinate($x, $y, $z)';
 
-  double distanceToSq(Point<double> other) {
+  // Overridden because Point's distanceTo does not allow comparing with a point
+  // of a different type.
+  @override
+  double distanceTo(Point<num> other) {
     final dx = x - other.x;
     final dy = y - other.y;
-    return dx * dx + dy * dy;
+    return sqrt(dx * dx + dy * dy);
   }
 
   @override

--- a/lib/src/layer/tile_layer/tile_image.dart
+++ b/lib/src/layer/tile_layer/tile_image.dart
@@ -92,10 +92,6 @@ class TileImage extends ChangeNotifier {
   /// tile display is used with a maximum opacity less than 1.
   bool get readyToDisplay => _readyToDisplay;
 
-  // Used to sort TileImages by their distance from the current zoom.
-  double zIndex(double maxZoom, int currentZoom) =>
-      maxZoom - (currentZoom - coordinates.z).abs();
-
   /// Change the tile display options.
   set tileDisplay(TileDisplay newTileDisplay) {
     final oldTileDisplay = _tileDisplay;

--- a/lib/src/layer/tile_layer/tile_image.dart
+++ b/lib/src/layer/tile_layer/tile_image.dart
@@ -83,8 +83,6 @@ class TileImage extends ChangeNotifier {
 
   AnimationController? get animation => _animationController;
 
-  TileCoordinates get coordinatesKey => coordinates;
-
   /// Whether the tile is displayable. This means that either:
   ///   * Loading errored but an error image is configured.
   ///   * Loading succeeded and the fade animation has finished.

--- a/lib/src/layer/tile_layer/tile_image_manager.dart
+++ b/lib/src/layer/tile_layer/tile_image_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:collection/collection.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_bounds/tile_bounds.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_bounds/tile_bounds_at_zoom.dart';
@@ -13,7 +15,8 @@ typedef TileCreator = TileImage Function(TileCoordinates coordinates);
 
 @immutable
 class TileImageManager {
-  final Map<TileCoordinates, TileImage> _tiles = {};
+  final Map<TileCoordinates, TileImage> _tiles =
+      HashMap<TileCoordinates, TileImage>();
 
   bool containsTileAt(TileCoordinates coordinates) =>
       _tiles.containsKey(coordinates);
@@ -21,19 +24,7 @@ class TileImageManager {
   bool get allLoaded =>
       _tiles.values.none((tile) => tile.loadFinishedAt == null);
 
-  /// Returns in the order in which they should be rendered:
-  ///   1. Tiles at the current zoom.
-  ///   2. Tiles at the current zoom +/- 1.
-  ///   3. Tiles at the current zoom +/- 2.
-  ///   4. ...etc
-  List<TileImage> inRenderOrder(double maxZoom, int currentZoom) {
-    final result = _tiles.values.toList()
-      ..sort((a, b) => a
-          .zIndex(maxZoom, currentZoom)
-          .compareTo(b.zIndex(maxZoom, currentZoom)));
-
-    return result;
-  }
+  Iterable<TileImage> get tiles => _tiles.values;
 
   // Creates missing tiles in the given range. Does not initiate loading of the
   // tiles.

--- a/lib/src/layer/tile_layer/tile_image_manager.dart
+++ b/lib/src/layer/tile_layer/tile_image_manager.dart
@@ -24,10 +24,23 @@ class TileImageManager {
   bool get allLoaded =>
       _tiles.values.none((tile) => tile.loadFinishedAt == null);
 
-  Iterable<TileImage> get tiles => _tiles.values;
+  /// Filter tiles to only tiles that would visible on screen. Specifically:
+  ///   1. Tiles in the visible range at the target zoom level.
+  ///   2. Tiles at non-target zoom level that would cover up holes that would
+  ///      be left by tiles in #1, which are not ready yet.
+  Iterable<TileImage> renderTiles({
+    required DiscreteTileRange visibleRange,
+  }) =>
+      TileImageView(
+        tileImages: _tiles,
+        visibleRange: visibleRange,
+        // `keepRange` is irrelevant here since we're not using the output for
+        // pruning storage but rather to decide on what to put on screen.
+        keepRange: visibleRange,
+      ).renderTiles();
 
-  // Creates missing tiles in the given range. Does not initiate loading of the
-  // tiles.
+  /// Creates missing tiles in the given range. Does not initiate loading of the
+  /// tiles.
   void createMissingTiles(
     DiscreteTileRange tileRange,
     TileBoundsAtZoom tileBoundsAtZoom, {

--- a/lib/src/layer/tile_layer/tile_image_manager.dart
+++ b/lib/src/layer/tile_layer/tile_image_manager.dart
@@ -43,10 +43,7 @@ class TileImageManager {
     required TileCreator createTileImage,
   }) {
     for (final coordinates in tileBoundsAtZoom.validCoordinatesIn(tileRange)) {
-      _tiles.putIfAbsent(
-        coordinates,
-        () => createTileImage(coordinates),
-      );
+      _tiles[coordinates] ??= createTileImage(coordinates);
     }
   }
 
@@ -63,12 +60,10 @@ class TileImageManager {
     final notLoaded = <TileImage>[];
 
     for (final coordinates in tileCoordinates) {
-      final tile = _tiles.putIfAbsent(
-        coordinates,
-        () => createTile(coordinates),
-      );
-
-      if (tile.loadStarted == null) notLoaded.add(tile);
+      final tile = _tiles[coordinates] ??= createTile(coordinates);
+      if (tile.loadStarted == null) {
+        notLoaded.add(tile);
+      }
     }
 
     return notLoaded;
@@ -162,11 +157,11 @@ class TileImageManager {
       case EvictErrorTileStrategy.notVisibleRespectMargin:
         for (final tileImage
             in tileRemovalState.errorTilesOutsideOfKeepMargin()) {
-          _remove(tileImage.coordinatesKey, evictImageFromCache: (_) => true);
+          _remove(tileImage.coordinates, evictImageFromCache: (_) => true);
         }
       case EvictErrorTileStrategy.notVisible:
         for (final tileImage in tileRemovalState.errorTilesNotVisible()) {
-          _remove(tileImage.coordinatesKey, evictImageFromCache: (_) => true);
+          _remove(tileImage.coordinates, evictImageFromCache: (_) => true);
         }
       case EvictErrorTileStrategy.dispose:
       case EvictErrorTileStrategy.none:
@@ -194,7 +189,7 @@ class TileImageManager {
     EvictErrorTileStrategy evictStrategy,
   ) {
     for (final tileImage in tileRemovalState.staleTiles()) {
-      _removeWithEvictionStrategy(tileImage.coordinatesKey, evictStrategy);
+      _removeWithEvictionStrategy(tileImage.coordinates, evictStrategy);
     }
   }
 }

--- a/lib/src/layer/tile_layer/tile_image_view.dart
+++ b/lib/src/layer/tile_layer/tile_image_view.dart
@@ -9,11 +9,11 @@ class TileImageView {
   final DiscreteTileRange _visibleRange;
   final DiscreteTileRange _keepRange;
 
-  TileImageView({
+  const TileImageView({
     required Map<TileCoordinates, TileImage> tileImages,
     required DiscreteTileRange visibleRange,
     required DiscreteTileRange keepRange,
-  })  : _tileImages = UnmodifiableMapView(tileImages),
+  })  : _tileImages = tileImages,
         _visibleRange = visibleRange,
         _keepRange = keepRange;
 
@@ -28,8 +28,8 @@ class TileImageView {
       .toList();
 
   Iterable<TileImage> staleTiles() {
-    final stale = <TileImage>{};
-    final retain = <TileImage>{};
+    final stale = HashSet<TileImage>();
+    final retain = HashSet<TileImage>();
 
     for (final tile in _tileImages.values) {
       final c = tile.coordinates;

--- a/lib/src/layer/tile_layer/tile_image_view.dart
+++ b/lib/src/layer/tile_layer/tile_image_view.dart
@@ -4,7 +4,7 @@ import 'package:flutter_map/src/layer/tile_layer/tile_coordinates.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_image.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_range.dart';
 
-class TileImageView {
+final class TileImageView {
   final Map<TileCoordinates, TileImage> _tileImages;
   final DiscreteTileRange _visibleRange;
   final DiscreteTileRange _keepRange;
@@ -27,42 +27,42 @@ class TileImageView {
           tileImage.loadError && !_visibleRange.contains(tileImage.coordinates))
       .toList();
 
-  Iterable<TileImage> staleTiles() {
+  Iterable<TileImage> get staleTiles {
     final stale = HashSet<TileImage>();
     final retain = HashSet<TileImage>();
 
     for (final tile in _tileImages.values) {
       final c = tile.coordinates;
-      if (_keepRange.contains(c)) {
-        if (!tile.readyToDisplay) {
-          final retainedAncestor =
-              _retainAncestor(retain, c.x, c.y, c.z, c.z - 5);
-          if (!retainedAncestor) {
-            _retainChildren(retain, c.x, c.y, c.z, c.z + 2);
-          }
-        }
-      } else {
+      if (!_keepRange.contains(c)) {
         stale.add(tile);
+        continue;
+      }
+
+      final retainedAncestor = _retainAncestor(retain, c.x, c.y, c.z, c.z - 5);
+      if (!retainedAncestor) {
+        _retainChildren(retain, c.x, c.y, c.z, c.z + 2);
       }
     }
 
     return stale.where((tile) => !retain.contains(tile));
   }
 
-  Iterable<TileImage> renderTiles() {
+  Iterable<TileImage> get renderTiles {
     final retain = HashSet<TileImage>();
 
     for (final tile in _tileImages.values) {
       final c = tile.coordinates;
-      if (_visibleRange.contains(c)) {
-        retain.add(tile);
+      if (!_visibleRange.contains(c)) {
+        continue;
+      }
 
-        if (!tile.readyToDisplay) {
-          final retainedAncestor =
-              _retainAncestor(retain, c.x, c.y, c.z, c.z - 5);
-          if (!retainedAncestor) {
-            _retainChildren(retain, c.x, c.y, c.z, c.z + 2);
-          }
+      retain.add(tile);
+
+      if (!tile.readyToDisplay) {
+        final retainedAncestor =
+            _retainAncestor(retain, c.x, c.y, c.z, c.z - 5);
+        if (!retainedAncestor) {
+          _retainChildren(retain, c.x, c.y, c.z, c.z + 2);
         }
       }
     }

--- a/lib/src/layer/tile_layer/tile_image_view.dart
+++ b/lib/src/layer/tile_layer/tile_image_view.dart
@@ -49,6 +49,26 @@ class TileImageView {
     return stale.where((tile) => !retain.contains(tile));
   }
 
+  Iterable<TileImage> renderTiles() {
+    final retain = HashSet<TileImage>();
+
+    for (final tile in _tileImages.values) {
+      final c = tile.coordinates;
+      if (_visibleRange.contains(c)) {
+        retain.add(tile);
+
+        if (!tile.readyToDisplay) {
+          final retainedAncestor =
+              _retainAncestor(retain, c.x, c.y, c.z, c.z - 5);
+          if (!retainedAncestor) {
+            _retainChildren(retain, c.x, c.y, c.z, c.z + 2);
+          }
+        }
+      }
+    }
+    return retain;
+  }
+
   // Recurses through the ancestors of the Tile at the given coordinates adding
   // them to [retain] if they are ready to display or loaded. Returns true if
   // any of the ancestor tiles were ready to display.

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -683,8 +683,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     final tileCenter = tileLoadRange.center;
     tilesToLoad.sort(
       (a, b) => a.coordinates
-          .distanceTo(tileCenter)
-          .compareTo(b.coordinates.distanceTo(tileCenter)),
+          .distanceToSq(tileCenter)
+          .compareTo(b.coordinates.distanceToSq(tileCenter)),
     );
 
     // Create the new Tiles.

--- a/lib/src/layer/tile_layer/tile_range.dart
+++ b/lib/src/layer/tile_layer/tile_range.dart
@@ -34,7 +34,7 @@ class DiscreteTileRange extends TileRange {
   factory DiscreteTileRange.fromPixelBounds({
     required int zoom,
     required double tileSize,
-    required Bounds<num> pixelBounds,
+    required Bounds<double> pixelBounds,
   }) {
     final Bounds<int> bounds;
     if (pixelBounds.min == pixelBounds.max) {
@@ -77,9 +77,9 @@ class DiscreteTileRange extends TileRange {
 
     return DiscreteTileRange(
       zoom,
-      Bounds(
-        Point(math.max(min.x, minX), min.y),
-        Point(math.min(max.x, maxX), max.y),
+      Bounds<int>(
+        Point<int>(math.max(min.x, minX), min.y),
+        Point<int>(math.min(max.x, maxX), max.y),
       ),
     );
   }
@@ -92,9 +92,9 @@ class DiscreteTileRange extends TileRange {
 
     return DiscreteTileRange(
       zoom,
-      Bounds(
-        Point(min.x, math.max(min.y, minY)),
-        Point(max.x, math.min(max.y, maxY)),
+      Bounds<int>(
+        Point<int>(min.x, math.max(min.y, minY)),
+        Point<int>(max.x, math.min(max.y, maxY)),
       ),
     );
   }

--- a/test/layer/tile_layer/tile_bounds/tile_bounds_at_zoom_test.dart
+++ b/test/layer/tile_layer/tile_bounds/tile_bounds_at_zoom_test.dart
@@ -9,10 +9,12 @@ import 'package:test/test.dart';
 void main() {
   group('TileBoundsAtZoom', () {
     const hugeCoordinate = TileCoordinates(999999999, 999999999, 0);
+    final hugePoint =
+        Point<double>(hugeCoordinate.x.toDouble(), hugeCoordinate.y.toDouble());
     final tileRangeWithHugeCoordinate = DiscreteTileRange.fromPixelBounds(
       zoom: 0,
       tileSize: 1,
-      pixelBounds: Bounds(hugeCoordinate, hugeCoordinate),
+      pixelBounds: Bounds(hugePoint, hugePoint),
     );
 
     DiscreteTileRange discreteTileRange(

--- a/test/layer/tile_layer/tile_image_view_test.dart
+++ b/test/layer/tile_layer/tile_image_view_test.dart
@@ -114,7 +114,7 @@ void main() {
       // a concurrent modification exception is thrown. This ensures that the
       // returned collection is not an iterable over the original collection.
       for (final staleTile in removalState.staleTiles()) {
-        tileImages.remove(staleTile.coordinatesKey)!;
+        tileImages.remove(staleTile.coordinates)!;
       }
     });
   });
@@ -141,7 +141,7 @@ void main() {
     // a concurrent modification exception is thrown. This ensures that the
     // returned collection is not an iterable over the original collection.
     for (final tileImage in tileImageView.errorTilesOutsideOfKeepMargin()) {
-      tileImages.remove(tileImage.coordinatesKey)!;
+      tileImages.remove(tileImage.coordinates)!;
     }
   });
 
@@ -167,7 +167,7 @@ void main() {
     // a concurrent modification exception is thrown. This ensures that the
     // returned collection is not an iterable over the original collection.
     for (final tileImage in tileImageView.errorTilesOutsideOfKeepMargin()) {
-      tileImages.remove(tileImage.coordinatesKey)!;
+      tileImages.remove(tileImage.coordinates)!;
     }
   });
 }

--- a/test/layer/tile_layer/tile_image_view_test.dart
+++ b/test/layer/tile_layer/tile_image_view_test.dart
@@ -54,7 +54,7 @@ void main() {
         keepRange: discreteTileRange(2, 1, 3, 3, zoom: 1),
       );
       expect(
-        removalState.staleTiles(),
+        removalState.staleTiles,
         containsTileImage(tileImages, const TileCoordinates(1, 1, 1)),
       );
     });
@@ -70,7 +70,7 @@ void main() {
         keepRange: discreteTileRange(0, 0, 0, 0, zoom: 1),
       );
       expect(
-        removalState.staleTiles(),
+        removalState.staleTiles,
         doesNotContainTileImage(tileImages, const TileCoordinates(0, 0, 0)),
       );
     });
@@ -88,7 +88,7 @@ void main() {
         keepRange: discreteTileRange(0, 0, 0, 0, zoom: 1),
       );
       expect(
-        removalState.staleTiles(),
+        removalState.staleTiles,
         doesNotContainTileImage(tileImages, const TileCoordinates(0, 0, 2)),
       );
     });
@@ -106,14 +106,14 @@ void main() {
         keepRange: discreteTileRange(2, 1, 3, 3, zoom: 1),
       );
       expect(
-        removalState.staleTiles(),
+        removalState.staleTiles,
         containsTileImage(tileImages, const TileCoordinates(1, 1, 1)),
       );
       // If an iterator over the original collection is returned then when
       // looping over that iterator and removing from the original collection
       // a concurrent modification exception is thrown. This ensures that the
       // returned collection is not an iterable over the original collection.
-      for (final staleTile in removalState.staleTiles()) {
+      for (final staleTile in removalState.staleTiles) {
         tileImages.remove(staleTile.coordinates)!;
       }
     });

--- a/test/layer/tile_layer/tile_range_test.dart
+++ b/test/layer/tile_layer/tile_range_test.dart
@@ -35,8 +35,8 @@ void main() {
             zoom: 0,
             tileSize: 10,
             pixelBounds: Bounds(
-              const Point(25.0, 25.0),
-              const Point(25.0, 25.0),
+              const Point(25, 25),
+              const Point(25, 25),
             ),
           );
 
@@ -49,7 +49,7 @@ void main() {
             zoom: 0,
             tileSize: 10,
             pixelBounds: Bounds(
-              const Point(0.0, 0.0),
+              const Point(0, 0),
               const Point(0.1, 0.1),
             ),
           );
@@ -63,7 +63,7 @@ void main() {
             zoom: 0,
             tileSize: 10,
             pixelBounds: Bounds(
-              const Point(0.0, 0.0),
+              const Point(0, 0),
               const Point(9.99, 9.99),
             ),
           );
@@ -101,8 +101,8 @@ void main() {
           zoom: 0,
           tileSize: 10,
           pixelBounds: Bounds(
-            const Point(25.0, 25.0),
-            const Point(25.0, 25.0),
+            const Point(25, 25),
+            const Point(25, 25),
           ),
         );
 
@@ -128,8 +128,8 @@ void main() {
           zoom: 0,
           tileSize: 10,
           pixelBounds: Bounds(
-            const Point(25.0, 25.0),
-            const Point(25.0, 25.0),
+            const Point(25, 25),
+            const Point(25, 25),
           ),
         );
 
@@ -137,8 +137,8 @@ void main() {
           zoom: 0,
           tileSize: 10,
           pixelBounds: Bounds(
-            const Point(35.0, 35.0),
-            const Point(35.0, 35.0),
+            const Point(35, 35),
+            const Point(35, 35),
           ),
         );
 
@@ -154,8 +154,8 @@ void main() {
           zoom: 0,
           tileSize: 10,
           pixelBounds: Bounds(
-            const Point(25.0, 25.0),
-            const Point(35.0, 35.0),
+            const Point(25, 25),
+            const Point(35, 35),
           ),
         );
 
@@ -163,8 +163,8 @@ void main() {
           zoom: 0,
           tileSize: 10,
           pixelBounds: Bounds(
-            const Point(35.0, 35.0),
-            const Point(45.0, 45.0),
+            const Point(35, 35),
+            const Point(45, 45),
           ),
         );
 
@@ -182,8 +182,8 @@ void main() {
           zoom: 0,
           tileSize: 10,
           pixelBounds: Bounds(
-            const Point(25.0, 25.0),
-            const Point(35.0, 35.0),
+            const Point(25, 25),
+            const Point(35, 35),
           ),
         );
 
@@ -191,8 +191,8 @@ void main() {
           zoom: 0,
           tileSize: 10,
           pixelBounds: Bounds(
-            const Point(15.0, 15.0),
-            const Point(45.0, 45.0),
+            const Point(15, 15),
+            const Point(45, 45),
           ),
         );
 
@@ -211,8 +211,8 @@ void main() {
         zoom: 0,
         tileSize: 10,
         pixelBounds: Bounds(
-          const Point(35.0, 35.0),
-          const Point(45.0, 45.0),
+          const Point(35, 35),
+          const Point(45, 45),
         ),
       );
 
@@ -226,8 +226,8 @@ void main() {
           zoom: 0,
           tileSize: 10,
           pixelBounds: Bounds(
-            const Point(35.0, 35.0),
-            const Point(35.0, 35.0),
+            const Point(35, 35),
+            const Point(35, 35),
           ),
         );
 
@@ -239,8 +239,8 @@ void main() {
           zoom: 0,
           tileSize: 10,
           pixelBounds: Bounds(
-            const Point(35.0, 35.0),
-            const Point(45.0, 45.0),
+            const Point(35, 35),
+            const Point(45, 45),
           ),
         );
 
@@ -252,8 +252,8 @@ void main() {
           zoom: 0,
           tileSize: 10,
           pixelBounds: Bounds(
-            const Point(35.0, 35.0),
-            const Point(55.0, 55.0),
+            const Point(35, 35),
+            const Point(55, 55),
           ),
         );
 
@@ -266,8 +266,8 @@ void main() {
         zoom: 0,
         tileSize: 10,
         pixelBounds: Bounds(
-          const Point(35.0, 35.0),
-          const Point(35.0, 35.0),
+          const Point(35, 35),
+          const Point(35, 35),
         ),
       );
 


### PR DESCRIPTION
A couple of performance improvements:
 * cheaper data structures
 * cheaper construction of stale Tiles
 * add missing early abort to _reainChildren
 * fewer allocations
 * and just do not render tiles that are off screen.