### PR TITLE
fix(gestures): double tap zoom events, fling events

### DIFF
--- a/example/lib/pages/gestures_page.dart
+++ b/example/lib/pages/gestures_page.dart
@@ -106,10 +106,7 @@ class _GesturesPageState extends State<GesturesPage> {
             Expanded(
               child: FlutterMap(
                 options: MapOptions(
-                  onMapEvent: (evt) {
-                    print(evt);
-                    setState(() => _latestEvent = evt);
-                  },
+                  onMapEvent: (event) => setState(() => _latestEvent = event),
                   initialCenter: const LatLng(51.5, -0.09),
                   initialZoom: 11,
                   interactionOptions: InteractionOptions(

--- a/example/lib/pages/gestures_page.dart
+++ b/example/lib/pages/gestures_page.dart
@@ -106,7 +106,10 @@ class _GesturesPageState extends State<GesturesPage> {
             Expanded(
               child: FlutterMap(
                 options: MapOptions(
-                  onMapEvent: (evt) => setState(() => _latestEvent = evt),
+                  onMapEvent: (evt) {
+                    print(evt);
+                    setState(() => _latestEvent = evt);
+                  },
                   initialCenter: const LatLng(51.5, -0.09),
                   initialZoom: 11,
                   interactionOptions: InteractionOptions(

--- a/lib/src/map/controller/map_controller_impl.dart
+++ b/lib/src/map/controller/map_controller_impl.dart
@@ -508,8 +508,8 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
   bool get isAnimating => _animationController.isAnimating;
 
   /// cancel all ongoing animation
-  void stopAnimations() {
-    _animationController.stop();
+  void stopAnimations({bool cancelled = true}) {
+    _animationController.stop(canceled: cancelled);
     _moveAnimation = null;
     _rotationAnimation = null;
     _zoomAnimation = null;

--- a/lib/src/map/controller/map_controller_impl.dart
+++ b/lib/src/map/controller/map_controller_impl.dart
@@ -441,7 +441,7 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
       );
       return;
     }
-    stopAnimation();
+    stopAnimationRaw();
 
     if (newCenter == camera.center && newZoom == camera.zoom) return;
 
@@ -479,7 +479,7 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
     AnimationEndedCallback? onAnimatedEnded,
     AnimationCancelledCallback? onAnimationCancelled,
   }) {
-    stopAnimation();
+    stopAnimationRaw();
     if (newRotation == camera.rotation) return;
 
     // create the new animation
@@ -502,19 +502,9 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
   /// This is commonly used by other gestures that should stop all
   /// ongoing movement.
   void stopAnimationRaw({bool canceled = true}) {
-    if (isAnimating) _animationController.stop(canceled: canceled);
-  }
-
-  /// Getter that returns true if the [MapControllerImpl] performs a zoom,
-  /// drag or rotate animation.
-  bool get isAnimating => _animationController.isAnimating;
-
-  /// cancel all ongoing animation
-  void stopAnimation() {
-    if (_animationController.isAnimating) {
-      // cancel animation
+    if (isAnimating) {
       _animatedCancelledCallback?.call(camera, _animationSource);
-      _animationController.stop();
+      _animationController.stop(canceled: canceled);
     }
     _moveAnimation = null;
     _rotationAnimation = null;
@@ -523,6 +513,10 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
     _animatedEndedCallback = null;
     _animatedCancelledCallback = null;
   }
+
+  /// Getter that returns true if the [MapControllerImpl] performs a zoom,
+  /// drag or rotate animation.
+  bool get isAnimating => _animationController.isAnimating;
 
   /// Fling animation for the map.
   /// The raw method allows to set all parameters.
@@ -536,7 +530,7 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
     double ratio = 5,
     required bool hasGesture,
   }) {
-    stopAnimation();
+    stopAnimationRaw();
 
     _animationHasGesture = hasGesture;
     _animationOffset = offset;
@@ -576,7 +570,7 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
     AnimationEndedCallback? onAnimatedEnded,
     AnimationCancelledCallback? onAnimationCancelled,
   }) {
-    stopAnimation();
+    stopAnimationRaw();
     if (newCenter == camera.center && newZoom == camera.zoom) return;
 
     // create the new animation

--- a/lib/src/map/controller/map_controller_impl.dart
+++ b/lib/src/map/controller/map_controller_impl.dart
@@ -669,6 +669,10 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
             camera: camera,
             source: _animationSource,
           ),
+        MapEventSource.flingAnimationController => MapEventFlingAnimationEnd(
+            camera: camera,
+            source: _animationSource,
+          ),
         _ => MapEventMoveEnd(
             camera: camera,
             source: _animationSource,

--- a/lib/src/map/controller/map_controller_impl.dart
+++ b/lib/src/map/controller/map_controller_impl.dart
@@ -439,9 +439,7 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
       );
       return;
     }
-    // cancel all ongoing animation
-    _animationController.stop();
-    _resetAnimations();
+    stopAnimations();
 
     if (newCenter == camera.center && newZoom == camera.zoom) return;
 
@@ -479,10 +477,7 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
     required AnimationEndedCallback? onAnimatedEnded,
     required AnimationCancelledCallback? onAnimationCancelled,
   }) {
-    // cancel all ongoing animation
-    _animationController.stop();
-    _resetAnimations();
-
+    stopAnimations();
     if (newRotation == camera.rotation) return;
 
     // create the new animation
@@ -512,11 +507,15 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
   /// drag or rotate animation.
   bool get isAnimating => _animationController.isAnimating;
 
-  void _resetAnimations() {
+  /// cancel all ongoing animation
+  void stopAnimations() {
+    _animationController.stop();
     _moveAnimation = null;
     _rotationAnimation = null;
     _zoomAnimation = null;
     _flingAnimation = null;
+    _animatedEndedCallback = null;
+    _animatedCancelledCallback = null;
   }
 
   /// Fling animation for the map.
@@ -531,9 +530,7 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
     double ratio = 5,
     required bool hasGesture,
   }) {
-    // cancel all ongoing animation
-    _animationController.stop();
-    _resetAnimations();
+    stopAnimations();
 
     _animationHasGesture = hasGesture;
     _animationOffset = offset;
@@ -573,10 +570,7 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
     required AnimationEndedCallback? onAnimatedEnded,
     required AnimationCancelledCallback? onAnimationCancelled,
   }) {
-    // cancel all ongoing animation
-    _animationController.stop();
-    _resetAnimations();
-
+    stopAnimations();
     if (newCenter == camera.center && newZoom == camera.zoom) return;
 
     // create the new animation

--- a/lib/src/map/gestures/services/double_tap.dart
+++ b/lib/src/map/gestures/services/double_tap.dart
@@ -21,7 +21,7 @@ class DoubleTapGestureService extends _SingleShotGestureService {
     controller.emitMapEvent(
       MapEventDoubleTapZoomStart(
         camera: _camera,
-        source: MapEventSource.doubleTap,
+        source: MapEventSource.doubleTapZoomAnimationController,
       ),
     );
 
@@ -29,7 +29,7 @@ class DoubleTapGestureService extends _SingleShotGestureService {
       newCenter,
       newZoom,
       hasGesture: true,
-      source: MapEventSource.doubleTap,
+      source: MapEventSource.doubleTapZoomAnimationController,
       curve: Curves.fastOutSlowIn,
       duration: const Duration(milliseconds: 200),
     );
@@ -37,7 +37,7 @@ class DoubleTapGestureService extends _SingleShotGestureService {
     controller.emitMapEvent(
       MapEventDoubleTapZoomEnd(
         camera: _camera,
-        source: MapEventSource.doubleTap,
+        source: MapEventSource.doubleTapZoomAnimationController,
       ),
     );
 


### PR DESCRIPTION
## Issue

#### (4) Double tap zoom no longer emits correct event.

PR           |  Master
:-------------------------:|:-------------------------:
!<img alt="pr" src="https://github.com/fleaflet/flutter_map/assets/58115698/2e6f4d64-6142-423c-9d2c-7a8ebbd150ee">  |  <img alt="master" src="https://github.com/fleaflet/flutter_map/assets/58115698/fe9c01d0-8835-45ed-8d22-a8472771eaec">

#### (3) One bug with fling event end/finished event not being emmitted (when fling is cancelled with tap (as shown in video), or when finished naturally)

https://github.com/fleaflet/flutter_map/assets/58115698/da44775d-4854-4665-b0c0-c2129393b7ba

## Information
- Fixed the emitted map events for `doubleTapZoomIn` and the fling animation of the `drag` gesture.
- I added callbacks for when an animation has ended or has been cancelled. It turned out that they are not used but having some callbacks for both events could make sense for the future. @JaffaKetchup you can decide if we keep or remove them.