### PR TITLE
fix: `MapPosition.hashCode` value distribution

### DIFF
--- a/lib/src/misc/position.dart
+++ b/lib/src/misc/position.dart
@@ -17,7 +17,7 @@ class MapPosition {
   });
 
   @override
-  int get hashCode => center.hashCode + bounds.hashCode + zoom.hashCode;
+  int get hashCode => Object.hash(center, bounds, zoom);
 
   @override
   bool operator ==(Object other) =>


### PR DESCRIPTION
This PR adds a better value distribution of for `MapPosition.hashCode`.
### Old
Adding the 3 hashCodes together has the effekt that relativly bigger values are more likely to happen. This increases the chance of hash code collision.
```dart
  @override
  int get hashCode => center.hashCode + bounds.hashCode + zoom.hashCode;
```

### New
If we use `.hashCode` anyway let's do the following change:
```dart
  @override
  int get hashCode => Object.hash(center, bounds, zoom);
```

Can and should get cherry picked to `v6.1.0-rc`