### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"


### PR DESCRIPTION
This pull request adds the dependabot configuration file. 

It uses loose package constrains because the used package version is defined in the final application anyways. Therefore only updates for major versions are active.

Example pull request (here using the beta grouped security updates feature):
![image](https://github.com/fleaflet/flutter_map/assets/34318751/6e0c7aef-3b42-4edd-8643-3f644a9202a3)

