### PR TITLE
perf: use `radians2Degrees` const from `vector_math`

### DIFF
--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -110,7 +110,7 @@ class LatLngBounds {
     final lambda3 = lambda1 + math.atan2(by, math.cos(phi1) + bx);
 
     // phi3 and lambda3 are actually in radians and LatLng wants degrees
-    return LatLng(radianToDeg(phi3), radianToDeg(lambda3));
+    return LatLng(phi3 * radians2Degrees, lambda3 * radians2Degrees);
   }
 
   /// Checks whether [point] is inside bounds

--- a/lib/src/gestures/map_interactive_viewer.dart
+++ b/lib/src/gestures/map_interactive_viewer.dart
@@ -486,7 +486,7 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
       return;
     }
 
-    final currentRotation = radianToDeg(details.rotation);
+    final currentRotation = details.rotation * radians2Degrees;
     if (_dragMode) {
       _handleScaleDragUpdate(details);
     } else if (InteractiveFlag.hasMultiFinger(_interactionOptions.flags)) {


### PR DESCRIPTION
This PR is a follow up to https://github.com/fleaflet/flutter_map/pull/1743.
It makes use of the `radians2Degrees` from the `vector_math` package.