### PR TITLE
perf!: add simplification caching to `PolygonLayer` & other performance improvements

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,7 +20,9 @@ import 'package:flutter_map_example/pages/overlay_image.dart';
 import 'package:flutter_map_example/pages/plugin_scalebar.dart';
 import 'package:flutter_map_example/pages/plugin_zoombuttons.dart';
 import 'package:flutter_map_example/pages/polygon.dart';
+import 'package:flutter_map_example/pages/polygon_perf_stress.dart';
 import 'package:flutter_map_example/pages/polyline.dart';
+import 'package:flutter_map_example/pages/polyline_perf_stress.dart';
 import 'package:flutter_map_example/pages/reset_tile_layer.dart';
 import 'package:flutter_map_example/pages/retina.dart';
 import 'package:flutter_map_example/pages/screen_point_to_latlng.dart';
@@ -53,6 +55,8 @@ class MyApp extends StatelessWidget {
         CancellableTileProviderPage.route: (context) =>
             const CancellableTileProviderPage(),
         PolylinePage.route: (context) => const PolylinePage(),
+        PolylinePerfStressPage.route: (context) =>
+            const PolylinePerfStressPage(),
         MapControllerPage.route: (context) => const MapControllerPage(),
         AnimatedMapControllerPage.route: (context) =>
             const AnimatedMapControllerPage(),
@@ -65,6 +69,7 @@ class MyApp extends StatelessWidget {
         CirclePage.route: (context) => const CirclePage(),
         OverlayImagePage.route: (context) => const OverlayImagePage(),
         PolygonPage.route: (context) => const PolygonPage(),
+        PolygonPerfStressPage.route: (context) => const PolygonPerfStressPage(),
         SlidingMapPage.route: (_) => const SlidingMapPage(),
         WMSLayerPage.route: (context) => const WMSLayerPage(),
         CustomCrsPage.route: (context) => const CustomCrsPage(),

--- a/example/lib/pages/many_circles.dart
+++ b/example/lib/pages/many_circles.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:flutter_map_example/widgets/number_of_items_slider.dart';
 import 'package:latlong2/latlong.dart';
 
 const maxCirclesCount = 20000;
@@ -26,7 +27,8 @@ class ManyCirclesPageState extends State<ManyCirclesPage> {
       source.nextDouble() * (end - start) + start;
   List<CircleMarker> allCircles = [];
 
-  int _sliderVal = maxCirclesCount ~/ 10;
+  static const int _initialNumOfCircles = maxCirclesCount ~/ 10;
+  int numOfCircles = _initialNumOfCircles;
 
   @override
   void initState() {
@@ -52,38 +54,35 @@ class ManyCirclesPageState extends State<ManyCirclesPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('A lot of circles')),
+      appBar: AppBar(title: const Text('Many Circles')),
       drawer: const MenuDrawer(ManyCirclesPage.route),
-      body: Column(
+      body: Stack(
         children: [
-          Slider(
-            min: 0,
-            max: maxCirclesCount.toDouble(),
-            divisions: maxCirclesCount ~/ 500,
-            label: 'Circles',
-            value: _sliderVal.toDouble(),
-            onChanged: (newVal) {
-              _sliderVal = newVal.toInt();
-              setState(() {});
-            },
-          ),
-          Text('$_sliderVal circles'),
-          Flexible(
-            child: FlutterMap(
-              options: const MapOptions(
-                initialCenter: LatLng(50, 20),
-                initialZoom: 5,
-                interactionOptions: InteractionOptions(
-                  flags: InteractiveFlag.all - InteractiveFlag.rotate,
-                ),
-              ),
-              children: [
-                openStreetMapTileLayer,
-                CircleLayer(
-                    circles: allCircles.sublist(
-                        0, min(allCircles.length, _sliderVal))),
-              ],
+          FlutterMap(
+            options: const MapOptions(
+              initialCenter: LatLng(45.389995, 11.694336),
+              initialZoom: 5,
             ),
+            children: [
+              openStreetMapTileLayer,
+              CircleLayer(circles: allCircles.take(numOfCircles).toList()),
+            ],
+          ),
+          Positioned(
+            left: 16,
+            top: 16,
+            right: 16,
+            child: NumberOfItemsSlider(
+              itemDescription: 'Circle',
+              initialNumber: _initialNumOfCircles,
+              onChangedNumber: (v) => setState(() => numOfCircles = v),
+            ),
+          ),
+          Positioned(
+            bottom: 16,
+            left: 0,
+            right: 0,
+            child: PerformanceOverlay.allEnabled(),
           ),
         ],
       ),

--- a/example/lib/pages/many_circles.dart
+++ b/example/lib/pages/many_circles.dart
@@ -7,9 +7,9 @@ import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
 import 'package:flutter_map_example/widgets/number_of_items_slider.dart';
 import 'package:latlong2/latlong.dart';
 
-const maxCirclesCount = 20000;
+const _maxCirclesCount = 20000;
 
-/// On this page, [maxCirclesCount] circles are randomly generated
+/// On this page, [_maxCirclesCount] circles are randomly generated
 /// across europe, and then you can limit them with a slider
 ///
 /// This way, you can test how map performs under a lot of circles
@@ -27,7 +27,7 @@ class ManyCirclesPageState extends State<ManyCirclesPage> {
       source.nextDouble() * (end - start) + start;
   List<CircleMarker> allCircles = [];
 
-  static const int _initialNumOfCircles = maxCirclesCount ~/ 10;
+  static const int _initialNumOfCircles = _maxCirclesCount ~/ 10;
   int numOfCircles = _initialNumOfCircles;
 
   @override
@@ -35,7 +35,7 @@ class ManyCirclesPageState extends State<ManyCirclesPage> {
     super.initState();
     Future.microtask(() {
       final r = Random();
-      for (var x = 0; x < maxCirclesCount; x++) {
+      for (var x = 0; x < _maxCirclesCount; x++) {
         allCircles.add(
           CircleMarker(
             point: LatLng(doubleInRange(r, 37, 55), doubleInRange(r, -9, 30)),
@@ -81,6 +81,7 @@ class ManyCirclesPageState extends State<ManyCirclesPage> {
             right: 16,
             child: NumberOfItemsSlider(
               itemDescription: 'Circle',
+              maxNumber: _maxCirclesCount,
               initialNumber: _initialNumOfCircles,
               onChangedNumber: (v) => setState(() => numOfCircles = v),
             ),

--- a/example/lib/pages/many_circles.dart
+++ b/example/lib/pages/many_circles.dart
@@ -38,10 +38,7 @@ class ManyCirclesPageState extends State<ManyCirclesPage> {
       for (var x = 0; x < maxCirclesCount; x++) {
         allCircles.add(
           CircleMarker(
-            point: LatLng(
-              doubleInRange(r, 37, 55),
-              doubleInRange(r, -9, 30),
-            ),
+            point: LatLng(doubleInRange(r, 37, 55), doubleInRange(r, -9, 30)),
             color: Colors.red,
             radius: 5,
           ),
@@ -59,9 +56,19 @@ class ManyCirclesPageState extends State<ManyCirclesPage> {
       body: Stack(
         children: [
           FlutterMap(
-            options: const MapOptions(
-              initialCenter: LatLng(45.389995, 11.694336),
-              initialZoom: 5,
+            options: MapOptions(
+              initialCameraFit: CameraFit.bounds(
+                bounds: LatLngBounds(
+                  const LatLng(55, -9),
+                  const LatLng(37, 30),
+                ),
+                padding: const EdgeInsets.only(
+                  left: 16,
+                  right: 16,
+                  top: 88,
+                  bottom: 192,
+                ),
+              ),
             ),
             children: [
               openStreetMapTileLayer,

--- a/example/lib/pages/many_markers.dart
+++ b/example/lib/pages/many_markers.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:flutter_map_example/widgets/number_of_items_slider.dart';
 import 'package:latlong2/latlong.dart';
 
 const maxMarkersCount = 20000;
@@ -26,7 +27,8 @@ class ManyMarkersPageState extends State<ManyMarkersPage> {
       source.nextDouble() * (end - start) + start;
   List<Marker> allMarkers = [];
 
-  int _sliderVal = maxMarkersCount ~/ 10;
+  static const int _initialNumOfMarkers = maxMarkersCount ~/ 10;
+  int numOfMarkers = _initialNumOfMarkers;
 
   @override
   void initState() {
@@ -50,41 +52,35 @@ class ManyMarkersPageState extends State<ManyMarkersPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('A lot of markers')),
+      appBar: AppBar(title: const Text('Many Markers')),
       drawer: const MenuDrawer(ManyMarkersPage.route),
-      body: Column(
+      body: Stack(
         children: [
-          Slider(
-            min: 0,
-            max: maxMarkersCount.toDouble(),
-            divisions: maxMarkersCount ~/ 500,
-            label: 'Markers',
-            value: _sliderVal.toDouble(),
-            onChanged: (newVal) {
-              _sliderVal = newVal.toInt();
-              setState(() {});
-            },
-          ),
-          Text('$_sliderVal markers'),
-          Flexible(
-            child: FlutterMap(
-              options: const MapOptions(
-                initialCenter: LatLng(50, 20),
-                initialZoom: 5,
-                interactionOptions: InteractionOptions(
-                  flags: InteractiveFlag.all - InteractiveFlag.rotate,
-                ),
-              ),
-              children: [
-                openStreetMapTileLayer,
-                MarkerLayer(
-                  markers: allMarkers.sublist(
-                    0,
-                    min(allMarkers.length, _sliderVal),
-                  ),
-                ),
-              ],
+          FlutterMap(
+            options: const MapOptions(
+              initialCenter: LatLng(45.359124, 10.419922),
+              initialZoom: 5,
             ),
+            children: [
+              openStreetMapTileLayer,
+              MarkerLayer(markers: allMarkers.take(numOfMarkers).toList()),
+            ],
+          ),
+          Positioned(
+            left: 16,
+            top: 16,
+            right: 16,
+            child: NumberOfItemsSlider(
+              itemDescription: 'Marker',
+              initialNumber: _initialNumOfMarkers,
+              onChangedNumber: (v) => setState(() => numOfMarkers = v),
+            ),
+          ),
+          Positioned(
+            bottom: 16,
+            left: 0,
+            right: 0,
+            child: PerformanceOverlay.allEnabled(),
           ),
         ],
       ),

--- a/example/lib/pages/many_markers.dart
+++ b/example/lib/pages/many_markers.dart
@@ -57,9 +57,19 @@ class ManyMarkersPageState extends State<ManyMarkersPage> {
       body: Stack(
         children: [
           FlutterMap(
-            options: const MapOptions(
-              initialCenter: LatLng(45.359124, 10.419922),
-              initialZoom: 5,
+            options: MapOptions(
+              initialCameraFit: CameraFit.bounds(
+                bounds: LatLngBounds(
+                  const LatLng(55, -9),
+                  const LatLng(37, 30),
+                ),
+                padding: const EdgeInsets.only(
+                  left: 16,
+                  right: 16,
+                  top: 88,
+                  bottom: 192,
+                ),
+              ),
             ),
             children: [
               openStreetMapTileLayer,

--- a/example/lib/pages/many_markers.dart
+++ b/example/lib/pages/many_markers.dart
@@ -7,9 +7,9 @@ import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
 import 'package:flutter_map_example/widgets/number_of_items_slider.dart';
 import 'package:latlong2/latlong.dart';
 
-const maxMarkersCount = 20000;
+const _maxMarkersCount = 20000;
 
-/// On this page, [maxMarkersCount] markers are randomly generated
+/// On this page, [_maxMarkersCount] markers are randomly generated
 /// across europe, and then you can limit them with a slider
 ///
 /// This way, you can test how map performs under a lot of markers
@@ -27,7 +27,7 @@ class ManyMarkersPageState extends State<ManyMarkersPage> {
       source.nextDouble() * (end - start) + start;
   List<Marker> allMarkers = [];
 
-  static const int _initialNumOfMarkers = maxMarkersCount ~/ 10;
+  static const int _initialNumOfMarkers = _maxMarkersCount ~/ 10;
   int numOfMarkers = _initialNumOfMarkers;
 
   @override
@@ -35,7 +35,7 @@ class ManyMarkersPageState extends State<ManyMarkersPage> {
     super.initState();
     Future.microtask(() {
       final r = Random();
-      for (var x = 0; x < maxMarkersCount; x++) {
+      for (var x = 0; x < _maxMarkersCount; x++) {
         allMarkers.add(
           Marker(
             point: LatLng(doubleInRange(r, 37, 55), doubleInRange(r, -9, 30)),
@@ -82,6 +82,7 @@ class ManyMarkersPageState extends State<ManyMarkersPage> {
             right: 16,
             child: NumberOfItemsSlider(
               itemDescription: 'Marker',
+              maxNumber: _maxMarkersCount,
               initialNumber: _initialNumOfMarkers,
               onChangedNumber: (v) => setState(() => numOfMarkers = v),
             ),

--- a/example/lib/pages/polygon.dart
+++ b/example/lib/pages/polygon.dart
@@ -1,151 +1,81 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:flutter_map_example/widgets/simplification_tolerance_slider.dart';
+import 'package:flutter_map_geojson/flutter_map_geojson.dart';
 import 'package:latlong2/latlong.dart';
 
-class PolygonPage extends StatelessWidget {
+class PolygonPage extends StatefulWidget {
   static const String route = '/polygon';
 
   const PolygonPage({super.key});
 
   @override
+  State<PolygonPage> createState() => _PolygonPageState();
+}
+
+class _PolygonPageState extends State<PolygonPage> {
+  static const double _initialSimplificationTolerance = 0.5;
+  double simplificationTolerance = _initialSimplificationTolerance;
+
+  final geoJsonParser = GeoJsonParser();
+  late final Future<void> geoJsonLoader;
+
+  @override
+  void initState() {
+    super.initState();
+    geoJsonLoader = rootBundle
+        .loadString('assets/138k-polygon-points.geojson.noformat')
+        .then(geoJsonParser.parseGeoJsonAsString);
+  }
+
+  @override
+  void dispose() {
+    geoJsonLoader.ignore();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final notFilledPoints = <LatLng>[
-      const LatLng(51.5, -0.09),
-      const LatLng(53.3498, -6.2603),
-      const LatLng(48.8566, 2.3522),
-    ];
-
-    final filledPoints = <LatLng>[
-      const LatLng(55.5, -0.09),
-      const LatLng(54.3498, -6.2603),
-      const LatLng(52.8566, 2.3522),
-    ];
-
-    final notFilledDotedPoints = <LatLng>[
-      const LatLng(49.29, -2.57),
-      const LatLng(51.46, -6.43),
-      const LatLng(49.86, -8.17),
-      const LatLng(48.39, -3.49),
-    ];
-
-    final filledDotedPoints = <LatLng>[
-      const LatLng(46.35, 4.94),
-      const LatLng(46.22, -0.11),
-      const LatLng(44.399, 1.76),
-    ];
-
-    final labelPoints = <LatLng>[
-      const LatLng(60.16, -9.38),
-      const LatLng(60.16, -4.16),
-      const LatLng(61.18, -4.16),
-      const LatLng(61.18, -9.38),
-    ];
-
-    final labelRotatedPoints = <LatLng>[
-      const LatLng(59.77, -10.28),
-      const LatLng(58.21, -10.28),
-      const LatLng(58.21, -7.01),
-      const LatLng(59.77, -7.01),
-      const LatLng(60.77, -6.01),
-    ];
-
-    final holeOuterPoints = <LatLng>[
-      const LatLng(50, -18),
-      const LatLng(50, -14),
-      const LatLng(54, -14),
-      const LatLng(54, -18),
-    ];
-
-    final holeInnerPoints = <LatLng>[
-      const LatLng(51, -17),
-      const LatLng(51, -16),
-      const LatLng(52, -16),
-      const LatLng(52, -17),
-    ];
-
     return Scaffold(
       appBar: AppBar(title: const Text('Polygons')),
       drawer: const MenuDrawer(PolygonPage.route),
-      body: FlutterMap(
-        options: const MapOptions(
-          initialCenter: LatLng(51.5, -0.09),
-          initialZoom: 5,
-        ),
+      body: Stack(
         children: [
-          openStreetMapTileLayer,
-          PolygonLayer(polygons: [
-            Polygon(
-              points: notFilledPoints,
-              isFilled: false, // By default it's false
-              borderColor: Colors.red,
-              borderStrokeWidth: 4,
+          FlutterMap(
+            options: const MapOptions(
+              initialCenter: LatLng(58.87141, 47.81469),
+              initialZoom: 10,
             ),
-            Polygon(
-              points: filledPoints,
-              isFilled: true,
-              color: Colors.purple,
-              borderColor: Colors.yellow,
-              borderStrokeWidth: 4,
+            children: [
+              openStreetMapTileLayer,
+              FutureBuilder(
+                future: geoJsonLoader,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState != ConnectionState.done) {
+                    return const SizedBox.shrink();
+                  }
+
+                  return PolygonLayer(
+                    simplificationTolerance: simplificationTolerance,
+                    polygons: geoJsonParser.polygons,
+                  );
+                },
+              ),
+            ],
+          ),
+          Positioned(
+            left: 16,
+            top: 16,
+            right: 16,
+            child: SimplificationToleranceSlider(
+              initialTolerance: _initialSimplificationTolerance,
+              onChangedTolerance: (v) =>
+                  setState(() => simplificationTolerance = v),
             ),
-            Polygon(
-              points: notFilledDotedPoints,
-              isFilled: false,
-              isDotted: true,
-              borderColor: Colors.green,
-              borderStrokeWidth: 4,
-              color: Colors.yellow,
-            ),
-            Polygon(
-              points: filledDotedPoints,
-              isFilled: true,
-              isDotted: true,
-              borderStrokeWidth: 4,
-              borderColor: Colors.lightBlue,
-              color: Colors.yellow,
-            ),
-            Polygon(
-              points: labelPoints,
-              borderStrokeWidth: 4,
-              isFilled: false,
-              color: Colors.pink,
-              borderColor: Colors.purple,
-              label: 'Label!',
-            ),
-            Polygon(
-              points: labelRotatedPoints,
-              borderStrokeWidth: 4,
-              borderColor: Colors.purple,
-              label: 'Rotated!',
-              rotateLabel: true,
-              labelPlacement: PolygonLabelPlacement.polylabel,
-            ),
-            Polygon(
-              points: holeOuterPoints,
-              isFilled: true,
-              holePointsList: [holeInnerPoints],
-              borderStrokeWidth: 4,
-              borderColor: Colors.green,
-              color: Colors.pink.withOpacity(0.5),
-            ),
-            Polygon(
-              points: holeOuterPoints
-                  .map(
-                      (latlng) => LatLng(latlng.latitude, latlng.longitude + 8))
-                  .toList(),
-              isFilled: false,
-              isDotted: true,
-              holePointsList: [
-                holeInnerPoints
-                    .map((latlng) =>
-                        LatLng(latlng.latitude, latlng.longitude + 8))
-                    .toList()
-              ],
-              borderStrokeWidth: 4,
-              borderColor: Colors.orange,
-            ),
-          ]),
+          ),
         ],
       ),
     );

--- a/example/lib/pages/polygon.dart
+++ b/example/lib/pages/polygon.dart
@@ -1,41 +1,60 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
-import 'package:flutter_map_example/widgets/simplification_tolerance_slider.dart';
-import 'package:flutter_map_geojson/flutter_map_geojson.dart';
 import 'package:latlong2/latlong.dart';
 
-class PolygonPage extends StatefulWidget {
+class PolygonPage extends StatelessWidget {
   static const String route = '/polygon';
 
   const PolygonPage({super.key});
 
-  @override
-  State<PolygonPage> createState() => _PolygonPageState();
-}
-
-class _PolygonPageState extends State<PolygonPage> {
-  static const double _initialSimplificationTolerance = 0.5;
-  double simplificationTolerance = _initialSimplificationTolerance;
-
-  final geoJsonParser = GeoJsonParser();
-  late final Future<void> geoJsonLoader;
-
-  @override
-  void initState() {
-    super.initState();
-    geoJsonLoader = rootBundle
-        .loadString('assets/138k-polygon-points.geojson.noformat')
-        .then(geoJsonParser.parseGeoJsonAsString);
-  }
-
-  @override
-  void dispose() {
-    geoJsonLoader.ignore();
-    super.dispose();
-  }
+  final _notFilledPoints = const [
+    LatLng(51.5, -0.09),
+    LatLng(53.3498, -6.2603),
+    LatLng(48.8566, 2.3522),
+  ];
+  final _filledPoints = const [
+    LatLng(55.5, -0.09),
+    LatLng(54.3498, -6.2603),
+    LatLng(52.8566, 2.3522),
+  ];
+  final _notFilledDotedPoints = const [
+    LatLng(49.29, -2.57),
+    LatLng(51.46, -6.43),
+    LatLng(49.86, -8.17),
+    LatLng(48.39, -3.49),
+  ];
+  final _filledDotedPoints = const [
+    LatLng(46.35, 4.94),
+    LatLng(46.22, -0.11),
+    LatLng(44.399, 1.76),
+  ];
+  final _labelPoints = const [
+    LatLng(60.16, -9.38),
+    LatLng(60.16, -4.16),
+    LatLng(61.18, -4.16),
+    LatLng(61.18, -9.38),
+  ];
+  final _labelRotatedPoints = const [
+    LatLng(59.77, -10.28),
+    LatLng(58.21, -10.28),
+    LatLng(58.21, -7.01),
+    LatLng(59.77, -7.01),
+    LatLng(60.77, -6.01),
+  ];
+  final _holeOuterPoints = const [
+    LatLng(50, -18),
+    LatLng(50, -14),
+    LatLng(54, -14),
+    LatLng(54, -18),
+  ];
+  final _holeInnerPoints = const [
+    LatLng(51, -17),
+    LatLng(51, -16),
+    LatLng(52, -16),
+    LatLng(52, -17),
+  ];
 
   @override
   Widget build(BuildContext context) {
@@ -46,35 +65,76 @@ class _PolygonPageState extends State<PolygonPage> {
         children: [
           FlutterMap(
             options: const MapOptions(
-              initialCenter: LatLng(58.87141, 47.81469),
-              initialZoom: 10,
+              initialCenter: LatLng(51.5, -0.09),
+              initialZoom: 5,
             ),
             children: [
               openStreetMapTileLayer,
-              FutureBuilder(
-                future: geoJsonLoader,
-                builder: (context, snapshot) {
-                  if (snapshot.connectionState != ConnectionState.done) {
-                    return const SizedBox.shrink();
-                  }
-
-                  return PolygonLayer(
-                    simplificationTolerance: simplificationTolerance,
-                    polygons: geoJsonParser.polygons,
-                  );
-                },
+              PolygonLayer(
+                simplificationTolerance: 0,
+                polygons: [
+                  Polygon(
+                    points: _notFilledPoints,
+                    borderColor: Colors.red,
+                    borderStrokeWidth: 4,
+                  ),
+                  Polygon(
+                    points: _filledPoints,
+                    color: Colors.purple,
+                    borderColor: Colors.yellow,
+                    borderStrokeWidth: 4,
+                  ),
+                  Polygon(
+                    points: _notFilledDotedPoints,
+                    isDotted: true,
+                    borderColor: Colors.green,
+                    borderStrokeWidth: 4,
+                  ),
+                  Polygon(
+                    points: _filledDotedPoints,
+                    isDotted: true,
+                    borderStrokeWidth: 4,
+                    borderColor: Colors.lightBlue,
+                    color: Colors.yellow,
+                  ),
+                  Polygon(
+                    points: _labelPoints,
+                    borderStrokeWidth: 4,
+                    borderColor: Colors.purple,
+                    label: 'Label!',
+                  ),
+                  Polygon(
+                    points: _labelRotatedPoints,
+                    borderStrokeWidth: 4,
+                    borderColor: Colors.purple,
+                    label: 'Rotated!',
+                    rotateLabel: true,
+                    labelPlacement: PolygonLabelPlacement.polylabel,
+                  ),
+                  Polygon(
+                    points: _holeOuterPoints,
+                    holePointsList: [_holeInnerPoints],
+                    borderStrokeWidth: 4,
+                    borderColor: Colors.green,
+                  ),
+                  Polygon(
+                    points: _holeOuterPoints
+                        .map((latlng) =>
+                            LatLng(latlng.latitude, latlng.longitude + 8))
+                        .toList(),
+                    isDotted: true,
+                    holePointsList: [
+                      _holeInnerPoints
+                          .map((latlng) =>
+                              LatLng(latlng.latitude, latlng.longitude + 8))
+                          .toList()
+                    ],
+                    borderStrokeWidth: 4,
+                    borderColor: Colors.orange,
+                  ),
+                ],
               ),
             ],
-          ),
-          Positioned(
-            left: 16,
-            top: 16,
-            right: 16,
-            child: SimplificationToleranceSlider(
-              initialTolerance: _initialSimplificationTolerance,
-              onChangedTolerance: (v) =>
-                  setState(() => simplificationTolerance = v),
-            ),
           ),
         ],
       ),

--- a/example/lib/pages/polygon_perf_stress.dart
+++ b/example/lib/pages/polygon_perf_stress.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_example/misc/tile_providers.dart';
+import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:flutter_map_example/widgets/simplification_tolerance_slider.dart';
+import 'package:flutter_map_geojson/flutter_map_geojson.dart';
+import 'package:latlong2/latlong.dart';
+
+class PolygonPerfStressPage extends StatefulWidget {
+  static const String route = '/polygon_perf_stress';
+
+  const PolygonPerfStressPage({super.key});
+
+  @override
+  State<PolygonPerfStressPage> createState() => _PolygonPerfStressPageState();
+}
+
+class _PolygonPerfStressPageState extends State<PolygonPerfStressPage> {
+  static const double _initialSimplificationTolerance = 0.5;
+  double simplificationTolerance = _initialSimplificationTolerance;
+
+  late final geoJsonLoader =
+      rootBundle.loadString('assets/138k-polygon-points.geojson.noformat').then(
+            (geoJson) => compute(
+              (geoJson) => GeoJsonParser()..parseGeoJsonAsString(geoJson),
+              geoJson,
+            ),
+          );
+
+  @override
+  void dispose() {
+    geoJsonLoader.ignore();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Polygon Stress Test')),
+      drawer: const MenuDrawer(PolygonPerfStressPage.route),
+      body: Stack(
+        children: [
+          FlutterMap(
+            options: const MapOptions(
+              initialCenter: LatLng(58.860759, 47.818809),
+              initialZoom: 11,
+            ),
+            children: [
+              openStreetMapTileLayer,
+              FutureBuilder(
+                future: geoJsonLoader,
+                builder: (context, geoJsonParser) =>
+                    geoJsonParser.connectionState != ConnectionState.done ||
+                            geoJsonParser.data == null
+                        ? const SizedBox.shrink()
+                        : PolygonLayer(
+                            simplificationTolerance: simplificationTolerance,
+                            polygons: geoJsonParser.data!.polygons,
+                          ),
+              ),
+            ],
+          ),
+          Positioned(
+            left: 16,
+            top: 16,
+            right: 16,
+            child: SimplificationToleranceSlider(
+              initialTolerance: _initialSimplificationTolerance,
+              onChangedTolerance: (v) =>
+                  setState(() => simplificationTolerance = v),
+            ),
+          ),
+          Positioned(
+            bottom: 16,
+            left: 0,
+            right: 0,
+            child: PerformanceOverlay.allEnabled(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/pages/polygon_perf_stress.dart
+++ b/example/lib/pages/polygon_perf_stress.dart
@@ -43,9 +43,19 @@ class _PolygonPerfStressPageState extends State<PolygonPerfStressPage> {
       body: Stack(
         children: [
           FlutterMap(
-            options: const MapOptions(
-              initialCenter: LatLng(58.860759, 47.818809),
-              initialZoom: 11,
+            options: MapOptions(
+              initialCameraFit: CameraFit.bounds(
+                bounds: LatLngBounds(
+                  const LatLng(58.93864, 47.757597),
+                  const LatLng(58.806666, 47.848959),
+                ),
+                padding: const EdgeInsets.only(
+                  left: 16,
+                  right: 16,
+                  top: 88,
+                  bottom: 192,
+                ),
+              ),
             ),
             children: [
               openStreetMapTileLayer,

--- a/example/lib/pages/polyline.dart
+++ b/example/lib/pages/polyline.dart
@@ -1,11 +1,8 @@
-import 'dart:math';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
-import 'package:flutter_map_example/widgets/simplification_tolerance_slider.dart';
 import 'package:latlong2/latlong.dart';
 
 typedef PolylineHitValue = ({String title, String subtitle});
@@ -118,27 +115,6 @@ class _PolylinePageState extends State<PolylinePage> {
   late final _polylines =
       Map.fromEntries(_polylinesRaw.map((e) => MapEntry(e.hitValue, e)));
 
-  final _randomWalk = [const LatLng(44.861294, 13.845086)];
-
-  static const double _initialSimplificationTolerance = 0.5;
-  double simplificationTolerance = _initialSimplificationTolerance;
-
-  @override
-  void initState() {
-    super.initState();
-    final random = Random(1234);
-    for (int i = 1; i < 200000; i++) {
-      final lat = (random.nextDouble() - 0.5) * 0.001;
-      final lon = (random.nextDouble() - 0.6) * 0.001;
-      _randomWalk.add(
-        LatLng(
-          _randomWalk[i - 1].latitude + lat,
-          _randomWalk[i - 1].longitude + lon,
-        ),
-      );
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -205,27 +181,7 @@ class _PolylinePageState extends State<PolylinePage> {
                   ),
                 ),
               ),
-              PolylineLayer(
-                simplificationTolerance: simplificationTolerance,
-                polylines: [
-                  Polyline(
-                    points: _randomWalk,
-                    strokeWidth: 3,
-                    color: Colors.deepOrange,
-                  ),
-                ],
-              ),
             ],
-          ),
-          Positioned(
-            left: 16,
-            top: 16,
-            right: 16,
-            child: SimplificationToleranceSlider(
-              initialTolerance: _initialSimplificationTolerance,
-              onChangedTolerance: (v) =>
-                  setState(() => simplificationTolerance = v),
-            ),
           ),
         ],
       ),

--- a/example/lib/pages/polyline.dart
+++ b/example/lib/pages/polyline.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_example/misc/tile_providers.dart';
 import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:flutter_map_example/widgets/simplification_tolerance_slider.dart';
 import 'package:latlong2/latlong.dart';
 
 typedef PolylineHitValue = ({String title, String subtitle});
@@ -24,24 +25,24 @@ class _PolylinePageState extends State<PolylinePage> {
   List<Polyline<PolylineHitValue>>? _hoverLines;
 
   final _polylinesRaw = <Polyline<PolylineHitValue>>[
-    const Polyline(
+    Polyline(
       points: [
-        LatLng(51.5, -0.09),
-        LatLng(53.3498, -6.2603),
-        LatLng(48.8566, 2.3522),
+        const LatLng(51.5, -0.09),
+        const LatLng(53.3498, -6.2603),
+        const LatLng(48.8566, 2.3522),
       ],
       strokeWidth: 8,
-      color: Color(0xFF60399E),
+      color: const Color(0xFF60399E),
       hitValue: (
         title: 'Elizabeth Line',
         subtitle: 'Nothing really special here...',
       ),
     ),
-    const Polyline(
+    Polyline(
       points: [
-        LatLng(48.5, -3.09),
-        LatLng(47.3498, -9.2603),
-        LatLng(43.8566, -1.3522),
+        const LatLng(48.5, -3.09),
+        const LatLng(47.3498, -9.2603),
+        const LatLng(43.8566, -1.3522),
       ],
       strokeWidth: 16000,
       color: Colors.pink,
@@ -51,17 +52,17 @@ class _PolylinePageState extends State<PolylinePage> {
         subtitle: 'Fixed radius in meters instead of pixels',
       ),
     ),
-    const Polyline(
+    Polyline(
       points: [
-        LatLng(51.74904, -10.32324),
-        LatLng(54.3498, -6.2603),
-        LatLng(52.8566, 2.3522),
+        const LatLng(51.74904, -10.32324),
+        const LatLng(54.3498, -6.2603),
+        const LatLng(52.8566, 2.3522),
       ],
       strokeWidth: 4,
       gradientColors: [
-        Color(0xffE40203),
-        Color(0xffFEED00),
-        Color(0xff007E2D),
+        const Color(0xffE40203),
+        const Color(0xffFEED00),
+        const Color(0xff007E2D),
       ],
       hitValue: (
         title: 'Traffic Light Line',
@@ -278,71 +279,6 @@ class _PolylinePageState extends State<PolylinePage> {
                   onPressed: () => Navigator.pop(context),
                   child: const Text('Close'),
                 ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class SimplificationToleranceSlider extends StatefulWidget {
-  const SimplificationToleranceSlider({
-    super.key,
-    required this.initialTolerance,
-    required this.onChangedTolerance,
-  });
-
-  final double initialTolerance;
-  final void Function(double) onChangedTolerance;
-
-  @override
-  State<SimplificationToleranceSlider> createState() =>
-      _SimplificationToleranceSliderState();
-}
-
-class _SimplificationToleranceSliderState
-    extends State<SimplificationToleranceSlider> {
-  late double _simplificationTolerance = widget.initialTolerance;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.background,
-        borderRadius: BorderRadius.circular(32),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.only(left: 16, right: 8, top: 4, bottom: 4),
-        child: Row(
-          children: [
-            const Tooltip(
-              message: 'Adjust Simplification Tolerance',
-              child: Row(
-                children: [
-                  Icon(Icons.insights),
-                  SizedBox(width: 8),
-                  Icon(Icons.hdr_strong),
-                ],
-              ),
-            ),
-            Expanded(
-              child: Slider(
-                value: _simplificationTolerance,
-                onChanged: (v) {
-                  if (_simplificationTolerance == 0 && v != 0) {
-                    widget.onChangedTolerance(v);
-                  }
-                  setState(() => _simplificationTolerance = v);
-                },
-                onChangeEnd: widget.onChangedTolerance,
-                min: 0,
-                max: 2,
-                divisions: 100,
-                label: _simplificationTolerance == 0
-                    ? 'Disabled'
-                    : _simplificationTolerance.toStringAsFixed(2),
               ),
             ),
           ],

--- a/example/lib/pages/polyline_perf_stress.dart
+++ b/example/lib/pages/polyline_perf_stress.dart
@@ -1,0 +1,87 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_example/misc/tile_providers.dart';
+import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:flutter_map_example/widgets/simplification_tolerance_slider.dart';
+import 'package:latlong2/latlong.dart';
+
+class PolylinePerfStressPage extends StatefulWidget {
+  static const String route = '/polyline_perf_stress';
+
+  const PolylinePerfStressPage({super.key});
+
+  @override
+  State<PolylinePerfStressPage> createState() => _PolylinePerfStressPageState();
+}
+
+class _PolylinePerfStressPageState extends State<PolylinePerfStressPage> {
+  static const double _initialSimplificationTolerance = 0.5;
+  double simplificationTolerance = _initialSimplificationTolerance;
+
+  final _randomWalk = [const LatLng(44.861294, 13.845086)];
+
+  @override
+  void initState() {
+    super.initState();
+    final random = Random(1234);
+    for (int i = 1; i < 300000; i++) {
+      final lat = (random.nextDouble() - 0.5) * 0.001;
+      final lon = (random.nextDouble() - 0.6) * 0.001;
+      _randomWalk.add(
+        LatLng(
+          _randomWalk[i - 1].latitude + lat,
+          _randomWalk[i - 1].longitude + lon,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Polyline Stress Test')),
+      drawer: const MenuDrawer(PolylinePerfStressPage.route),
+      body: Stack(
+        children: [
+          FlutterMap(
+            options: const MapOptions(
+              initialCenter: LatLng(45.172136, -0.046055),
+              initialZoom: 6,
+            ),
+            children: [
+              openStreetMapTileLayer,
+              PolylineLayer(
+                simplificationTolerance: simplificationTolerance,
+                polylines: [
+                  Polyline(
+                    points: _randomWalk,
+                    strokeWidth: 3,
+                    color: Colors.deepOrange,
+                  ),
+                ],
+              ),
+            ],
+          ),
+          Positioned(
+            left: 16,
+            top: 16,
+            right: 16,
+            child: SimplificationToleranceSlider(
+              initialTolerance: _initialSimplificationTolerance,
+              onChangedTolerance: (v) =>
+                  setState(() => simplificationTolerance = v),
+            ),
+          ),
+          Positioned(
+            bottom: 16,
+            left: 0,
+            right: 0,
+            child: PerformanceOverlay.allEnabled(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/pages/polyline_perf_stress.dart
+++ b/example/lib/pages/polyline_perf_stress.dart
@@ -46,9 +46,16 @@ class _PolylinePerfStressPageState extends State<PolylinePerfStressPage> {
       body: Stack(
         children: [
           FlutterMap(
-            options: const MapOptions(
-              initialCenter: LatLng(45.172136, -0.046055),
-              initialZoom: 6,
+            options: MapOptions(
+              initialCameraFit: CameraFit.bounds(
+                bounds: LatLngBounds.fromPoints(_randomWalk),
+                padding: const EdgeInsets.only(
+                  left: 16,
+                  right: 16,
+                  top: 88,
+                  bottom: 192,
+                ),
+              ),
             ),
             children: [
               openStreetMapTileLayer,

--- a/example/lib/widgets/drawer/menu_drawer.dart
+++ b/example/lib/widgets/drawer/menu_drawer.dart
@@ -20,7 +20,9 @@ import 'package:flutter_map_example/pages/overlay_image.dart';
 import 'package:flutter_map_example/pages/plugin_scalebar.dart';
 import 'package:flutter_map_example/pages/plugin_zoombuttons.dart';
 import 'package:flutter_map_example/pages/polygon.dart';
+import 'package:flutter_map_example/pages/polygon_perf_stress.dart';
 import 'package:flutter_map_example/pages/polyline.dart';
+import 'package:flutter_map_example/pages/polyline_perf_stress.dart';
 import 'package:flutter_map_example/pages/reset_tile_layer.dart';
 import 'package:flutter_map_example/pages/retina.dart';
 import 'package:flutter_map_example/pages/screen_point_to_latlng.dart';
@@ -134,8 +136,13 @@ class MenuDrawer extends StatelessWidget {
           ),
           const Divider(),
           MenuItemWidget(
-            caption: 'Stateful Markers',
-            routeName: StatefulMarkersPage.route,
+            caption: 'Polygon Stress Test',
+            routeName: PolygonPerfStressPage.route,
+            currentRoute: currentRoute,
+          ),
+          MenuItemWidget(
+            caption: 'Polyline Stress Test',
+            routeName: PolylinePerfStressPage.route,
             currentRoute: currentRoute,
           ),
           MenuItemWidget(
@@ -146,6 +153,12 @@ class MenuDrawer extends StatelessWidget {
           MenuItemWidget(
             caption: 'Many Circles',
             routeName: ManyCirclesPage.route,
+            currentRoute: currentRoute,
+          ),
+          const Divider(),
+          MenuItemWidget(
+            caption: 'Stateful Markers',
+            routeName: StatefulMarkersPage.route,
             currentRoute: currentRoute,
           ),
           MenuItemWidget(

--- a/example/lib/widgets/number_of_items_slider.dart
+++ b/example/lib/widgets/number_of_items_slider.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+class NumberOfItemsSlider extends StatefulWidget {
+  const NumberOfItemsSlider({
+    super.key,
+    required this.initialNumber,
+    required this.onChangedNumber,
+    this.itemDescription = 'Item',
+  });
+
+  final int initialNumber;
+  final void Function(int) onChangedNumber;
+  final String itemDescription;
+
+  @override
+  State<NumberOfItemsSlider> createState() => _NumberOfItemsSliderState();
+}
+
+class _NumberOfItemsSliderState extends State<NumberOfItemsSlider> {
+  late int _number = widget.initialNumber;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.background,
+        borderRadius: BorderRadius.circular(32),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.only(left: 16, right: 8, top: 4, bottom: 4),
+        child: Row(
+          children: [
+            Tooltip(
+              message: 'Adjust Number of ${widget.itemDescription}s',
+              child: const Icon(Icons.numbers),
+            ),
+            Expanded(
+              child: Slider(
+                value: _number.toDouble(),
+                onChanged: (v) {
+                  if (_number == 0 && v != 0) {
+                    widget.onChangedNumber(v.toInt());
+                  }
+                  setState(() => _number = v.toInt());
+                },
+                onChangeEnd: (v) => widget.onChangedNumber(v.toInt()),
+                min: 0,
+                max: 20000,
+                divisions: 20,
+                label: _number.toString(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/widgets/number_of_items_slider.dart
+++ b/example/lib/widgets/number_of_items_slider.dart
@@ -5,12 +5,20 @@ class NumberOfItemsSlider extends StatefulWidget {
     super.key,
     required this.initialNumber,
     required this.onChangedNumber,
+    required this.maxNumber,
     this.itemDescription = 'Item',
-  });
+    int itemsPerDivision = 1000,
+  })  : assert(
+          (maxNumber / itemsPerDivision) % 1 == 0,
+          '`maxNumber` / `itemsPerDivision` must yield integer',
+        ),
+        divisions = maxNumber ~/ itemsPerDivision;
 
   final int initialNumber;
   final void Function(int) onChangedNumber;
   final String itemDescription;
+  final int maxNumber;
+  final int divisions;
 
   @override
   State<NumberOfItemsSlider> createState() => _NumberOfItemsSliderState();
@@ -45,8 +53,8 @@ class _NumberOfItemsSliderState extends State<NumberOfItemsSlider> {
                 },
                 onChangeEnd: (v) => widget.onChangedNumber(v.toInt()),
                 min: 0,
-                max: 20000,
-                divisions: 20,
+                max: widget.maxNumber.toDouble(),
+                divisions: widget.divisions,
                 label: _number.toString(),
               ),
             ),

--- a/example/lib/widgets/simplification_tolerance_slider.dart
+++ b/example/lib/widgets/simplification_tolerance_slider.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+class SimplificationToleranceSlider extends StatefulWidget {
+  const SimplificationToleranceSlider({
+    super.key,
+    required this.initialTolerance,
+    required this.onChangedTolerance,
+  });
+
+  final double initialTolerance;
+  final void Function(double) onChangedTolerance;
+
+  @override
+  State<SimplificationToleranceSlider> createState() =>
+      _SimplificationToleranceSliderState();
+}
+
+class _SimplificationToleranceSliderState
+    extends State<SimplificationToleranceSlider> {
+  late double _simplificationTolerance = widget.initialTolerance;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.background,
+        borderRadius: BorderRadius.circular(32),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.only(left: 16, right: 8, top: 4, bottom: 4),
+        child: Row(
+          children: [
+            const Tooltip(
+              message: 'Adjust Simplification Tolerance',
+              child: Row(
+                children: [
+                  Icon(Icons.insights),
+                  SizedBox(width: 8),
+                  Icon(Icons.hdr_strong),
+                ],
+              ),
+            ),
+            Expanded(
+              child: Slider(
+                value: _simplificationTolerance,
+                onChanged: (v) {
+                  if (_simplificationTolerance == 0 && v != 0) {
+                    widget.onChangedTolerance(v);
+                  }
+                  setState(() => _simplificationTolerance = v);
+                },
+                onChangeEnd: widget.onChangedTolerance,
+                min: 0,
+                max: 2,
+                divisions: 100,
+                label: _simplificationTolerance == 0
+                    ? 'Disabled'
+                    : _simplificationTolerance.toStringAsFixed(2),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   url_strategy: ^0.2.0
   http: ^1.1.0
   vector_math: ^2.1.2
+  flutter_map_geojson: ^1.0.6
 
 dependency_overrides:
   flutter_map_cancellable_tile_provider:

--- a/lib/src/gestures/positioned_tap_detector_2.dart
+++ b/lib/src/gestures/positioned_tap_detector_2.dart
@@ -220,7 +220,7 @@ class TapPosition {
   final Offset? relative;
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (other is! TapPosition) return false;
     final typedOther = other;
     return global == typedOther.global && relative == other.relative;

--- a/lib/src/layer/polygon_layer/label.dart
+++ b/lib/src/layer/polygon_layer/label.dart
@@ -1,12 +1,6 @@
-import 'dart:math' as math;
+part of 'polygon_layer.dart';
 
-import 'package:collection/collection.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_map/src/layer/polygon_layer/polygon_layer.dart';
-import 'package:latlong2/latlong.dart';
-import 'package:polylabel/polylabel.dart';
-
-void Function(Canvas canvas)? buildLabelTextPainter({
+void Function(Canvas canvas)? _buildLabelTextPainter({
   required math.Point<double> mapSize,
   required Offset placementPoint,
   required ({Offset min, Offset max}) bounds,
@@ -59,7 +53,7 @@ void Function(Canvas canvas)? buildLabelTextPainter({
   return null;
 }
 
-LatLng computeLabelPosition(
+LatLng _computeLabelPosition(
     PolygonLabelPlacement labelPlacement, List<LatLng> points) {
   return switch (labelPlacement) {
     PolygonLabelPlacement.centroid => _computeCentroid(points),

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -1,0 +1,256 @@
+part of 'polygon_layer.dart';
+
+class PolygonPainter extends CustomPainter {
+  final List<Polygon> polygons;
+  final MapCamera camera;
+  final LatLngBounds bounds;
+  final bool polygonLabels;
+  final bool drawLabelsLast;
+
+  PolygonPainter({
+    required this.polygons,
+    required this.camera,
+    required this.polygonLabels,
+    required this.drawLabelsLast,
+  }) : bounds = camera.visibleBounds;
+
+  ({Offset min, Offset max}) getBounds(Offset origin, Polygon polygon) {
+    final bbox = polygon.boundingBox;
+    return (
+      min: getOffset(origin, bbox.southWest),
+      max: getOffset(origin, bbox.northEast),
+    );
+  }
+
+  Offset getOffset(Offset origin, LatLng point) {
+    // Critically create as little garbage as possible. This is called on every frame.
+    final projected = camera.project(point);
+    return Offset(projected.x - origin.dx, projected.y - origin.dy);
+  }
+
+  List<Offset> getOffsets(Offset origin, List<LatLng> points) => List.generate(
+        points.length,
+        (index) => getOffset(origin, points[index]),
+        growable: false,
+      );
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    var filledPath = ui.Path();
+    var borderPath = ui.Path();
+    Polygon? lastPolygon;
+    int? lastHash;
+
+    // This functions flushes the batched fill and border paths constructed below.
+    void drawPaths() {
+      if (lastPolygon == null) {
+        return;
+      }
+      final polygon = lastPolygon!;
+
+      // Draw filled polygon .
+      if (polygon.isFilled) {
+        final paint = Paint()
+          ..style = PaintingStyle.fill
+          ..color = polygon.color;
+
+        canvas.drawPath(filledPath, paint);
+      }
+
+      // Draw polygon outline.
+      if (polygon.borderStrokeWidth > 0) {
+        final borderPaint = _getBorderPaint(polygon);
+        canvas.drawPath(borderPath, borderPaint);
+      }
+
+      filledPath = ui.Path();
+      borderPath = ui.Path();
+      lastPolygon = null;
+      lastHash = null;
+    }
+
+    final origin = (camera.project(camera.center) - camera.size / 2).toOffset();
+
+    // Main loop constructing batched fill and border paths from given polygons.
+    for (final polygon in polygons) {
+      if (polygon.points.isEmpty) {
+        continue;
+      }
+      final offsets = getOffsets(origin, polygon.points);
+
+      // The hash is based on the polygons visual properties. If the hash from
+      // the current and the previous polygon no longer match, we need to flush
+      // the batch previous polygons.
+      final hash = polygon.renderHashCode;
+      if (lastHash != hash) {
+        drawPaths();
+      }
+      lastPolygon = polygon;
+      lastHash = hash;
+
+      // First add fills and borders to path.
+      if (polygon.isFilled) {
+        filledPath.addPolygon(offsets, true);
+      }
+      if (polygon.borderStrokeWidth > 0.0) {
+        _addBorderToPath(borderPath, polygon, offsets);
+      }
+
+      // Afterwards deal with more complicated holes.
+      final holePointsList = polygon.holePointsList;
+      if (holePointsList != null && holePointsList.isNotEmpty) {
+        // Ideally we'd use `Path.combine(PathOperation.difference, ...)`
+        // instead of evenOdd fill-type, however it creates visual artifacts
+        // using the web renderer.
+        filledPath.fillType = PathFillType.evenOdd;
+
+        final holeOffsetsList = List<List<Offset>>.generate(
+          holePointsList.length,
+          (i) => getOffsets(origin, holePointsList[i]),
+          growable: false,
+        );
+
+        for (final holeOffsets in holeOffsetsList) {
+          filledPath.addPolygon(holeOffsets, true);
+        }
+
+        if (!polygon.disableHolesBorder && polygon.borderStrokeWidth > 0.0) {
+          _addHoleBordersToPath(borderPath, polygon, holeOffsetsList);
+        }
+      }
+
+      if (!drawLabelsLast && polygonLabels && polygon.textPainter != null) {
+        // Labels are expensive because:
+        //  * they themselves cannot easily be pulled into our batched path
+        //    painting with the given text APIs
+        //  * therefore, they require us to flush the batch of polygon draws to
+        //    ensure polygons and labels are stacked correctly, i.e.:
+        //    p1, p1_label, p2, p2_label, ... .
+
+        // The painter will be null if the layouting algorithm determined that
+        // there isn't enough space.
+        final painter = _buildLabelTextPainter(
+          mapSize: camera.size,
+          placementPoint: camera.getOffsetFromOrigin(polygon.labelPosition),
+          bounds: getBounds(origin, polygon),
+          textPainter: polygon.textPainter!,
+          rotationRad: camera.rotationRad,
+          rotate: polygon.rotateLabel,
+          padding: 20,
+        );
+
+        if (painter != null) {
+          // Flush the batch before painting to preserve stacking.
+          drawPaths();
+
+          painter(canvas);
+        }
+      }
+    }
+
+    drawPaths();
+
+    if (polygonLabels && drawLabelsLast) {
+      for (final polygon in polygons) {
+        if (polygon.points.isEmpty) {
+          continue;
+        }
+        final textPainter = polygon.textPainter;
+        if (textPainter != null) {
+          final painter = _buildLabelTextPainter(
+            mapSize: camera.size,
+            placementPoint:
+                camera.project(polygon.labelPosition).toOffset() - origin,
+            bounds: getBounds(origin, polygon),
+            textPainter: textPainter,
+            rotationRad: camera.rotationRad,
+            rotate: polygon.rotateLabel,
+            padding: 20,
+          );
+
+          painter?.call(canvas);
+        }
+      }
+    }
+  }
+
+  Paint _getBorderPaint(Polygon polygon) {
+    final isDotted = polygon.isDotted;
+    return Paint()
+      ..color = polygon.borderColor
+      ..strokeWidth = polygon.borderStrokeWidth
+      ..strokeCap = polygon.strokeCap
+      ..strokeJoin = polygon.strokeJoin
+      ..style = isDotted ? PaintingStyle.fill : PaintingStyle.stroke;
+  }
+
+  void _addBorderToPath(
+    ui.Path path,
+    Polygon polygon,
+    List<Offset> offsets,
+  ) {
+    if (polygon.isDotted) {
+      final borderRadius = polygon.borderStrokeWidth / 2;
+      final spacing = polygon.borderStrokeWidth * 1.5;
+      _addDottedLineToPath(path, offsets, borderRadius, spacing);
+    } else {
+      _addLineToPath(path, offsets);
+    }
+  }
+
+  void _addHoleBordersToPath(
+    ui.Path path,
+    Polygon polygon,
+    List<List<Offset>> holeOffsetsList,
+  ) {
+    if (polygon.isDotted) {
+      final borderRadius = polygon.borderStrokeWidth / 2;
+      final spacing = polygon.borderStrokeWidth * 1.5;
+      for (final offsets in holeOffsetsList) {
+        _addDottedLineToPath(path, offsets, borderRadius, spacing);
+      }
+    } else {
+      for (final offsets in holeOffsetsList) {
+        _addLineToPath(path, offsets);
+      }
+    }
+  }
+
+  void _addDottedLineToPath(
+      ui.Path path, List<Offset> offsets, double radius, double stepLength) {
+    if (offsets.isEmpty) {
+      return;
+    }
+
+    double startDistance = 0;
+    for (var i = 0; i < offsets.length; i++) {
+      final o0 = offsets[i % offsets.length];
+      final o1 = offsets[(i + 1) % offsets.length];
+      final totalDistance = (o0 - o1).distance;
+
+      double distance = startDistance;
+      for (; distance < totalDistance; distance += stepLength) {
+        final done = distance / totalDistance;
+        final remain = 1.0 - done;
+        final offset = Offset(
+          o0.dx * remain + o1.dx * done,
+          o0.dy * remain + o1.dy * done,
+        );
+        path.addOval(Rect.fromCircle(center: offset, radius: radius));
+      }
+
+      startDistance = distance < totalDistance
+          ? stepLength - (totalDistance - distance)
+          : distance - totalDistance;
+    }
+
+    path.addOval(Rect.fromCircle(center: offsets.last, radius: radius));
+  }
+
+  void _addLineToPath(ui.Path path, List<Offset> offsets) {
+    path.addPolygon(offsets, true);
+  }
+
+  @override
+  bool shouldRepaint(PolygonPainter oldDelegate) => false;
+}

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -41,23 +41,24 @@ class PolygonPainter extends CustomPainter {
     Polygon? lastPolygon;
     int? lastHash;
 
-    // This functions flushes the batched fill and border paths constructed below.
+    // This functions flushes the batched fill and border paths constructed below
     void drawPaths() {
-      if (lastPolygon == null) {
-        return;
-      }
+      if (lastPolygon == null) return;
       final polygon = lastPolygon!;
 
-      // Draw filled polygon .
-      if (polygon.isFilled) {
-        final paint = Paint()
-          ..style = PaintingStyle.fill
-          ..color = polygon.color;
+      // Draw filled polygon
+      // ignore: deprecated_member_use_from_same_package
+      if (polygon.isFilled ?? true) {
+        if (polygon.color case final color?) {
+          final paint = Paint()
+            ..style = PaintingStyle.fill
+            ..color = color;
 
-        canvas.drawPath(filledPath, paint);
+          canvas.drawPath(filledPath, paint);
+        }
       }
 
-      // Draw polygon outline.
+      // Draw polygon outline
       if (polygon.borderStrokeWidth > 0) {
         final borderPaint = _getBorderPaint(polygon);
         canvas.drawPath(borderPath, borderPaint);
@@ -89,8 +90,11 @@ class PolygonPainter extends CustomPainter {
       lastHash = hash;
 
       // First add fills and borders to path.
-      if (polygon.isFilled) {
-        filledPath.addPolygon(offsets, true);
+      // ignore: deprecated_member_use_from_same_package
+      if (polygon.isFilled ?? true) {
+        if (polygon.color != null) {
+          filledPath.addPolygon(offsets, true);
+        }
       }
       if (polygon.borderStrokeWidth > 0.0) {
         _addBorderToPath(borderPath, polygon, offsets);

--- a/lib/src/layer/polygon_layer/polygon.dart
+++ b/lib/src/layer/polygon_layer/polygon.dart
@@ -9,12 +9,18 @@ class Polygon {
   final List<LatLng> points;
   final List<List<LatLng>>? holePointsList;
 
-  final Color color;
+  final Color? color;
   final double borderStrokeWidth;
   final Color borderColor;
   final bool disableHolesBorder;
   final bool isDotted;
-  final bool isFilled;
+  @Deprecated(
+    'Prefer setting `color` to null to disable filling, or a `Color` to enable filling of that color. '
+    'This parameter will be removed to simplify the API, as this was a remnant of pre-null-safety. '
+    'The default of this parameter is now `null` and will use the rules above - the option is retained so as not to break APIs. '
+    'This feature was deprecated after v7.',
+  )
+  final bool? isFilled;
   final StrokeCap strokeCap;
   final StrokeJoin strokeJoin;
   final String? label;
@@ -50,19 +56,26 @@ class Polygon {
   Polygon({
     required this.points,
     this.holePointsList,
-    this.color = const Color(0xFF00FF00),
-    this.borderStrokeWidth = 0.0,
+    this.color,
+    this.borderStrokeWidth = 0,
     this.borderColor = const Color(0xFFFFFF00),
     this.disableHolesBorder = false,
     this.isDotted = false,
-    this.isFilled = false,
+    @Deprecated(
+      'Prefer setting `color` to null to disable filling, or a `Color` to enable filling of that color. '
+      'This parameter will be removed to simplify the API, as this was a remnant of pre-null-safety. '
+      'The default of this parameter is now `null` and will use the rules above - the option is retained so as not to break APIs. '
+      'This feature was deprecated after v7.',
+    )
+    this.isFilled,
     this.strokeCap = StrokeCap.round,
     this.strokeJoin = StrokeJoin.round,
     this.label,
     this.labelStyle = const TextStyle(),
     this.labelPlacement = PolygonLabelPlacement.centroid,
     this.rotateLabel = false,
-  }) : _filledAndClockwise = isFilled && isClockwise(points);
+  }) : _filledAndClockwise =
+            (isFilled ?? (color != null)) && isClockwise(points);
 
   Polygon copyWithNewPoints(List<LatLng> points) => Polygon(
         points: points,
@@ -72,6 +85,8 @@ class Polygon {
         borderColor: borderColor,
         disableHolesBorder: disableHolesBorder,
         isDotted: isDotted,
+        // ignore: deprecated_member_use_from_same_package
+        isFilled: isFilled,
         strokeCap: strokeCap,
         strokeJoin: strokeJoin,
         label: label,
@@ -100,6 +115,8 @@ class Polygon {
           borderColor == other.borderColor &&
           disableHolesBorder == other.disableHolesBorder &&
           isDotted == other.isDotted &&
+          // ignore: deprecated_member_use_from_same_package
+          isFilled == other.isFilled &&
           strokeCap == other.strokeCap &&
           strokeJoin == other.strokeJoin &&
           label == other.label &&
@@ -119,6 +136,7 @@ class Polygon {
         borderColor,
         disableHolesBorder,
         isDotted,
+        // ignore: deprecated_member_use_from_same_package
         isFilled,
         strokeCap,
         strokeJoin,

--- a/lib/src/layer/polygon_layer/polygon.dart
+++ b/lib/src/layer/polygon_layer/polygon.dart
@@ -1,0 +1,138 @@
+part of 'polygon_layer.dart';
+
+enum PolygonLabelPlacement {
+  centroid,
+  polylabel,
+}
+
+class Polygon {
+  final List<LatLng> points;
+  final List<List<LatLng>>? holePointsList;
+
+  final Color color;
+  final double borderStrokeWidth;
+  final Color borderColor;
+  final bool disableHolesBorder;
+  final bool isDotted;
+  final bool isFilled;
+  final StrokeCap strokeCap;
+  final StrokeJoin strokeJoin;
+  final String? label;
+  final TextStyle labelStyle;
+  final PolygonLabelPlacement labelPlacement;
+  final bool rotateLabel;
+  // Designates whether the given polygon points follow a clock or anti-clockwise direction.
+  // This is respected during draw call batching for filled polygons. Otherwise, batched polygons
+  // of opposing clock-directions cut holes into each other leading to a leaky optimization.
+  final bool _filledAndClockwise;
+
+  // Location where to place the label if `label` is set.
+  LatLng? _labelPosition;
+  LatLng get labelPosition =>
+      _labelPosition ??= _computeLabelPosition(labelPlacement, points);
+
+  LatLngBounds? _boundingBox;
+  LatLngBounds get boundingBox =>
+      _boundingBox ??= LatLngBounds.fromPoints(points);
+
+  TextPainter? _textPainter;
+  TextPainter? get textPainter {
+    if (label != null) {
+      return _textPainter ??= TextPainter(
+        text: TextSpan(text: label, style: labelStyle),
+        textAlign: TextAlign.center,
+        textDirection: TextDirection.ltr,
+      )..layout();
+    }
+    return null;
+  }
+
+  Polygon({
+    required this.points,
+    this.holePointsList,
+    this.color = const Color(0xFF00FF00),
+    this.borderStrokeWidth = 0.0,
+    this.borderColor = const Color(0xFFFFFF00),
+    this.disableHolesBorder = false,
+    this.isDotted = false,
+    this.isFilled = false,
+    this.strokeCap = StrokeCap.round,
+    this.strokeJoin = StrokeJoin.round,
+    this.label,
+    this.labelStyle = const TextStyle(),
+    this.labelPlacement = PolygonLabelPlacement.centroid,
+    this.rotateLabel = false,
+  }) : _filledAndClockwise = isFilled && isClockwise(points);
+
+  Polygon copyWithNewPoints(List<LatLng> points) => Polygon(
+        points: points,
+        holePointsList: holePointsList,
+        color: color,
+        borderStrokeWidth: borderStrokeWidth,
+        borderColor: borderColor,
+        disableHolesBorder: disableHolesBorder,
+        isDotted: isDotted,
+        strokeCap: strokeCap,
+        strokeJoin: strokeJoin,
+        label: label,
+        labelStyle: labelStyle,
+        labelPlacement: labelPlacement,
+        rotateLabel: rotateLabel,
+      );
+
+  static bool isClockwise(List<LatLng> points) {
+    double sum = 0;
+    for (int i = 0; i < points.length; ++i) {
+      final a = points[i];
+      final b = points[(i + 1) % points.length];
+
+      sum += (b.longitude - a.longitude) * (b.latitude + a.latitude);
+    }
+    return sum >= 0;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Polygon &&
+          color == other.color &&
+          borderStrokeWidth == other.borderStrokeWidth &&
+          borderColor == other.borderColor &&
+          disableHolesBorder == other.disableHolesBorder &&
+          isDotted == other.isDotted &&
+          strokeCap == other.strokeCap &&
+          strokeJoin == other.strokeJoin &&
+          label == other.label &&
+          labelStyle == other.labelStyle &&
+          labelPlacement == other.labelPlacement &&
+          rotateLabel == other.rotateLabel &&
+          // Expensive computations last to take advantage of lazy logic gates
+          listEquals(holePointsList, other.holePointsList) &&
+          listEquals(points, other.points));
+
+  // Used to batch draw calls to the canvas
+  int? _renderHashCode;
+  int get renderHashCode => _renderHashCode ??= Object.hash(
+        holePointsList,
+        color,
+        borderStrokeWidth,
+        borderColor,
+        disableHolesBorder,
+        isDotted,
+        isFilled,
+        strokeCap,
+        strokeJoin,
+        _filledAndClockwise,
+      );
+
+  int? _hashCode;
+  @override
+  int get hashCode => _hashCode ??= Object.hashAll([
+        ...points,
+        label,
+        labelStyle,
+        labelPlacement,
+        rotateLabel,
+        renderHashCode,
+      ]);
+}

--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -1,110 +1,23 @@
-import 'dart:math';
+import 'dart:math' as math;
 import 'dart:ui' as ui;
 
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/src/geo/latlng_bounds.dart';
 import 'package:flutter_map/src/layer/general/mobile_layer_transformer.dart';
-import 'package:flutter_map/src/layer/polygon_layer/label.dart';
 import 'package:flutter_map/src/map/camera/camera.dart';
 import 'package:flutter_map/src/misc/point_extensions.dart';
 import 'package:flutter_map/src/misc/simplify.dart';
-import 'package:latlong2/latlong.dart' hide Path; // conflict with Path from UI
+import 'package:latlong2/latlong.dart' hide Path;
+import 'package:polylabel/polylabel.dart'; // conflict with Path from UI
 
-enum PolygonLabelPlacement {
-  centroid,
-  polylabel,
-}
-
-bool isClockwise(List<LatLng> points) {
-  double sum = 0;
-  for (int i = 0; i < points.length; ++i) {
-    final a = points[i];
-    final b = points[(i + 1) % points.length];
-
-    sum += (b.longitude - a.longitude) * (b.latitude + a.latitude);
-  }
-  return sum >= 0;
-}
-
-class Polygon {
-  final List<LatLng> points;
-  final List<List<LatLng>>? holePointsList;
-
-  final Color color;
-  final double borderStrokeWidth;
-  final Color borderColor;
-  final bool disableHolesBorder;
-  final bool isDotted;
-  final bool isFilled;
-  final StrokeCap strokeCap;
-  final StrokeJoin strokeJoin;
-  final String? label;
-  final TextStyle labelStyle;
-  final PolygonLabelPlacement labelPlacement;
-  final bool rotateLabel;
-  // Designates whether the given polygon points follow a clock or anti-clockwise direction.
-  // This is respected during draw call batching for filled polygons. Otherwise, batched polygons
-  // of opposing clock-directions cut holes into each other leading to a leaky optimization.
-  final bool _filledAndClockwise;
-
-  // Location where to place the label if `label` is set.
-  LatLng? _labelPosition;
-  LatLng get labelPosition =>
-      _labelPosition ??= computeLabelPosition(labelPlacement, points);
-
-  LatLngBounds? _boundingBox;
-  LatLngBounds get boundingBox =>
-      _boundingBox ??= LatLngBounds.fromPoints(points);
-
-  TextPainter? _textPainter;
-  TextPainter? get textPainter {
-    if (label != null) {
-      return _textPainter ??= TextPainter(
-        text: TextSpan(text: label, style: labelStyle),
-        textAlign: TextAlign.center,
-        textDirection: TextDirection.ltr,
-      )..layout();
-    }
-    return null;
-  }
-
-  Polygon({
-    required this.points,
-    this.holePointsList,
-    this.color = const Color(0xFF00FF00),
-    this.borderStrokeWidth = 0.0,
-    this.borderColor = const Color(0xFFFFFF00),
-    this.disableHolesBorder = false,
-    this.isDotted = false,
-    this.isFilled = false,
-    this.strokeCap = StrokeCap.round,
-    this.strokeJoin = StrokeJoin.round,
-    this.label,
-    this.labelStyle = const TextStyle(),
-    this.labelPlacement = PolygonLabelPlacement.centroid,
-    this.rotateLabel = false,
-  }) : _filledAndClockwise = isFilled && isClockwise(points);
-
-  /// Used to batch draw calls to the canvas.
-  int get renderHashCode {
-    return _hash ??= Object.hash(
-      holePointsList,
-      color,
-      borderStrokeWidth,
-      borderColor,
-      isDotted,
-      isFilled,
-      strokeCap,
-      strokeJoin,
-      _filledAndClockwise,
-    );
-  }
-
-  int? _hash;
-}
+part 'label.dart';
+part 'painter.dart';
+part 'polygon.dart';
 
 @immutable
-class PolygonLayer extends StatelessWidget {
+class PolygonLayer extends StatefulWidget {
   /// [Polygon]s to draw
   final List<Polygon> polygons;
 
@@ -147,305 +60,74 @@ class PolygonLayer extends StatelessWidget {
   });
 
   @override
+  State<PolygonLayer> createState() => _PolygonLayerState();
+}
+
+class _PolygonLayerState extends State<PolygonLayer> {
+  final _cachedSimplifiedPolygons = <int, List<Polygon>>{};
+
+  @override
+  void didUpdateWidget(PolygonLayer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    // IF old yes & new no, clear
+    // IF old no & new yes, compute
+    // IF old no & new no, nothing
+    // IF old yes & new yes & (different tolerance | different lines), both
+    //    otherwise, nothing
+    if (oldWidget.simplificationTolerance != 0 &&
+        widget.simplificationTolerance != 0 &&
+        (!listEquals(oldWidget.polygons, widget.polygons) ||
+            oldWidget.simplificationTolerance !=
+                widget.simplificationTolerance)) {
+      _cachedSimplifiedPolygons.clear();
+      _computeZoomLevelSimplification(MapCamera.of(context).zoom.floor());
+    } else if (oldWidget.simplificationTolerance != 0 &&
+        widget.simplificationTolerance == 0) {
+      _cachedSimplifiedPolygons.clear();
+    } else if (oldWidget.simplificationTolerance == 0 &&
+        widget.simplificationTolerance != 0) {
+      _computeZoomLevelSimplification(MapCamera.of(context).zoom.floor());
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final camera = MapCamera.of(context);
 
-    final culledPolygons = polygonCulling
-        ? polygons
+    final simplified = widget.simplificationTolerance == 0
+        ? widget.polygons
+        : _computeZoomLevelSimplification(camera.zoom.floor());
+
+    final culled = !widget.polygonCulling
+        ? simplified
+        : simplified
             .where((p) => p.boundingBox.isOverlapping(camera.visibleBounds))
-            .toList()
-        : polygons;
+            .toList();
 
     return MobileLayerTransformer(
       child: CustomPaint(
         painter: PolygonPainter(
-          polygons: culledPolygons,
+          polygons: culled,
           camera: camera,
-          polygonLabels: polygonLabels,
-          drawLabelsLast: drawLabelsLast,
-          simplificationTolerance: simplificationTolerance,
+          polygonLabels: widget.polygonLabels,
+          drawLabelsLast: widget.drawLabelsLast,
         ),
         size: Size(camera.size.x, camera.size.y),
-        isComplex: true,
       ),
     );
   }
-}
 
-class PolygonPainter extends CustomPainter {
-  final List<Polygon> polygons;
-  final MapCamera camera;
-  final LatLngBounds bounds;
-  final bool polygonLabels;
-  final bool drawLabelsLast;
-  final double simplificationTolerance;
-
-  PolygonPainter({
-    required this.polygons,
-    required this.camera,
-    required this.polygonLabels,
-    required this.simplificationTolerance,
-    required this.drawLabelsLast,
-  }) : bounds = camera.visibleBounds;
-
-  int get hash {
-    _hash ??= Object.hashAll(polygons);
-    return _hash!;
-  }
-
-  int? _hash;
-
-  ({Offset min, Offset max}) getBounds(Offset origin, Polygon polygon) {
-    final bbox = polygon.boundingBox;
-    return (
-      min: getOffset(origin, bbox.southWest),
-      max: getOffset(origin, bbox.northEast),
-    );
-  }
-
-  Offset getOffset(Offset origin, LatLng point) {
-    // Critically create as little garbage as possible. This is called on every frame.
-    final projected = camera.project(point);
-    return Offset(projected.x - origin.dx, projected.y - origin.dy);
-  }
-
-  List<Offset> getOffsets(Offset origin, List<LatLng> points) {
-    final renderedPoints = simplificationTolerance != 0
-        ? simplify(
-            points,
-            simplificationTolerance / pow(2, camera.zoom.floor()),
-            highestQuality: true,
+  List<Polygon> _computeZoomLevelSimplification(int zoom) =>
+      _cachedSimplifiedPolygons[zoom] ??= widget.polygons
+          .map(
+            (polygon) => polygon.copyWithNewPoints(
+              simplify(
+                polygon.points,
+                widget.simplificationTolerance / math.pow(2, zoom),
+                highestQuality: true,
+              ),
+            ),
           )
-        : points;
-
-    return List.generate(
-      renderedPoints.length,
-      (index) => getOffset(origin, renderedPoints[index]),
-      growable: false,
-    );
-  }
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    var filledPath = ui.Path();
-    var borderPath = ui.Path();
-    Polygon? lastPolygon;
-    int? lastHash;
-
-    // This functions flushes the batched fill and border paths constructed below.
-    void drawPaths() {
-      if (lastPolygon == null) {
-        return;
-      }
-      final polygon = lastPolygon!;
-
-      // Draw filled polygon .
-      if (polygon.isFilled) {
-        final paint = Paint()
-          ..style = PaintingStyle.fill
-          ..color = polygon.color;
-
-        canvas.drawPath(filledPath, paint);
-      }
-
-      // Draw polygon outline.
-      if (polygon.borderStrokeWidth > 0) {
-        final borderPaint = _getBorderPaint(polygon);
-        canvas.drawPath(borderPath, borderPaint);
-      }
-
-      filledPath = ui.Path();
-      borderPath = ui.Path();
-      lastPolygon = null;
-      lastHash = null;
-    }
-
-    final origin = (camera.project(camera.center) - camera.size / 2).toOffset();
-
-    // Main loop constructing batched fill and border paths from given polygons.
-    for (final polygon in polygons) {
-      if (polygon.points.isEmpty) {
-        continue;
-      }
-      final offsets = getOffsets(origin, polygon.points);
-
-      // The hash is based on the polygons visual properties. If the hash from
-      // the current and the previous polygon no longer match, we need to flush
-      // the batch previous polygons.
-      final hash = polygon.renderHashCode;
-      if (lastHash != hash) {
-        drawPaths();
-      }
-      lastPolygon = polygon;
-      lastHash = hash;
-
-      // First add fills and borders to path.
-      if (polygon.isFilled) {
-        filledPath.addPolygon(offsets, true);
-      }
-      if (polygon.borderStrokeWidth > 0.0) {
-        _addBorderToPath(borderPath, polygon, offsets);
-      }
-
-      // Afterwards deal with more complicated holes.
-      final holePointsList = polygon.holePointsList;
-      if (holePointsList != null && holePointsList.isNotEmpty) {
-        // Ideally we'd use `Path.combine(PathOperation.difference, ...)`
-        // instead of evenOdd fill-type, however it creates visual artifacts
-        // using the web renderer.
-        filledPath.fillType = PathFillType.evenOdd;
-
-        final holeOffsetsList = List<List<Offset>>.generate(
-          holePointsList.length,
-          (i) => getOffsets(origin, holePointsList[i]),
-          growable: false,
-        );
-
-        for (final holeOffsets in holeOffsetsList) {
-          filledPath.addPolygon(holeOffsets, true);
-        }
-
-        if (!polygon.disableHolesBorder && polygon.borderStrokeWidth > 0.0) {
-          _addHoleBordersToPath(borderPath, polygon, holeOffsetsList);
-        }
-      }
-
-      if (!drawLabelsLast && polygonLabels && polygon.textPainter != null) {
-        // Labels are expensive because:
-        //  * they themselves cannot easily be pulled into our batched path
-        //    painting with the given text APIs
-        //  * therefore, they require us to flush the batch of polygon draws to
-        //    ensure polygons and labels are stacked correctly, i.e.:
-        //    p1, p1_label, p2, p2_label, ... .
-
-        // The painter will be null if the layouting algorithm determined that
-        // there isn't enough space.
-        final painter = buildLabelTextPainter(
-          mapSize: camera.size,
-          placementPoint: camera.getOffsetFromOrigin(polygon.labelPosition),
-          bounds: getBounds(origin, polygon),
-          textPainter: polygon.textPainter!,
-          rotationRad: camera.rotationRad,
-          rotate: polygon.rotateLabel,
-          padding: 20,
-        );
-
-        if (painter != null) {
-          // Flush the batch before painting to preserve stacking.
-          drawPaths();
-
-          painter(canvas);
-        }
-      }
-    }
-
-    drawPaths();
-
-    if (polygonLabels && drawLabelsLast) {
-      for (final polygon in polygons) {
-        if (polygon.points.isEmpty) {
-          continue;
-        }
-        final textPainter = polygon.textPainter;
-        if (textPainter != null) {
-          final painter = buildLabelTextPainter(
-            mapSize: camera.size,
-            placementPoint:
-                camera.project(polygon.labelPosition).toOffset() - origin,
-            bounds: getBounds(origin, polygon),
-            textPainter: textPainter,
-            rotationRad: camera.rotationRad,
-            rotate: polygon.rotateLabel,
-            padding: 20,
-          );
-
-          painter?.call(canvas);
-        }
-      }
-    }
-  }
-
-  Paint _getBorderPaint(Polygon polygon) {
-    final isDotted = polygon.isDotted;
-    return Paint()
-      ..color = polygon.borderColor
-      ..strokeWidth = polygon.borderStrokeWidth
-      ..strokeCap = polygon.strokeCap
-      ..strokeJoin = polygon.strokeJoin
-      ..style = isDotted ? PaintingStyle.fill : PaintingStyle.stroke;
-  }
-
-  void _addBorderToPath(
-    ui.Path path,
-    Polygon polygon,
-    List<Offset> offsets,
-  ) {
-    if (polygon.isDotted) {
-      final borderRadius = polygon.borderStrokeWidth / 2;
-      final spacing = polygon.borderStrokeWidth * 1.5;
-      _addDottedLineToPath(path, offsets, borderRadius, spacing);
-    } else {
-      _addLineToPath(path, offsets);
-    }
-  }
-
-  void _addHoleBordersToPath(
-    ui.Path path,
-    Polygon polygon,
-    List<List<Offset>> holeOffsetsList,
-  ) {
-    if (polygon.isDotted) {
-      final borderRadius = polygon.borderStrokeWidth / 2;
-      final spacing = polygon.borderStrokeWidth * 1.5;
-      for (final offsets in holeOffsetsList) {
-        _addDottedLineToPath(path, offsets, borderRadius, spacing);
-      }
-    } else {
-      for (final offsets in holeOffsetsList) {
-        _addLineToPath(path, offsets);
-      }
-    }
-  }
-
-  void _addDottedLineToPath(
-      ui.Path path, List<Offset> offsets, double radius, double stepLength) {
-    if (offsets.isEmpty) {
-      return;
-    }
-
-    double startDistance = 0;
-    for (var i = 0; i < offsets.length; i++) {
-      final o0 = offsets[i % offsets.length];
-      final o1 = offsets[(i + 1) % offsets.length];
-      final totalDistance = (o0 - o1).distance;
-
-      double distance = startDistance;
-      for (; distance < totalDistance; distance += stepLength) {
-        final done = distance / totalDistance;
-        final remain = 1.0 - done;
-        final offset = Offset(
-          o0.dx * remain + o1.dx * done,
-          o0.dy * remain + o1.dy * done,
-        );
-        path.addOval(Rect.fromCircle(center: offset, radius: radius));
-      }
-
-      startDistance = distance < totalDistance
-          ? stepLength - (totalDistance - distance)
-          : distance - totalDistance;
-    }
-
-    path.addOval(Rect.fromCircle(center: offsets.last, radius: radius));
-  }
-
-  void _addLineToPath(ui.Path path, List<Offset> offsets) {
-    path.addPolygon(offsets, true);
-  }
-
-  @override
-  bool shouldRepaint(PolygonPainter oldDelegate) {
-    return oldDelegate.bounds != bounds ||
-        oldDelegate.polygons.length != polygons.length ||
-        oldDelegate.hash != hash;
-  }
+          .toList();
 }

--- a/lib/src/layer/polyline_layer/painter.dart
+++ b/lib/src/layer/polyline_layer/painter.dart
@@ -8,9 +8,6 @@ class PolylinePainter<R extends Object> extends CustomPainter {
 
   final _hits = <R>[]; // Avoids repetitive memory reallocation
 
-  int get hash => _hash ??= Object.hashAll(polylines);
-  int? _hash;
-
   PolylinePainter({
     required this.polylines,
     required this.camera,

--- a/lib/src/layer/polyline_layer/polyline.dart
+++ b/lib/src/layer/polyline_layer/polyline.dart
@@ -1,6 +1,5 @@
 part of 'polyline_layer.dart';
 
-@immutable
 class Polyline<R extends Object> {
   final List<LatLng> points;
   final double strokeWidth;
@@ -22,7 +21,7 @@ class Polyline<R extends Object> {
   /// Should implement an equality operator to avoid breaking [Polyline.==].
   final R? hitValue;
 
-  const Polyline({
+  Polyline({
     required this.points,
     this.strokeWidth = 1.0,
     this.color = const Color(0xFF00FF00),
@@ -56,21 +55,23 @@ class Polyline<R extends Object> {
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is Polyline &&
-          listEquals(points, other.points) &&
           strokeWidth == other.strokeWidth &&
           color == other.color &&
           borderStrokeWidth == other.borderStrokeWidth &&
           borderColor == other.borderColor &&
-          listEquals(gradientColors, other.gradientColors) &&
-          listEquals(colorsStop, other.colorsStop) &&
           isDotted == other.isDotted &&
           strokeCap == other.strokeCap &&
           strokeJoin == other.strokeJoin &&
           useStrokeWidthInMeter == other.useStrokeWidthInMeter &&
-          hitValue == other.hitValue);
+          hitValue == other.hitValue &&
+          // Expensive computations last to take advantage of lazy logic gates
+          listEquals(colorsStop, other.colorsStop) &&
+          listEquals(gradientColors, other.gradientColors) &&
+          listEquals(points, other.points));
 
-  /// Used to batch draw calls to the canvas
-  int get renderHashCode => Object.hash(
+  // Used to batch draw calls to the canvas
+  int? _renderHashCode;
+  int get renderHashCode => _renderHashCode ??= Object.hash(
         strokeWidth,
         color,
         borderStrokeWidth,
@@ -84,6 +85,7 @@ class Polyline<R extends Object> {
         hitValue,
       );
 
+  int? _hashCode;
   @override
-  int get hashCode => Object.hashAll([...points, renderHashCode]);
+  int get hashCode => _hashCode ??= Object.hashAll([...points, renderHashCode]);
 }

--- a/lib/src/map/widget.dart
+++ b/lib/src/map/widget.dart
@@ -113,22 +113,24 @@ class _FlutterMapStateContainer extends State<FlutterMap>
       ),
     );
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        _updateAndEmitSizeIfConstraintsChanged(constraints);
+    return RepaintBoundary(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          _updateAndEmitSizeIfConstraintsChanged(constraints);
 
-        return MapInteractiveViewer(
-          controller: _mapController,
-          builder: (context, options, camera) {
-            return MapInheritedModel(
-              controller: _mapController,
-              options: options,
-              camera: camera,
-              child: widgets,
-            );
-          },
-        );
-      },
+          return MapInteractiveViewer(
+            controller: _mapController,
+            builder: (context, options, camera) {
+              return MapInheritedModel(
+                controller: _mapController,
+                options: options,
+                camera: camera,
+                child: widgets,
+              );
+            },
+          );
+        },
+      ),
     );
   }
 

--- a/test/full_coverage_test.dart
+++ b/test/full_coverage_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_map/src/layer/attribution_layer/rich/source.dart';
 import 'package:flutter_map/src/layer/attribution_layer/rich/widget.dart';
 import 'package:flutter_map/src/layer/attribution_layer/simple.dart';
 import 'package:flutter_map/src/layer/circle_layer.dart';
+import 'package:flutter_map/src/layer/general/hit_detection.dart';
 import 'package:flutter_map/src/layer/general/mobile_layer_transformer.dart';
 import 'package:flutter_map/src/layer/general/translucent_pointer.dart';
 import 'package:flutter_map/src/layer/marker_layer.dart';
@@ -56,5 +57,6 @@ import 'package:flutter_map/src/misc/move_and_rotate_result.dart';
 import 'package:flutter_map/src/misc/offsets.dart';
 import 'package:flutter_map/src/misc/point_extensions.dart';
 import 'package:flutter_map/src/misc/position.dart';
+import 'package:flutter_map/src/misc/simplify.dart';
 
 void main() {}

--- a/test/full_coverage_test.dart
+++ b/test/full_coverage_test.dart
@@ -17,7 +17,6 @@ import 'package:flutter_map/src/layer/general/mobile_layer_transformer.dart';
 import 'package:flutter_map/src/layer/general/translucent_pointer.dart';
 import 'package:flutter_map/src/layer/marker_layer.dart';
 import 'package:flutter_map/src/layer/overlay_image_layer.dart';
-import 'package:flutter_map/src/layer/polygon_layer/label.dart';
 import 'package:flutter_map/src/layer/polygon_layer/polygon_layer.dart';
 import 'package:flutter_map/src/layer/polyline_layer/polyline_layer.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile.dart';

--- a/test/layer/polygon_layer_test.dart
+++ b/test/layer/polygon_layer_test.dart
@@ -11,7 +11,6 @@ void main() {
     final polygons = <Polygon>[
       for (int i = 0; i < 1; ++i)
         Polygon(
-          isFilled: true,
           color: Colors.purple,
           borderColor: Colors.purple,
           borderStrokeWidth: 4,

--- a/test/layer/polygon_layer_test.dart
+++ b/test/layer/polygon_layer_test.dart
@@ -43,7 +43,7 @@ void main() {
       LatLng(20, 30),
       LatLng(20, 20),
     ];
-    expect(isClockwise(clockwise), isTrue);
-    expect(isClockwise(clockwise.reversed.toList()), isFalse);
+    expect(Polygon.isClockwise(clockwise), isTrue);
+    expect(Polygon.isClockwise(clockwise.reversed.toList()), isFalse);
   });
 }


### PR DESCRIPTION
Reflected the same changes made to `PolylineLayer`. Also includes some minor performance enhancements and consistency changes to both.

Updated example project and improved consistency and styling. Added `PerformanceOverlay` widget to performance stress testing pages.

Also includes some other minor performance improvements (eg. wrapped `RepaintBoundary` around widget tree), and deprecates `Polygon.isFilled`.