### PR TITLE
fix: CircleLayer not updating on pan

### DIFF
--- a/lib/src/layer/circle_layer.dart
+++ b/lib/src/layer/circle_layer.dart
@@ -157,5 +157,7 @@ class CirclePainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(CirclePainter oldDelegate) => false;
+  bool shouldRepaint(CirclePainter oldDelegate) =>
+    circles != oldDelegate.circles ||
+    map != oldDelegate.map;
 }

--- a/lib/src/layer/circle_layer.dart
+++ b/lib/src/layer/circle_layer.dart
@@ -158,6 +158,5 @@ class CirclePainter extends CustomPainter {
 
   @override
   bool shouldRepaint(CirclePainter oldDelegate) =>
-    circles != oldDelegate.circles ||
-    map != oldDelegate.map;
+      circles != oldDelegate.circles || map != oldDelegate.map;
 }


### PR DESCRIPTION
Since version 6.0.1 the circle layer is not updated properly any more.

This was introduced as a side effect of: https://github.com/fleaflet/flutter_map/commit/117f2543dc89f0fc0901be536f73d379adeba592#diff-5d1e8506fe899e135910abbab2ef61ca6b4fde4e34f60b80b0fd85204ae485baL40-L47

<table>
<tr>
<th> Before </th>
<th> After </th>
</tr>
<tr>
<td>

[before.webm](https://github.com/fleaflet/flutter_map/assets/13716661/801e99c2-b7c2-4ae5-af2f-d2ba159ce8b3)

</td>
<td>

[after.webm](https://github.com/fleaflet/flutter_map/assets/13716661/7c46e81b-77e5-48ba-86e5-f05798dd1585)

</td>
</tr>
</table>

This can also be tested using the example app's circle layer page by adding an `AnimatedSwitcher` around the `CircleLayer`.
```dart
AnimatedSwitcher(
  duration: Duration(milliseconds: 300),
  child: CircleLayer(circles: circleMarkers),
),
```


While looking at it the circle layer could certainly get some more love (like caching the grouped circles), but I currently don't have time for any additional optimizations.