### PR TITLE
revert: #1731

### DIFF
--- a/example/lib/pages/animated_map_controller.dart
+++ b/example/lib/pages/animated_map_controller.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class AnimatedMapControllerPage extends StatefulWidget {
   static const String route = '/map_controller_animated';

--- a/example/lib/pages/bundled_offline_map.dart
+++ b/example/lib/pages/bundled_offline_map.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class BundledOfflineMapPage extends StatelessWidget {
   static const String route = '/bundled_offline_map';

--- a/example/lib/pages/cancellable_tile_provider.dart
+++ b/example/lib/pages/cancellable_tile_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
 import 'package:flutter_map_example/widgets/notice_banner.dart';
+import 'package:latlong2/latlong.dart';
 
 class CancellableTileProviderPage extends StatefulWidget {
   static const String route = '/cancellable_tile_provider_page';

--- a/example/lib/pages/circle.dart
+++ b/example/lib/pages/circle.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class CirclePage extends StatelessWidget {
   static const String route = '/circle';

--- a/example/lib/pages/custom_crs/custom_crs.dart
+++ b/example/lib/pages/custom_crs/custom_crs.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:proj4dart/proj4dart.dart' as proj4;
 import 'package:url_launcher/url_launcher.dart';
 

--- a/example/lib/pages/epsg3413_crs.dart
+++ b/example/lib/pages/epsg3413_crs.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:proj4dart/proj4dart.dart' as proj4;
 import 'package:url_launcher/url_launcher.dart';
 

--- a/example/lib/pages/epsg4326_crs.dart
+++ b/example/lib/pages/epsg4326_crs.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class EPSG4326Page extends StatelessWidget {
   static const String route = '/crs_epsg4326';

--- a/example/lib/pages/fallback_url_page.dart
+++ b/example/lib/pages/fallback_url_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
 import 'package:flutter_map_example/widgets/notice_banner.dart';
+import 'package:latlong2/latlong.dart';
 
 class FallbackUrlPage extends StatelessWidget {
   static const String route = '/fallback_url';

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -6,6 +6,7 @@ import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/floating_menu_button.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
 import 'package:flutter_map_example/widgets/first_start_dialog.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/example/lib/pages/interactive_test_page.dart
+++ b/example/lib/pages/interactive_test_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class InteractiveFlagsPage extends StatefulWidget {
   static const String route = '/interactive_flags_page';

--- a/example/lib/pages/latlng_to_screen_point.dart
+++ b/example/lib/pages/latlng_to_screen_point.dart
@@ -5,6 +5,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class LatLngToScreenPointPage extends StatefulWidget {
   static const String route = '/latlng_to_screen_point';

--- a/example/lib/pages/many_circles.dart
+++ b/example/lib/pages/many_circles.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 const maxCirclesCount = 20000;
 

--- a/example/lib/pages/many_markers.dart
+++ b/example/lib/pages/many_markers.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 const maxMarkersCount = 20000;
 

--- a/example/lib/pages/map_controller.dart
+++ b/example/lib/pages/map_controller.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class MapControllerPage extends StatefulWidget {
   static const String route = 'map_controller';

--- a/example/lib/pages/map_inside_listview.dart
+++ b/example/lib/pages/map_inside_listview.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/plugins/zoombuttons_plugin_option.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class MapInsideListViewPage extends StatelessWidget {
   static const String route = '/map_inside_listview';

--- a/example/lib/pages/markers.dart
+++ b/example/lib/pages/markers.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class MarkerPage extends StatefulWidget {
   static const String route = '/markers';

--- a/example/lib/pages/moving_markers.dart
+++ b/example/lib/pages/moving_markers.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class MovingMarkersPage extends StatefulWidget {
   static const String route = '/moving_markers';

--- a/example/lib/pages/overlay_image.dart
+++ b/example/lib/pages/overlay_image.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class OverlayImagePage extends StatelessWidget {
   static const String route = '/overlay_image';

--- a/example/lib/pages/polygon.dart
+++ b/example/lib/pages/polygon.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class PolygonPage extends StatelessWidget {
   static const String route = '/polygon';

--- a/example/lib/pages/polyline.dart
+++ b/example/lib/pages/polyline.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class PolylinePage extends StatefulWidget {
   static const String route = '/polyline';

--- a/example/lib/pages/reset_tile_layer.dart
+++ b/example/lib/pages/reset_tile_layer.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class ResetTileLayerPage extends StatefulWidget {
   static const String route = '/reset_tilelayer';

--- a/example/lib/pages/retina.dart
+++ b/example/lib/pages/retina.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class RetinaPage extends StatefulWidget {

--- a/example/lib/pages/scalebar_utils.dart
+++ b/example/lib/pages/scalebar_utils.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 import 'dart:ui';
 
-import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
 
 const double piOver180 = pi / 180.0;
 

--- a/example/lib/pages/screen_point_to_latlng.dart
+++ b/example/lib/pages/screen_point_to_latlng.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class ScreenPointToLatLngPage extends StatefulWidget {
   static const String route = '/screen_point_to_latlng';

--- a/example/lib/pages/secondary_tap.dart
+++ b/example/lib/pages/secondary_tap.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class SecondaryTapPage extends StatelessWidget {
   const SecondaryTapPage({super.key});

--- a/example/lib/pages/sliding_map.dart
+++ b/example/lib/pages/sliding_map.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class SlidingMapPage extends StatelessWidget {
   static const String route = '/sliding_map';

--- a/example/lib/pages/stateful_markers.dart
+++ b/example/lib/pages/stateful_markers.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class StatefulMarkersPage extends StatefulWidget {
   static const String route = '/stateful_markers';

--- a/example/lib/pages/tile_builder.dart
+++ b/example/lib/pages/tile_builder.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class TileBuilderPage extends StatefulWidget {
   static const String route = '/tile_builder';

--- a/example/lib/pages/tile_loading_error_handle.dart
+++ b/example/lib/pages/tile_loading_error_handle.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class TileLoadingErrorHandle extends StatefulWidget {
   static const String route = '/tile_loading_error_handle';

--- a/example/lib/pages/wms_tile_layer.dart
+++ b/example/lib/pages/wms_tile_layer.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class WMSLayerPage extends StatelessWidget {

--- a/example/lib/plugins/plugin_scalebar.dart
+++ b/example/lib/plugins/plugin_scalebar.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/pages/scale_layer_plugin_option.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class PluginScaleBar extends StatelessWidget {
   static const String route = '/plugin_scalebar';

--- a/example/lib/plugins/plugin_zoombuttons.dart
+++ b/example/lib/plugins/plugin_zoombuttons.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/plugins/zoombuttons_plugin_option.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
 
 class PluginZoomButtons extends StatelessWidget {
   static const String route = '/plugin_zoombuttons';

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   flutter_map:
   flutter_map_cancellable_tile_provider:
+  latlong2: ^0.9.0
   proj4dart: ^2.1.0
   url_launcher: ^6.1.14
   shared_preferences: ^2.2.1

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -60,4 +60,3 @@ export 'package:flutter_map/src/misc/center_zoom.dart';
 export 'package:flutter_map/src/misc/move_and_rotate_result.dart';
 export 'package:flutter_map/src/misc/point_extensions.dart';
 export 'package:flutter_map/src/misc/position.dart';
-export 'package:latlong2/latlong.dart';


### PR DESCRIPTION
With new plans underway to eventually remove the 'latlong2' dependency altogether, this should help avoid user's needing two migrations.

Should be cherry picked into v6.1.0.