### PR TITLE
chore: v6.1.0 release preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Please consider [donating](https://docs.fleaflet.dev/supporters#support-us) or [contributing](https://docs.fleaflet.dev/credits#contributing) if you're a fan of what we're doing and you'd like to support future releases!
 
-## [6.1.0] - 2023/12/XX
+## [6.1.0] - 2023/12/02
 
 Contains the following user-affecting changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,50 @@
 # Changelog
 
-## [6.0.1] - 2023/10/XX
+Please consider [donating](https://docs.fleaflet.dev/supporters#support-us) or [contributing](https://docs.fleaflet.dev/credits#contributing) if you're a fan of what we're doing and you'd like to support future releases!
+
+## [6.1.0] - 2023/12/XX
+
+Contains the following user-affecting changes:
+
+- 🟢 Added option to draw labels on top of all `Polygon`s in a layer - [#1707](https://github.com/fleaflet/flutter_map/pull/1707)
+- (Released 'flutter_map_cancellable_tile_provider' [v2.0.0](https://pub.dev/packages/flutter_map_cancellable_tile_provider/changelog))
 
 Contains the following user-affecting bug fixes:
 
-- Fixed `CircleMarker`'s incorrect appearance and size  - [#1692](https://github.com/fleaflet/flutter_map/pull/1692) for [#1688](https://github.com/fleaflet/flutter_map/issues/1688)
+- Removed flutter_map text attribution when `RichAttributionWidget.showFlutterMapAttribution` is `false` - [#1712](https://github.com/fleaflet/flutter_map/pull/1712)
+- Repaired `TileLayer.tileBounds` - [#1713](https://github.com/fleaflet/flutter_map/pull/1713) for [#1710](https://github.com/fleaflet/flutter_map/issues/1710)
+- Added `doubleTapDragZoom` and `scrollWheelZoom` to `InteractiveFlag.all` - [#1726](https://github.com/fleaflet/flutter_map/pull/1726) for [#1725](https://github.com/fleaflet/flutter_map/issues/1725)
+- Repaired correct movement for `CircleLayer` when panning - [#1735](https://github.com/fleaflet/flutter_map/pull/1735)
+- Improved value distribution for `MapPosition.hashCode` - [#1747](https://github.com/fleaflet/flutter_map/pull/1747)
+
+Contains the following user-affecting performance improvements:
+
+- Optimized `Bounds` - [#1706](https://github.com/fleaflet/flutter_map/pull/1706)
+- Avoided creating a new list on every frame unnecessarily - [#1708](https://github.com/fleaflet/flutter_map/pull/1708)
+- Cull `Polygon` labels seperately (more strongly), and cache the `TextPainter` - [#1716](https://github.com/fleaflet/flutter_map/pull/1716)
+- Avoided caching a single commonly-used multiplication - [#1743](https://github.com/fleaflet/flutter_map/pull/1743)
+
+Many thanks to these contributors (in no particular order):
+
+- @ignatz
+- @amal-stack
+- @Robbendebiene
+- ... and all the maintainers
+
+And an additional special thanks to @ignatz for investing so much of their time into this project recently - we appreciate it!
+
+In other news:
+
+- A warm welcome to @josxha, who's recently joined the maintainer team
+- We've also made some widespread minor improvmenents to the example application
+- Check out the new [Showcase](https://docs.fleaflet.dev/showcase) page on our docs for some awesome projects
+- We're working on some very exciting reworked features and performance improvements for v7 - keep an ear out by joining our [Discord server](https://discord.gg/BwpEsjqMAH)
+
+## [6.0.1] - 2023/10/24
+
+Contains the following user-affecting bug fixes:
+
+- Fixed `CircleMarker`'s incorrect appearance and size - [#1692](https://github.com/fleaflet/flutter_map/pull/1692) for [#1688](https://github.com/fleaflet/flutter_map/issues/1688)
 - Fixed `LateInitializationError` when specifying `initialCameraFit` - [#1691](https://github.com/fleaflet/flutter_map/pull/1691) for [#1684](https://github.com/fleaflet/flutter_map/issues/1684)
 - Fixed incorrect behaviour issues caused by the adjusted default `MapOptions.cameraConstraint` - [#1700](https://github.com/fleaflet/flutter_map/pull/1700) for [#1682](https://github.com/fleaflet/flutter_map/issues/1682) & [#1699](https://github.com/fleaflet/flutter_map/issues/1699)
 - Fixed bug where not providing either `wmsOptions` nor `urlTemplate` caused a null exception in `getTileUrl` and when `retinaMode` is `true` - [#1701](https://github.com/fleaflet/flutter_map/pull/1701)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,15 @@
 # Contributing
 
-'flutter_map' is only as great as it is because of generous open-source contributors!
-
 We're always happy to receive improvements and fixes, so please submit them whenever you can! A few key points are listed below.
 
 > Many feature additions are more suitable for plugins, instead of being added to the core. This is aimed to reduce the future maintenance burden/cost on the maintainers.  
 If we deny your PR for this reason, please do consider publishing a plugin, and we'll be happy to add it to the [Plugins List](https://docs.fleaflet.dev/plugins/list)! See [Making A Plugin](https://docs.fleaflet.dev/plugins/making-a-plugin) for more information.
 
-* If your PR will add a major or breaking change, please discuss it with us first, via the Issue Tracker
-* Always link your PR to at least one issue, and as many as are resolved
-* Create a draft PR as soon as work starts, and take it out of draft status when ready for review
-* Avoid changing the package version or GitHub workflows
-* Fix issues reported by the GitHub workflows (such as formatting) yourself
+* **If your PR will add a major or breaking change, please discuss it with us first, via the Issue Tracker**  
+We don't want to waste your time if we think it's more appropriate for a plugin, and it helps to make a clear plan before starting work
+* **Create a draft PR as soon as work starts, and take it out of draft status when ready for review**  
+Keep everyone in the loop, so no-one tries working on the same thing as you
+* **Don't change the package version, GitHub workflows, lints, or any other meta files without clarification**  
+We rely on a standardized process and procedure to ensure top-quality releases
+* **Use a clear (preferably [Conventional](https://www.conventionalcommits.org/)) PR title**  
+This makes it easier for us to group commits for release and write correct CHANGELOGs

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -19,7 +19,7 @@ if (flutterVersionCode == null) {
 
 def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
-    flutterVersionName = '6.0.1'
+    flutterVersionName = '6.1.0'
 }
 
 android {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_map_example
 description: Example application for 'flutter_map' package
 publish_to: "none"
-version: 6.0.1
+version: 6.1.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_map
 description: A versatile mapping package for Flutter, that's simple and easy to learn, yet completely customizable and configurable
-version: 6.0.1
+version: 6.1.0
 
 repository: https://github.com/fleaflet/flutter_map
 issue_tracker: https://github.com/fleaflet/flutter_map/issues
@@ -30,7 +30,7 @@ dependencies:
   collection: ^1.17.1
   flutter:
     sdk: flutter
-  http: ^1.0.0
+  http: ^1.1.2
   latlong2: ^0.9.0
   logger: ^2.0.1
   meta: ^1.9.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   collection: ^1.17.1
   flutter:
     sdk: flutter
-  http: ^1.1.2
+  http: ^1.0.0
   latlong2: ^0.9.0
   logger: ^2.0.1
   meta: ^1.9.1

--- a/windowsApplicationInstallerSetup.iss
+++ b/windowsApplicationInstallerSetup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "flutter_map Demo"
-#define MyAppVersion "for 6.0.1"
+#define MyAppVersion "for 6.1.0"
 #define MyAppPublisher "fleaflet"
 #define MyAppURL "https://github.com/fleaflet/flutter_map"
 #define MyAppSupportURL "https://github.com/fleaflet/flutter_map/issues"


### PR DESCRIPTION
- Updated CHANGELOG
- Updated self versions throughout
- Updated dependencies
- Updated contributing guidelines

#### before merging:
- [x] Requires flutter_map_cancellable_tile_provider v2 before merge and v6.1.0 release
- [x] add current date to `CHANGELOG.md`