### PR TITLE
feat(gestures): fling animation as drag gesture option

### DIFF
--- a/example/lib/pages/gestures_page.dart
+++ b/example/lib/pages/gestures_page.dart
@@ -17,7 +17,6 @@ class _GesturesPageState extends State<GesturesPage> {
   static const availableFlags = {
     'Movement': {
       InteractiveFlag.drag: 'Drag',
-      InteractiveFlag.flingAnimation: 'Fling',
       InteractiveFlag.twoFingerMove: 'Two finger drag',
     },
     'Zooming': {

--- a/lib/src/map/gestures/services/drag.dart
+++ b/lib/src/map/gestures/services/drag.dart
@@ -7,7 +7,7 @@ class DragGestureService extends _BaseGestureService
   Offset? _lastLocalFocal;
   Offset? _focalStartLocal;
 
-  bool get _flingEnabled => _options.interactionOptions.gestures.flingAnimation;
+  bool get _flingEnabled => _options.interactionOptions.dragFlingAnimation;
 
   /// Create a new service to handle drag gestures.
   DragGestureService({required super.controller});
@@ -65,6 +65,14 @@ class DragGestureService extends _BaseGestureService
     _lastLocalFocal = null;
     _focalStartLocal = null;
 
+    flingAnimation(details, focalStartLocal, lastLocalFocal);
+  }
+
+  void flingAnimation(
+    ScaleEndDetails details,
+    Offset focalStartLocal,
+    Offset lastLocalFocal,
+  ) {
     if (!_flingEnabled) return;
 
     final magnitude = details.velocity.pixelsPerSecond.distance;

--- a/lib/src/map/options/interaction_options.dart
+++ b/lib/src/map/options/interaction_options.dart
@@ -19,6 +19,11 @@ final class InteractionOptions {
   /// For more information see the documentation on [InteractiveFlag].
   final MapGestures gestures;
 
+  /// Enable fling animation after panning if velocity is great enough.
+  ///
+  /// Defaults to true, this requires the `drag` gesture to be enabled.
+  final bool dragFlingAnimation;
+
   /// Map starts to rotate when [twoFingerRotateThreshold] has been achieved
   /// or another multi finger gesture wins.
   /// Default is 0.1
@@ -74,6 +79,7 @@ final class InteractionOptions {
     this.twoFingerMoveThreshold = 3.0,
     this.scrollWheelVelocity = 0.01,
     this.trackpadZoomVelocity = 0.5,
+    this.dragFlingAnimation = true,
     this.keyTriggerDragRotateKeys = defaultKeyTriggerDragRotateKeys,
   })  : assert(
           twoFingerRotateThreshold >= 0.0,

--- a/lib/src/map/options/map_gestures.dart
+++ b/lib/src/map/options/map_gestures.dart
@@ -13,7 +13,6 @@ class MapGestures {
   /// use [InteractiveFlags.bitfield] instead.
   const MapGestures({
     required this.drag,
-    required this.flingAnimation,
     required this.twoFingerMove,
     required this.twoFingerZoom,
     required this.doubleTapZoomIn,
@@ -31,7 +30,6 @@ class MapGestures {
   /// [InteractiveFlags.none] constructor instead.
   const MapGestures.all({
     this.drag = true,
-    this.flingAnimation = true,
     this.twoFingerMove = true,
     this.twoFingerZoom = true,
     this.doubleTapZoomIn = true,
@@ -49,7 +47,6 @@ class MapGestures {
   /// [InteractiveFlags.all] constructor instead.
   const MapGestures.none({
     this.drag = false,
-    this.flingAnimation = false,
     this.twoFingerMove = false,
     this.twoFingerZoom = false,
     this.doubleTapZoomIn = false,
@@ -74,7 +71,6 @@ class MapGestures {
   }) : this(
           drag: move,
           twoFingerMove: move,
-          flingAnimation: move,
           doubleTapDragZoom: zoom,
           doubleTapZoomIn: zoom,
           scrollWheelZoom: zoom,
@@ -117,8 +113,6 @@ class MapGestures {
   factory MapGestures.bitfield(int flags) {
     return MapGestures(
       drag: InteractiveFlag.hasFlag(flags, InteractiveFlag.drag),
-      flingAnimation:
-          InteractiveFlag.hasFlag(flags, InteractiveFlag.flingAnimation),
       twoFingerMove:
           InteractiveFlag.hasFlag(flags, InteractiveFlag.twoFingerMove),
       twoFingerZoom:
@@ -140,9 +134,6 @@ class MapGestures {
 
   /// Enable panning with a single finger or cursor
   final bool drag;
-
-  /// Enable fling animation after panning if velocity is great enough.
-  final bool flingAnimation;
 
   /// Enable panning with multiple fingers
   final bool twoFingerMove;
@@ -188,7 +179,6 @@ class MapGestures {
   }) =>
       MapGestures(
         drag: drag ?? this.drag,
-        flingAnimation: flingAnimation ?? this.flingAnimation,
         twoFingerZoom: twoFingerZoom ?? this.twoFingerZoom,
         twoFingerMove: twoFingerMove ?? this.twoFingerMove,
         doubleTapZoomIn: doubleTapZoomIn ?? this.doubleTapZoomIn,
@@ -205,7 +195,6 @@ class MapGestures {
       other is MapGestures &&
           runtimeType == other.runtimeType &&
           drag == other.drag &&
-          flingAnimation == other.flingAnimation &&
           twoFingerMove == other.twoFingerMove &&
           twoFingerZoom == other.twoFingerZoom &&
           doubleTapZoomIn == other.doubleTapZoomIn &&
@@ -217,7 +206,6 @@ class MapGestures {
   @override
   int get hashCode => Object.hash(
         drag,
-        flingAnimation,
         twoFingerMove,
         twoFingerZoom,
         doubleTapZoomIn,
@@ -248,7 +236,6 @@ abstract class InteractiveFlag {
   /// All available interactive flags, use as `flags: InteractiveFlag.all` to
   /// enable all gestures.
   static const int all = drag |
-      flingAnimation |
       twoFingerMove |
       twoFingerZoom |
       doubleTapZoomIn |
@@ -264,9 +251,6 @@ abstract class InteractiveFlag {
 
   /// Enable panning with a single finger or cursor
   static const int drag = 1 << 0;
-
-  /// Enable fling animation after panning if velocity is great enough.
-  static const int flingAnimation = 1 << 1;
 
   /// Enable panning with multiple fingers
   static const int twoFingerMove = 1 << 2;


### PR DESCRIPTION
(5) ~~Can no longer fling if drag gesture is disabled. On master, enabling fling without drag would start a fling if the normal conditions were met, but wouldn't drag/move if not, and wouldn't move whilst normal dragging.~~ 
Turn the fling gesture into an option for the drag gesture.

