### PR TITLE
chore: disable CodeCov coverage warnings in PR diff

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,14 +1,18 @@
 codecov:
   require_ci_to_pass: true
+
+coverage:
   status:
     project:
       default:
+        # the required coverage value
         target: 0%
-        threshold: 0%
+        # the leniency in hitting the target
+        threshold: 100%
+    # completely disable coverage warnings and the status check for changes
+    patch: off
 
 ignore:
   - "**/*.g.dart"
   - "example"
   - "benchmark"
-
-comment: false


### PR DESCRIPTION
I first had this change in https://github.com/fleaflet/flutter_map/pull/1757 but it's really annoing to review https://github.com/fleaflet/flutter_map/pull/1728 with all those warnings.

<img src="https://github.com/fleaflet/flutter_map/assets/34318751/5c7f0291-d0db-4b9a-b81c-29c50d5829ce" 
         width="50%" />

That's why I moved those changes over to a new PR.
The changes can be seen in effect in https://github.com/fleaflet/flutter_map/pull/1757.

Last codecov pull request.™