### PR TITLE
feat(gestures): add key trigger click rotate gesture

### DIFF
--- a/lib/src/map/gestures/map_interactive_viewer.dart
+++ b/lib/src/map/gestures/map_interactive_viewer.dart
@@ -42,6 +42,7 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
   DragGestureService? _drag;
   DoubleTapDragZoomGestureService? _doubleTapDragZoom;
   KeyTriggerDragRotateGestureService? _keyTriggerDragRotate;
+  KeyTriggerClickRotateGestureService? _keyTriggerClickRotate;
 
   MapControllerImpl get _controller => widget.controller;
 
@@ -295,6 +296,13 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
           KeyTriggerDragRotateGestureService(controller: _controller);
     } else {
       _keyTriggerDragRotate = null;
+    }
+
+    if (newGestures.keyTriggerClickRotate) {
+      _keyTriggerClickRotate =
+          KeyTriggerClickRotateGestureService(controller: _controller);
+    } else {
+      _keyTriggerClickRotate = null;
     }
 
     if (newGestures.doubleTapDragZoom) {

--- a/lib/src/map/gestures/services/base_services.dart
+++ b/lib/src/map/gestures/services/base_services.dart
@@ -5,10 +5,12 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:vector_math/vector_math.dart';
 
 part 'double_tap.dart';
 part 'double_tap_drag_zoom.dart';
 part 'drag.dart';
+part 'key_trigger_click_rotate.dart';
 part 'key_trigger_drag_rotate.dart';
 part 'long_press.dart';
 part 'scroll_wheel_zoom.dart';

--- a/lib/src/map/gestures/services/key_trigger_click_rotate.dart
+++ b/lib/src/map/gestures/services/key_trigger_click_rotate.dart
@@ -1,0 +1,48 @@
+part of 'base_services.dart';
+
+/// Service to handle the key-trigger and click gesture to rotate the map.
+/// By clicking at the top of the map the map gets set to 0°-ish, by clicking
+/// on the left side of the map the rotation is set to 270°-ish.
+///
+/// The key is by default the CTRL key on the keyboard.
+class KeyTriggerClickRotateGestureService extends _BaseGestureService {
+  /// Getter for the keyboard keys that trigger the drag to rotate gesture.
+  List<LogicalKeyboardKey> get keys =>
+      _options.interactionOptions.keyTriggerDragRotateKeys;
+
+  /// Create a new service that rotates the map if the map gets dragged while
+  /// a specified key is pressed.
+  KeyTriggerClickRotateGestureService({required super.controller});
+
+  /// Called when the gesture receives an update, updates the [MapCamera].
+  void update(ScaleUpdateDetails details) {
+    controller.rotateRaw(
+      _camera.rotation - (details.focalPointDelta.dy * 0.5),
+      hasGesture: true,
+      source: MapEventSource.keyTriggerDragRotate,
+    );
+  }
+
+  /// Checks if one of the specified keys that enable this gesture is pressed.
+  bool get keyPressed => RawKeyboard.instance.keysPressed
+      .where((key) => keys.contains(key))
+      .isNotEmpty;
+
+  /// Get the Rotation in degrees in relation to the cursor position.
+  ///
+  /// - Cursor on the left side of the screen and downwards movement:
+  ///   rotate counter clockwise
+  /// - Cursor on the right side of the screen and downwards movement:
+  ///   rotate clockwise
+  /// and vice versa.
+  ///
+  /// Calculation thanks to https://stackoverflow.com/questions/48916517/javascript-click-and-drag-to-rotate
+  double getCursorRotationDegrees(Size screenSize, Offset cursorOffset) {
+    const correctionTerm = 180; // North = cursor
+
+    return (-math.atan2(cursorOffset.dx - screenSize.width / 2,
+                cursorOffset.dy - screenSize.height / 2) *
+            radians2Degrees) +
+        correctionTerm;
+  }
+}

--- a/lib/src/map/gestures/services/key_trigger_click_rotate.dart
+++ b/lib/src/map/gestures/services/key_trigger_click_rotate.dart
@@ -30,11 +30,8 @@ class KeyTriggerClickRotateGestureService extends _BaseGestureService {
 
   /// Get the Rotation in degrees in relation to the cursor position.
   ///
-  /// - Cursor on the left side of the screen and downwards movement:
-  ///   rotate counter clockwise
-  /// - Cursor on the right side of the screen and downwards movement:
-  ///   rotate clockwise
-  /// and vice versa.
+  /// By clicking at the top of the map the map gets set to 0°-ish, by clicking
+  /// on the left side of the map the rotation is set to 270°-ish.
   ///
   /// Calculation thanks to https://stackoverflow.com/questions/48916517/javascript-click-and-drag-to-rotate
   double getCursorRotationDegrees(Size screenSize, Offset cursorOffset) {

--- a/lib/src/map/gestures/services/key_trigger_click_rotate.dart
+++ b/lib/src/map/gestures/services/key_trigger_click_rotate.dart
@@ -6,18 +6,30 @@ part of 'base_services.dart';
 ///
 /// The key is by default the CTRL key on the keyboard.
 class KeyTriggerClickRotateGestureService extends _BaseGestureService {
+  TapDownDetails? details;
+
   /// Getter for the keyboard keys that trigger the drag to rotate gesture.
   List<LogicalKeyboardKey> get keys =>
       _options.interactionOptions.keyTriggerDragRotateKeys;
+
+  /// Returns true if the service has consumed a [TapDownDetails] for the
+  /// tap gesture.
+  bool get isActive => details != null;
 
   /// Create a new service that rotates the map if the map gets dragged while
   /// a specified key is pressed.
   KeyTriggerClickRotateGestureService({required super.controller});
 
+  void setDetails(TapDownDetails newDetails) => details = newDetails;
+
+  void reset() => details = null;
+
   /// Called when the gesture receives an update, updates the [MapCamera].
-  void update(ScaleUpdateDetails details) {
+  void submit(Size screenSize) {
+    if (details == null) return;
+
     controller.rotateRaw(
-      _camera.rotation - (details.focalPointDelta.dy * 0.5),
+      getCursorRotationDegrees(screenSize, details!.localPosition),
       hasGesture: true,
       source: MapEventSource.keyTriggerDragRotate,
     );

--- a/lib/src/map/options/map_gestures.dart
+++ b/lib/src/map/options/map_gestures.dart
@@ -21,6 +21,7 @@ class MapGestures {
     required this.scrollWheelZoom,
     required this.twoFingerRotate,
     required this.keyTriggerDragRotate,
+    required this.keyTriggerClickRotate,
     required this.trackpadZoom,
   });
 
@@ -39,6 +40,7 @@ class MapGestures {
     this.scrollWheelZoom = true,
     this.twoFingerRotate = true,
     this.keyTriggerDragRotate = true,
+    this.keyTriggerClickRotate = true,
     this.trackpadZoom = true,
   });
 
@@ -57,6 +59,7 @@ class MapGestures {
     this.scrollWheelZoom = false,
     this.twoFingerRotate = false,
     this.keyTriggerDragRotate = false,
+    this.keyTriggerClickRotate = false,
     this.trackpadZoom = false,
   });
 
@@ -81,6 +84,7 @@ class MapGestures {
           twoFingerZoom: zoom,
           twoFingerRotate: rotate,
           keyTriggerDragRotate: rotate,
+          keyTriggerClickRotate: rotate,
           trackpadZoom: zoom,
         );
 
@@ -133,6 +137,8 @@ class MapGestures {
           InteractiveFlag.hasFlag(flags, InteractiveFlag.twoFingerRotate),
       keyTriggerDragRotate:
           InteractiveFlag.hasFlag(flags, InteractiveFlag.keyTriggerDragRotate),
+      keyTriggerClickRotate:
+          InteractiveFlag.hasFlag(flags, InteractiveFlag.keyTriggerClickRotate),
       trackpadZoom:
           InteractiveFlag.hasFlag(flags, InteractiveFlag.trackpadZoom),
     );
@@ -172,6 +178,13 @@ class MapGestures {
   /// or finger.
   final bool keyTriggerDragRotate;
 
+  /// Enable rotation by pressing the defined keyboard key (by default CTRL key)
+  /// and clicking on the map.
+  ///
+  /// By clicking at the top of the map the map gets set to 0°-ish, by clicking
+  /// on the left side of the map the rotation is set to 270°-ish.
+  final bool keyTriggerClickRotate;
+
   /// Wither to change the value of some gestures. Returns a new
   /// [MapGestures] object.
   MapGestures copyWith({
@@ -184,6 +197,7 @@ class MapGestures {
     bool? scrollWheelZoom,
     bool? twoFingerRotate,
     bool? keyTriggerDragRotate,
+    bool? keyTriggerClickRotate,
     bool? trackpadZoom,
   }) =>
       MapGestures(
@@ -196,6 +210,8 @@ class MapGestures {
         scrollWheelZoom: scrollWheelZoom ?? this.scrollWheelZoom,
         twoFingerRotate: twoFingerRotate ?? this.twoFingerRotate,
         keyTriggerDragRotate: keyTriggerDragRotate ?? this.keyTriggerDragRotate,
+        keyTriggerClickRotate:
+            keyTriggerClickRotate ?? this.keyTriggerClickRotate,
         trackpadZoom: trackpadZoom ?? this.trackpadZoom,
       );
 
@@ -256,7 +272,8 @@ abstract class InteractiveFlag {
       scrollWheelZoom |
       twoFingerRotate |
       trackpadZoom |
-      keyTriggerDragRotate;
+      keyTriggerDragRotate |
+      keyTriggerClickRotate;
 
   /// No enabled interactive flags, use as `flags: InteractiveFlag.none` to
   /// have a non interactive map.
@@ -298,9 +315,6 @@ abstract class InteractiveFlag {
   static const int scrollWheelZoom = 1 << 6;
 
   /// Enable rotation with two-finger twist gesture
-  ///
-  /// For controlling cursor/keyboard rotation, see
-  /// [InteractionOptions.cursorKeyboardRotationOptions].
   static const int twoFingerRotate = 1 << 7;
 
   /// Enable rotation with two-finger twist gesture.
@@ -309,11 +323,16 @@ abstract class InteractiveFlag {
 
   /// Enable rotation by pressing the defined keyboard keys
   /// (by default CTRL Key) and drag the map with the cursor.
-  /// To change the key see [InteractionOptions.cursorKeyboardRotationOptions].
+  /// To change the key see [InteractionOptions.keyTriggerDragRotateKeys].
   static const int keyTriggerDragRotate = 1 << 8;
 
   /// Enable zooming by using the trackpad / touchpad of a device.
   static const int trackpadZoom = 1 << 9;
+
+  /// Enable rotation by pressing the defined keyboard keys
+  /// (by default CTRL Key) and click on the map.
+  /// To change the key see [InteractionOptions.keyTriggerDragRotateKeys].
+  static const int keyTriggerClickRotate = 1 << 10;
 
   /// Returns `true` if [leftFlags] has at least one member in [rightFlags]
   /// (intersection) for example


### PR DESCRIPTION
>  (1) One bug with cursor keyboard rotation. Rotation is not tracking the cursor properly. I remember having a similar issue when implementing the algorithm initially. Maybe double checking that nothing in the implementaiton itself has changed, and every variable is being changed/reset at the correct points.

- This pr adds the `keyTriggerClickRotate` gesture to the gesture rewrite.
- The gesture takes slightly longer to execute than on master to filter out drag gestures while the CTRL/specified key is pressed.
- The rotation should be animated, added this as an idea to https://github.com/fleaflet/flutter_map/issues/1748.