### PR TITLE
chore: remove error in console for example app

### DIFF
--- a/example/lib/pages/plugin_scalebar.dart
+++ b/example/lib/pages/plugin_scalebar.dart
@@ -15,22 +15,20 @@ class PluginScaleBar extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Scale Bar Plugin')),
       drawer: const MenuDrawer(PluginScaleBar.route),
-      body: Flexible(
-        child: FlutterMap(
-          options: const MapOptions(
-            initialCenter: LatLng(51.5, -0.09),
-            initialZoom: 5,
-          ),
-          children: [
-            openStreetMapTileLayer,
-            const FlutterMapScaleLayer(
-              lineColor: Colors.black,
-              lineWidth: 3,
-              textStyle: TextStyle(color: Colors.black, fontSize: 14),
-              padding: EdgeInsets.all(10),
-            ),
-          ],
+      body: FlutterMap(
+        options: const MapOptions(
+          initialCenter: LatLng(51.5, -0.09),
+          initialZoom: 5,
         ),
+        children: [
+          openStreetMapTileLayer,
+          const FlutterMapScaleLayer(
+            lineColor: Colors.black,
+            lineWidth: 3,
+            textStyle: TextStyle(color: Colors.black, fontSize: 14),
+            padding: EdgeInsets.all(10),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
The `PluginScaleBar` page of the example app has the following exception in the console:
```
======== Exception caught by widgets library =======================================================
The following assertion was thrown while applying parent data.:
Incorrect use of ParentDataWidget.

The ParentDataWidget Flexible(flex: 1) wants to apply ParentData of type FlexParentData to a RenderObject, which has been set up to accept ParentData of incompatible type MultiChildLayoutParentData.

Usually, this means that the Flexible widget has the wrong ancestor RenderObjectWidget. Typically, Flexible widgets are placed directly inside Flex widgets.
The offending Flexible is currently placed inside a CustomMultiChildLayout widget.

The ownership chain for the RenderObject that received the incompatible parent data was:
  LayoutBuilder ← FlutterMap ← Flexible ← KeyedSubtree-[GlobalKey#1f663] ← _BodyBuilder ← MediaQuery ← LayoutId-[<_ScaffoldSlot.body>] ← CustomMultiChildLayout ← _ActionsScope ← Actions ← ⋯
```

This happens because `FlutterMap` is wrapped in a `Flexible` parent widget that is not needed.
By removing the wrapping `Flexible` the error gets removed.