### PR TITLE
perf!: optimize CRS performance and add micro-benchmark of limited expressiveness

### DIFF
--- a/benchmark/crs.dart
+++ b/benchmark/crs.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter_map/src/geo/crs.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:logger/logger.dart';
+
+class NoFilter extends LogFilter {
+  @override
+  bool shouldLog(LogEvent event) => true;
+}
+
+typedef Result = ({
+  String name,
+  Duration duration,
+});
+
+Future<Result> timedRun(String name, dynamic Function() body) async {
+  Logger().i('running $name...');
+  final watch = Stopwatch()..start();
+  await body();
+  watch.stop();
+
+  return (name: name, duration: watch.elapsed);
+}
+
+// NOTE: to have a more prod like comparison, run with:
+//     $ dart compile exe benchmark/crs.dart && ./benchmark/crs.exe
+//
+// If you run in JIT mode, the resulting execution times will be a lot more similar.
+Future<void> main() async {
+  Logger.level = Level.all;
+  Logger.defaultFilter = () => NoFilter();
+  Logger.defaultPrinter = () => SimplePrinter();
+
+  final results = <Result>[];
+  const N = 100000000;
+
+  const crs = Epsg3857();
+  results.add(await timedRun('Concrete type: ${crs.code}.latLngToXY()', () {
+    double x = 0;
+    double y = 0;
+    for (int i = 0; i < N; ++i) {
+      final latlng = LatLng((i % 90).toDouble(), (i % 180).toDouble());
+      final (cx, cy) = crs.latLngToXY(latlng, 1);
+      x += cx;
+      y += cy;
+    }
+    return x + y;
+  }));
+
+  results.add(await timedRun('Concrete type: ${crs.code}.latLngToPoint()', () {
+    double x = 0;
+    double y = 0;
+    for (int i = 0; i < N; ++i) {
+      final latlng = LatLng((i % 90).toDouble(), (i % 180).toDouble());
+      final p = crs.latLngToPoint(latlng, 1);
+      x += p.x;
+      y += p.y;
+    }
+    return x + y;
+  }));
+
+  const crss = <Crs>[
+    Epsg3857(),
+    Epsg4326(),
+  ];
+
+  for (final crs in crss) {
+    results.add(await timedRun('${crs.code}.latLngToXY()', () {
+      double x = 0;
+      double y = 0;
+      for (int i = 0; i < N; ++i) {
+        final latlng = LatLng((i % 90).toDouble(), (i % 180).toDouble());
+        final (cx, cy) = crs.latLngToXY(latlng, 1);
+        x += cx;
+        y += cy;
+      }
+      return x + y;
+    }));
+
+    results.add(await timedRun('${crs.code}.latlngToPoint()', () {
+      double x = 0;
+      double y = 0;
+      for (int i = 0; i < N; ++i) {
+        final latlng = LatLng((i % 90).toDouble(), (i % 180).toDouble());
+        final point = crs.latLngToPoint(latlng, 1);
+        x += point.x;
+        y += point.y;
+      }
+      return x + y;
+    }));
+
+    results.add(await timedRun('${crs.code}.pointToLatLng()', () {
+      double x = 0;
+      double y = 0;
+      for (int i = 0; i < N; ++i) {
+        final latlng = crs.pointToLatLng(math.Point<double>(x, y), 1);
+        x += latlng.longitude;
+        y += latlng.latitude;
+      }
+      return x + y;
+    }));
+  }
+
+  Logger().i('Results:\n${results.map((r) => r.toString()).join('\n')}');
+}

--- a/example/lib/pages/custom_crs/custom_crs.dart
+++ b/example/lib/pages/custom_crs/custom_crs.dart
@@ -83,8 +83,6 @@ class CustomCrsPageState extends State<CustomCrsPage> {
       // Scale factors (pixels per projection unit, for example pixels/meter) for zoom levels;
       // specify either scales or resolutions, not both
       scales: null,
-      // The transformation to use when transforming projected coordinates into pixel coordinates
-      transformation: null,
     );
   }
 

--- a/example/lib/pages/epsg3413_crs.dart
+++ b/example/lib/pages/epsg3413_crs.dart
@@ -64,7 +64,6 @@ class EPSG3413PageState extends State<EPSG3413Page> {
       bounds: epsg3413Bounds,
       origins: const [Point(0, 0)],
       scales: null,
-      transformation: null,
     );
   }
 

--- a/lib/src/geo/crs.dart
+++ b/lib/src/geo/crs.dart
@@ -322,6 +322,7 @@ abstract class Projection {
 
   const Projection(this.bounds);
 
+  @nonVirtual
   Point<double> project(LatLng latlng) {
     final (x, y) = projectXY(latlng);
     return Point<double>(x, y);
@@ -329,6 +330,7 @@ abstract class Projection {
 
   (double, double) projectXY(LatLng latlng);
 
+  @nonVirtual
   LatLng unproject(Point point) =>
       unprojectXY(point.x.toDouble(), point.y.toDouble());
   LatLng unprojectXY(double x, double y);
@@ -365,7 +367,7 @@ class SphericalMercator extends Projection {
   const SphericalMercator() : super(_bounds);
 
   static double projectLat(double latitude) {
-    final lat = latitude.clamp(-maxLatitude, maxLatitude);
+    final lat = _clampSym(latitude, maxLatitude);
     final sin = math.sin(lat * math.pi / 180);
 
     return r / 2 * math.log((1 + sin) / (1 - sin));
@@ -445,5 +447,8 @@ class _Transformation {
       );
 }
 
-double _inclusiveLat(double value) => value.clamp(-90, 90);
-double _inclusiveLng(double value) => value.clamp(-180, 180);
+// Num.clamp is slow due to virtual function overhead.
+double _clampSym(double value, double limit) =>
+    value < -limit ? -limit : (value > limit ? limit : value);
+double _inclusiveLat(double value) => _clampSym(value, 90);
+double _inclusiveLng(double value) => _clampSym(value, 180);

--- a/lib/src/geo/crs.dart
+++ b/lib/src/geo/crs.dart
@@ -13,24 +13,34 @@ import 'package:proj4dart/proj4dart.dart' as proj4;
 /// points of objects of different dimensions. In our case 3D and 2D objects.
 @immutable
 abstract class Crs {
-  const Crs();
+  @nonVirtual
+  final String code;
+  @nonVirtual
+  final bool infinite;
+  @nonVirtual
+  final (double, double)? wrapLng;
+  @nonVirtual
+  final (double, double)? wrapLat;
 
-  String get code;
+  const Crs({
+    required this.code,
+    required this.infinite,
+    this.wrapLng,
+    this.wrapLat,
+  });
 
   Projection get projection;
 
-  Transformation get transformation;
-
   /// Converts a point on the sphere surface (with a certain zoom) in a
   /// map point.
+  (double, double) latLngToXY(LatLng latlng, double scale);
   Point<double> latLngToPoint(LatLng latlng, double zoom) {
-    final projectedPoint = projection.project(latlng);
-    return transformation.transform(projectedPoint, scale(zoom));
+    final (x, y) = latLngToXY(latlng, scale(zoom));
+    return Point<double>(x, y);
   }
 
   /// Converts a map point to the sphere coordinate (at a certain zoom).
-  LatLng pointToLatLng(Point point, double zoom) =>
-      projection.unproject(transformation.untransform(point, scale(zoom)));
+  LatLng pointToLatLng(Point point, double zoom);
 
   /// Zoom to Scale function.
   double scale(double zoom) => 256.0 * math.pow(2, zoom);
@@ -39,156 +49,147 @@ abstract class Crs {
   double zoom(double scale) => math.log(scale / 256) / math.ln2;
 
   /// Rescales the bounds to a given zoom value.
+  Bounds<double>? getProjectedBounds(double zoom);
+}
+
+@immutable
+abstract class _CrsWithStaticTransformation extends Crs {
+  @nonVirtual
+  @protected
+  final _Transformation transformation;
+
+  @override
+  final Projection projection;
+
+  const _CrsWithStaticTransformation({
+    required this.transformation,
+    required this.projection,
+    required super.code,
+    required super.infinite,
+    super.wrapLng,
+    super.wrapLat,
+  });
+
+  @override
+  (double, double) latLngToXY(LatLng latlng, double scale) {
+    final (x, y) = projection.projectXY(latlng);
+    return transformation.transform(x, y, scale);
+  }
+
+  @override
+  LatLng pointToLatLng(Point point, double zoom) {
+    final (x, y) = transformation.untransform(
+      point.x.toDouble(),
+      point.y.toDouble(),
+      scale(zoom),
+    );
+    return projection.unprojectXY(x, y);
+  }
+
+  @override
   Bounds<double>? getProjectedBounds(double zoom) {
     if (infinite) return null;
 
     final b = projection.bounds!;
     final s = scale(zoom);
-    final min = transformation.transform(b.min, s);
-    final max = transformation.transform(b.max, s);
-    return Bounds<double>(min, max);
+    final (minx, miny) = transformation.transform(b.min.x, b.min.y, s);
+    final (maxx, maxy) = transformation.transform(b.max.x, b.max.y, s);
+    return Bounds<double>(
+      Point<double>(minx, miny),
+      Point<double>(maxx, maxy),
+    );
   }
-
-  bool get infinite;
-
-  (double, double)? get wrapLng;
-
-  (double, double)? get wrapLat;
 }
 
 // Custom CRS for non geographical maps
 @immutable
-class CrsSimple extends Crs {
-  @override
-  final String code = 'CRS.SIMPLE';
-
-  @override
-  final Projection projection;
-
-  @override
-  final Transformation transformation;
-
+class CrsSimple extends _CrsWithStaticTransformation {
   const CrsSimple()
-      : projection = const _LonLat(),
-        transformation = const Transformation(1, 0, -1, 0),
-        super();
-
-  @override
-  bool get infinite => false;
-
-  @override
-  (double, double)? get wrapLat => null;
-
-  @override
-  (double, double)? get wrapLng => null;
-}
-
-@immutable
-abstract class Earth extends Crs {
-  @override
-  bool get infinite => false;
-
-  @override
-  final (double, double) wrapLng = const (-180, 180);
-
-  @override
-  final (double, double)? wrapLat = null;
-
-  const Earth() : super();
+      : super(
+          code: 'CRS.SIMPLE',
+          transformation: const _Transformation(1, 0, -1, 0),
+          projection: const _LonLat(),
+          infinite: false,
+          wrapLat: null,
+          wrapLng: null,
+        );
 }
 
 /// The most common CRS used for rendering maps.
 @immutable
-class Epsg3857 extends Earth {
-  @override
-  final String code = 'EPSG:3857';
-
-  @override
-  final Projection projection;
-
-  @override
-  final Transformation transformation;
-
+class Epsg3857 extends _CrsWithStaticTransformation {
   static const double _scale = 0.5 / (math.pi * SphericalMercator.r);
 
   const Epsg3857()
-      : projection = const SphericalMercator(),
-        transformation = const Transformation(_scale, 0.5, -_scale, 0.5),
-        super();
+      : super(
+          code: 'EPSG:3857',
+          transformation: const _Transformation(_scale, 0.5, -_scale, 0.5),
+          projection: const SphericalMercator(),
+          infinite: false,
+          wrapLng: const (-180, 180),
+        );
 
-// Epsg3857 seems to have latitude limits. https://epsg.io/3857
-//@override
-//(double, double) get wrapLat => const (-85.06, 85.06);
+  @override
+  (double, double) latLngToXY(LatLng latlng, double scale) =>
+      transformation.transform(SphericalMercator.projectLng(latlng.longitude),
+          SphericalMercator.projectLat(latlng.latitude), scale);
+
+  @override
+  Point<double> latLngToPoint(LatLng latlng, double zoom) {
+    final (x, y) = transformation.transform(
+      SphericalMercator.projectLng(latlng.longitude),
+      SphericalMercator.projectLat(latlng.latitude),
+      scale(zoom),
+    );
+    return Point<double>(x, y);
+  }
 }
 
 /// A common CRS among GIS enthusiasts. Uses simple Equirectangular projection.
 @immutable
-class Epsg4326 extends Earth {
-  @override
-  final String code = 'EPSG:4326';
-
-  @override
-  final Projection projection;
-
-  @override
-  final Transformation transformation;
-
+class Epsg4326 extends _CrsWithStaticTransformation {
   const Epsg4326()
-      : projection = const _LonLat(),
-        transformation = const Transformation(1 / 180, 1, -1 / 180, 0.5),
-        super();
+      : super(
+          projection: const _LonLat(),
+          transformation: const _Transformation(1 / 180, 1, -1 / 180, 0.5),
+          code: 'EPSG:4326',
+          infinite: false,
+          wrapLng: const (-180, 180),
+        );
 }
 
 /// Custom CRS
 @immutable
 class Proj4Crs extends Crs {
   @override
-  final String code;
-
-  @override
   final Projection projection;
-
-  @override
-  final Transformation transformation;
-
-  @override
-  final bool infinite;
-
-  @override
-  final (double, double)? wrapLat = null;
-
-  @override
-  final (double, double)? wrapLng = null;
-
-  final List<Transformation>? _transformations;
-
+  final List<_Transformation> _transformations;
   final List<double> _scales;
 
   const Proj4Crs._({
-    required this.code,
+    required super.code,
     required this.projection,
-    required this.transformation,
-    required this.infinite,
-    List<Transformation>? transformations,
+    required super.infinite,
+    required List<_Transformation> transformations,
     required List<double> scales,
   })  : _transformations = transformations,
-        _scales = scales;
+        _scales = scales,
+        super(wrapLat: null, wrapLng: null);
 
   factory Proj4Crs.fromFactory({
     required String code,
     required proj4.Projection proj4Projection,
-    Transformation? transformation,
     List<Point<double>>? origins,
     Bounds<double>? bounds,
     List<double>? scales,
     List<double>? resolutions,
   }) {
-    final projection =
-        _Proj4Projection(proj4Projection: proj4Projection, bounds: bounds);
-    List<Transformation>? transformations;
-    final infinite = null == bounds;
-    List<double> finalScales;
+    final projection = _Proj4Projection(
+      proj4Projection: proj4Projection,
+      bounds: bounds,
+    );
 
+    List<double> finalScales;
     if (null != scales && scales.isNotEmpty) {
       finalScales = scales;
     } else if (null != resolutions && resolutions.isNotEmpty) {
@@ -198,24 +199,23 @@ class Proj4Crs extends Crs {
           'Please provide scales or resolutions to determine scales');
     }
 
+    List<_Transformation> transformations;
     if (null == origins || origins.isEmpty) {
-      transformation ??= const Transformation(1, 0, -1, 0);
+      transformations = [const _Transformation(1, 0, -1, 0)];
     } else {
       if (origins.length == 1) {
         final origin = origins[0];
-        transformation = Transformation(1, -origin.x, -1, origin.y);
+        transformations = [_Transformation(1, -origin.x, -1, origin.y)];
       } else {
         transformations =
-            origins.map((p) => Transformation(1, -p.x, -1, p.y)).toList();
-        transformation = null;
+            origins.map((p) => _Transformation(1, -p.x, -1, p.y)).toList();
       }
     }
 
     return Proj4Crs._(
       code: code,
       projection: projection,
-      transformation: transformation!,
-      infinite: infinite,
+      infinite: null == bounds,
       transformations: transformations,
       scales: finalScales,
     );
@@ -224,18 +224,22 @@ class Proj4Crs extends Crs {
   /// Converts a point on the sphere surface (with a certain zoom) in a
   /// map point.
   @override
-  Point<double> latLngToPoint(LatLng latlng, double zoom) {
-    final projectedPoint = projection.project(latlng);
-    final scale = this.scale(zoom);
-    final transformation = _getTransformationByZoom(zoom);
-
-    return transformation.transform(projectedPoint, scale);
+  (double, double) latLngToXY(LatLng latlng, double scale) {
+    final (x, y) = projection.projectXY(latlng);
+    final transformation = _getTransformationByZoom(zoom(scale));
+    return transformation.transform(x, y, scale);
   }
 
   /// Converts a map point to the sphere coordinate (at a certain zoom).
   @override
-  LatLng pointToLatLng(Point point, double zoom) => projection.unproject(
-      _getTransformationByZoom(zoom).untransform(point, scale(zoom)));
+  LatLng pointToLatLng(Point point, double zoom) {
+    final (x, y) = _getTransformationByZoom(zoom).untransform(
+      point.x.toDouble(),
+      point.y.toDouble(),
+      scale(zoom),
+    );
+    return projection.unprojectXY(x, y);
+  }
 
   /// Rescales the bounds to a given zoom value.
   @override
@@ -243,13 +247,15 @@ class Proj4Crs extends Crs {
     if (infinite) return null;
 
     final b = projection.bounds!;
-    final s = scale(zoom);
+    final zoomScale = scale(zoom);
 
     final transformation = _getTransformationByZoom(zoom);
-
-    final min = transformation.transform(b.min, s);
-    final max = transformation.transform(b.max, s);
-    return Bounds<double>(min, max);
+    final (minx, miny) = transformation.transform(b.min.x, b.min.y, zoomScale);
+    final (maxx, maxy) = transformation.transform(b.max.x, b.max.y, zoomScale);
+    return Bounds<double>(
+      Point<double>(minx, miny),
+      Point<double>(maxx, maxy),
+    );
   }
 
   /// Zoom to Scale function.
@@ -303,66 +309,46 @@ class Proj4Crs extends Crs {
   }
 
   /// returns Transformation object based on zoom
-  Transformation _getTransformationByZoom(double zoom) {
-    final transformations = _transformations;
-    if (transformations == null || transformations.isEmpty) {
-      return transformation;
-    }
-
+  _Transformation _getTransformationByZoom(double zoom) {
     final iZoom = zoom.round();
-    final lastIdx = transformations.length - 1;
-
-    return transformations[iZoom > lastIdx ? lastIdx : iZoom];
+    final lastIdx = _transformations.length - 1;
+    return _transformations[iZoom > lastIdx ? lastIdx : iZoom];
   }
 }
 
 @immutable
 abstract class Projection {
-  const Projection();
+  final Bounds<double>? bounds;
 
-  Bounds<double>? get bounds;
+  const Projection(this.bounds);
 
-  Point<double> project(LatLng latlng);
-
-  LatLng unproject(Point point);
-
-  double _inclusive(double start, double end, double value) {
-    if (value < start) return start;
-    if (value > end) return end;
-
-    return value;
+  Point<double> project(LatLng latlng) {
+    final (x, y) = projectXY(latlng);
+    return Point<double>(x, y);
   }
 
-  @protected
-  double inclusiveLat(double value) {
-    return _inclusive(-90, 90, value);
-  }
+  (double, double) projectXY(LatLng latlng);
 
-  @protected
-  double inclusiveLng(double value) {
-    return _inclusive(-180, 180, value);
-  }
+  LatLng unproject(Point point) =>
+      unprojectXY(point.x.toDouble(), point.y.toDouble());
+  LatLng unprojectXY(double x, double y);
 }
 
 class _LonLat extends Projection {
-  static final Bounds<double> _bounds = Bounds<double>(
-      const Point<double>(-180, -90), const Point<double>(180, 90));
+  static const _bounds = Bounds<double>.unsafe(
+    Point<double>(-180, -90),
+    Point<double>(180, 90),
+  );
 
-  const _LonLat() : super();
-
-  @override
-  Bounds<double> get bounds => _bounds;
-
-  @override
-  Point<double> project(LatLng latlng) {
-    return Point(latlng.longitude, latlng.latitude);
-  }
+  const _LonLat() : super(_bounds);
 
   @override
-  LatLng unproject(Point point) {
-    return LatLng(
-        inclusiveLat(point.y.toDouble()), inclusiveLng(point.x.toDouble()));
-  }
+  (double, double) projectXY(LatLng latlng) =>
+      (latlng.longitude, latlng.latitude);
+
+  @override
+  LatLng unprojectXY(double x, double y) =>
+      LatLng(_inclusiveLat(y), _inclusiveLng(x));
 }
 
 @immutable
@@ -370,89 +356,94 @@ class SphericalMercator extends Projection {
   static const int r = 6378137;
   static const double maxLatitude = 85.0511287798;
   static const double _boundsD = r * math.pi;
-  static final Bounds<double> _bounds = Bounds<double>(
-    const Point<double>(-_boundsD, -_boundsD),
-    const Point<double>(_boundsD, _boundsD),
+
+  static const Bounds<double> _bounds = Bounds<double>.unsafe(
+    Point<double>(-_boundsD, -_boundsD),
+    Point<double>(_boundsD, _boundsD),
   );
 
-  const SphericalMercator() : super();
+  const SphericalMercator() : super(_bounds);
+
+  static double projectLat(double latitude) {
+    final lat = latitude.clamp(-maxLatitude, maxLatitude);
+    final sin = math.sin(lat * math.pi / 180);
+
+    return r / 2 * math.log((1 + sin) / (1 - sin));
+  }
+
+  static double projectLng(double longitude) {
+    return r * math.pi / 180 * longitude;
+  }
 
   @override
-  Bounds<double> get bounds => _bounds;
-
-  @override
-  Point<double> project(LatLng latlng) {
-    const d = math.pi / 180;
-    final lat = latlng.latitude.clamp(-maxLatitude, maxLatitude);
-    final sin = math.sin(lat * d);
-
-    return Point(
-      r * d * latlng.longitude,
-      r / 2 * math.log((1 + sin) / (1 - sin)),
+  (double, double) projectXY(LatLng latlng) {
+    return (
+      projectLng(latlng.longitude),
+      projectLat(latlng.latitude),
     );
   }
 
   @override
-  LatLng unproject(Point point) {
+  LatLng unprojectXY(double x, double y) {
     const d = 180 / math.pi;
     return LatLng(
-        inclusiveLat(
-            (2 * math.atan(math.exp(point.y / r)) - (math.pi / 2)) * d),
-        inclusiveLng(point.x * d / r));
+      _inclusiveLat((2 * math.atan(math.exp(y / r)) - (math.pi / 2)) * d),
+      _inclusiveLng(x * d / r),
+    );
   }
 }
 
 @immutable
 class _Proj4Projection extends Projection {
   final proj4.Projection epsg4326;
-
   final proj4.Projection proj4Projection;
-
-  @override
-  final Bounds<double>? bounds;
 
   _Proj4Projection({
     required this.proj4Projection,
-    this.bounds,
-  }) : epsg4326 = proj4.Projection.WGS84;
+    required Bounds<double>? bounds,
+  })  : epsg4326 = proj4.Projection.WGS84,
+        super(bounds);
 
   @override
-  Point<double> project(LatLng latlng) {
+  (double, double) projectXY(LatLng latlng) {
     final point = epsg4326.transform(
         proj4Projection, proj4.Point(x: latlng.longitude, y: latlng.latitude));
 
-    return Point(point.x, point.y);
+    return (point.x, point.y);
   }
 
   @override
-  LatLng unproject(Point point) {
-    final point2 = proj4Projection.transform(
-        epsg4326, proj4.Point(x: point.x.toDouble(), y: point.y.toDouble()));
+  LatLng unprojectXY(double x, double y) {
+    final point = proj4Projection.transform(epsg4326, proj4.Point(x: x, y: y));
 
-    return LatLng(inclusiveLat(point2.y), inclusiveLng(point2.x));
+    return LatLng(
+      _inclusiveLat(point.y),
+      _inclusiveLng(point.x),
+    );
   }
 }
 
 @immutable
-class Transformation {
+class _Transformation {
   final double a;
   final double b;
   final double c;
   final double d;
 
-  const Transformation(this.a, this.b, this.c, this.d);
+  const _Transformation(this.a, this.b, this.c, this.d);
 
-  Point<double> transform(Point point, double? scale) {
-    scale ??= 1.0;
-    final x = scale * (a * point.x + b);
-    final y = scale * (c * point.y + d);
-    return Point(x, y);
-  }
+  @nonVirtual
+  (double, double) transform(double x, double y, double scale) => (
+        scale * (a * x + b),
+        scale * (c * y + d),
+      );
 
-  Point<double> untransform(Point point, double? scale) {
-    scale ??= 1.0;
-    final x = (point.x / scale - b) / a;
-    final y = (point.y / scale - d) / c;
-    return Point(x, y);
-  }
+  @nonVirtual
+  (double, double) untransform(double x, double y, double scale) => (
+        (x / scale - b) / a,
+        (y / scale - d) / c,
+      );
 }
+
+double _inclusiveLat(double value) => value.clamp(-90, 90);
+double _inclusiveLng(double value) => value.clamp(-180, 180);

--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -171,14 +171,23 @@ class PolygonPainter extends CustomPainter {
 
   Offset getOffset(Offset origin, LatLng point) {
     // Critically create as little garbage as possible. This is called on every frame.
-    final projected = map.project(point);
+    final projected = map.project(point, map.zoom);
     return Offset(projected.x - origin.dx, projected.y - origin.dy);
   }
 
   List<Offset> getOffsets(Offset origin, List<LatLng> points) {
-    return List.generate(
+    final crs = map.crs;
+    final zoomScale = crs.scale(map.zoom);
+
+    final ox = -origin.dx;
+    final oy = -origin.dy;
+
+    return List<Offset>.generate(
       points.length,
-      (index) => getOffset(origin, points[index]),
+      (index) {
+        final (x, y) = crs.latLngToXY(points[index], zoomScale);
+        return Offset(x + ox, y + oy);
+      },
       growable: false,
     );
   }

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -100,14 +100,23 @@ class PolylinePainter extends CustomPainter {
 
   Offset getOffset(Offset origin, LatLng point) {
     // Critically create as little garbage as possible. This is called on every frame.
-    final projected = map.project(point);
+    final projected = map.project(point, map.zoom);
     return Offset(projected.x - origin.dx, projected.y - origin.dy);
   }
 
   List<Offset> getOffsets(Offset origin, List<LatLng> points) {
-    return List.generate(
+    final crs = map.crs;
+    final zoomScale = crs.scale(map.zoom);
+
+    final ox = -origin.dx;
+    final oy = -origin.dy;
+
+    return List<Offset>.generate(
       points.length,
-      (index) => getOffset(origin, points[index]),
+      (index) {
+        final (x, y) = crs.latLngToXY(points[index], zoomScale);
+        return Offset(x + ox, y + oy);
+      },
       growable: false,
     );
   }

--- a/lib/src/misc/bounds.dart
+++ b/lib/src/misc/bounds.dart
@@ -16,6 +16,7 @@ class Bounds<T extends num> {
     return Bounds._(Point<T>(minx, miny), Point<T>(maxx, maxy));
   }
 
+  const Bounds.unsafe(this.min, this.max);
   const Bounds._(this.min, this.max);
 
   static Bounds<double> containing(Iterable<Point<double>> points) {

--- a/lib/src/misc/offsets.dart
+++ b/lib/src/misc/offsets.dart
@@ -1,0 +1,40 @@
+import 'dart:ui';
+
+import 'package:flutter_map/src/geo/crs.dart';
+import 'package:flutter_map/src/map/camera/camera.dart';
+import 'package:latlong2/latlong.dart';
+
+Offset getOffset(MapCamera camera, Offset origin, LatLng point) {
+  final crs = camera.crs;
+  final zoomScale = crs.scale(camera.zoom);
+  final (x, y) = crs.latLngToXY(point, zoomScale);
+  return Offset(x - origin.dx, y - origin.dy);
+}
+
+List<Offset> getOffsets(MapCamera camera, Offset origin, List<LatLng> points) {
+  // Critically create as little garbage as possible. This is called on every frame.
+  final crs = camera.crs;
+  final zoomScale = crs.scale(camera.zoom);
+
+  final ox = -origin.dx;
+  final oy = -origin.dy;
+  final len = points.length;
+
+  // Optimization: monomorphize the Epsg3857-case to save the virtual function overhead.
+  if (crs is Epsg3857) {
+    final Epsg3857 epsg3857 = crs;
+    final v = List<Offset>.filled(len, Offset.zero);
+    for (int i = 0; i < len; ++i) {
+      final (x, y) = epsg3857.latLngToXY(points[i], zoomScale);
+      v[i] = Offset(x + ox, y + oy);
+    }
+    return v;
+  }
+
+  final v = List<Offset>.filled(len, Offset.zero);
+  for (int i = 0; i < len; ++i) {
+    final (x, y) = crs.latLngToXY(points[i], zoomScale);
+    v[i] = Offset(x + ox, y + oy);
+  }
+  return v;
+}

--- a/test/layer/tile_layer/tile_bounds/crs_fakes.dart
+++ b/test/layer/tile_layer/tile_bounds/crs_fakes.dart
@@ -1,30 +1,31 @@
 import 'dart:math';
 
 import 'package:flutter_map/src/geo/crs.dart';
+import 'package:flutter_map/src/misc/bounds.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:meta/meta.dart';
 
+@immutable
 class FakeInfiniteCrs extends Crs {
-  @override
-  String get code => throw UnimplementedError();
-
-  @override
-  bool get infinite => true;
+  const FakeInfiniteCrs() : super(code: 'fake', infinite: true);
 
   @override
   Projection get projection => throw UnimplementedError();
-
-  @override
-  Transformation get transformation => throw UnimplementedError();
-
-  @override
-  (double, double)? get wrapLat => null;
-
-  @override
-  (double, double)? get wrapLng => null;
 
   /// Any projection just to get non-zero coordiantes.
   @override
   Point<double> latLngToPoint(LatLng latlng, double zoom) {
     return const Epsg3857().latLngToPoint(latlng, zoom);
   }
+
+  @override
+  (double, double) latLngToXY(LatLng latlng, double scale) {
+    return const Epsg3857().latLngToXY(latlng, scale);
+  }
+
+  @override
+  LatLng pointToLatLng(Point point, double zoom) => throw UnimplementedError();
+
+  @override
+  Bounds<double>? getProjectedBounds(double zoom) => throw UnimplementedError();
 }

--- a/test/layer/tile_layer/tile_bounds/tile_bounds_test.dart
+++ b/test/layer/tile_layer/tile_bounds/tile_bounds_test.dart
@@ -14,7 +14,7 @@ void main() {
   group('TileBounds', () {
     test('crs is infinite, latLngBounds null', () {
       final tileBounds = TileBounds(
-        crs: FakeInfiniteCrs(),
+        crs: const FakeInfiniteCrs(),
         tileSize: 256,
       );
 
@@ -24,7 +24,7 @@ void main() {
 
     test('crs is infinite, latLngBounds provided', () {
       final tileBounds = TileBounds(
-        crs: FakeInfiniteCrs(),
+        crs: const FakeInfiniteCrs(),
         tileSize: 256,
         latLngBounds: LatLngBounds.fromPoints(
           [const LatLng(-44, -55), const LatLng(44, 55)],


### PR DESCRIPTION
Sorry to any reviewer, this change looks wilder than it is. It should no be braking unless you were depending on Transformation which I now  made internal (should allow us to freely change APIs in the future). At the end of the day, I spend a significant effort to reduce the `math.Point` constructions and most importantly reduce virtual function call overhead.

There are also some minor simplifications:
 * I moved things that don't need to be virtual into the base class since we're sub-typing anyway
 * I moved transformation out of `Crs` and up a level since it didn't seem to fit the Proj4Crs well.

I found testing on a device a bit limiting so I ended up adding some micro-benchmarks (we can also drop 'em, no strong feelings). I always like to say: don't trust micro-benchmarks but I also found them to be quite misleading in some cases. Things that seemed faster in the micro-benchmark didn't have an effect on-device and vice versa. It's unclear to me how much this is artifacting or due to the differences in the arm/x86 compiler backends :shrug:

At the end of the day, we probably care the most that it's faster on-device. The impact of this change will ultimately depend on how many LatLng coordinates you're translating into screen coordinates. In other words, more poly(gons|lines), more impact. I used the example and added an extra 100 polygons with 50 points each. The result was roughly a **25% reduction** in UI thread times:

<table>
<tr>
<th> Before: </th>
<th> After: </th>
</tr>
<tr>
<td>

![Screenshot_20231110-142305_flutter_map Demo](https://github.com/fleaflet/flutter_map/assets/111986/271f04b6-d72d-4c33-8ca9-96d6bb95d20a)

</td>
<td>

![Screenshot_20231110-143225_flutter_map Demo](https://github.com/fleaflet/flutter_map/assets/111986/1bb7f2d8-2d9b-45ce-b3cc-8ebad60c3867)

</td>
</tr>
</table>

I only wish, I could point to the micro benchmarks and see a similar uplift. For transparency:

```
BEFORE:
(duration: 0:00:04.416050, name: Concrete type: EPSG:3857.latLngToPoint())
(duration: 0:00:03.895437, name: EPSG:3857.latlngToPoint())
(duration: 0:00:04.058475, name: EPSG:3857.pointToLatLng())
(duration: 0:00:01.341018, name: EPSG:4326.latlngToPoint())
(duration: 0:00:02.095936, name: EPSG:4326.pointToLatLng())


AFTER
(duration: 0:00:02.536865, name: Concrete type: EPSG:3857.latLngToCoordinates())
(duration: 0:00:03.327685, name: Concrete type: EPSG:3857.latLngToPoint())
(duration: 0:00:04.135330, name: EPSG:3857.latLngToCoordinates())
(duration: 0:00:04.808905, name: EPSG:3857.latlngToPoint())
(duration: 0:00:04.275039, name: EPSG:3857.pointToLatLng())
(duration: 0:00:01.148857, name: EPSG:4326.latLngToCoordinates())
(duration: 0:00:01.656589, name: EPSG:4326.latlngToPoint())
(duration: 0:00:02.149977, name: EPSG:4326.pointToLatLng())
```