### PR TITLE
fix: add `doubleTapDragZoom` and `scrollWheelZoom` to `InteractiveFlag.all`

### DIFF
--- a/lib/src/gestures/flutter_map_interactive_viewer.dart
+++ b/lib/src/gestures/flutter_map_interactive_viewer.dart
@@ -388,8 +388,7 @@ class FlutterMapInteractiveViewerState
   void _onPointerSignal(PointerSignalEvent pointerSignal) {
     // Handle mouse scroll events if the enableScrollWheel parameter is enabled
     if (pointerSignal is PointerScrollEvent &&
-        (InteractiveFlag.hasFlag(
-                _interactionOptions.flags, InteractiveFlag.scrollWheelZoom) ||
+        (InteractiveFlag.hasScrollWheelZoom(_interactionOptions.flags) ||
             // ignore: deprecated_member_use_from_same_package
             _interactionOptions.enableScrollWheel) &&
         pointerSignal.scrollDelta.dy != 0) {

--- a/lib/src/gestures/interactive_flag.dart
+++ b/lib/src/gestures/interactive_flag.dart
@@ -14,10 +14,15 @@
 abstract class InteractiveFlag {
   const InteractiveFlag._();
 
-  static const int all =
-      drag | flingAnimation | pinchMove | pinchZoom 
-      | doubleTapZoom | doubleTapDragZoom | scrollWheelZoom | rotate;
-  
+  static const int all = drag |
+      flingAnimation |
+      pinchMove |
+      pinchZoom |
+      doubleTapZoom |
+      doubleTapDragZoom |
+      scrollWheelZoom |
+      rotate;
+
   static const int none = 0;
 
   /// Enable panning with a single finger or cursor

--- a/lib/src/gestures/interactive_flag.dart
+++ b/lib/src/gestures/interactive_flag.dart
@@ -4,7 +4,7 @@
 ///
 /// If you want mix interactions for example drag and rotate interactions then
 /// you have two options:
-///   a. Add you own flags: [InteractiveFlag.drag] | [InteractiveFlag.rotate]
+///   a. Add your own flags: [InteractiveFlag.drag] | [InteractiveFlag.rotate]
 ///   b. Remove unnecessary flags from all:
 ///     [InteractiveFlag.all] &
 ///       ~[InteractiveFlag.flingAnimation] &
@@ -15,7 +15,9 @@ abstract class InteractiveFlag {
   const InteractiveFlag._();
 
   static const int all =
-      drag | flingAnimation | pinchMove | pinchZoom | doubleTapZoom | rotate;
+      drag | flingAnimation | pinchMove | pinchZoom 
+      | doubleTapZoom | doubleTapDragZoom | scrollWheelZoom | rotate;
+  
   static const int none = 0;
 
   /// Enable panning with a single finger or cursor

--- a/lib/src/gestures/interactive_flag.dart
+++ b/lib/src/gestures/interactive_flag.dart
@@ -90,4 +90,7 @@ abstract class InteractiveFlag {
 
   /// True if the [rotate] interactive flag is enabled.
   static bool hasRotate(int flags) => hasFlag(flags, rotate);
+
+  /// True if the [scrollWheelZoom] interactive flag is enabled.
+  static bool hasScrollWheelZoom(int flags) => hasFlag(flags, scrollWheelZoom);
 }


### PR DESCRIPTION
Fixes #1725.