### PR TITLE
Fix: repaint polygons/polylines on changes.

### DIFF
--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -306,9 +306,12 @@ class _PolygonPainter extends CustomPainter {
     path.addPolygon(offsets, true);
   }
 
-  // TODO: Fix bug where wrapping layer in some widgets (eg. opacity) causes the
-  // features to not move unless this is `true`, but `true` significantly impacts
-  // performance
   @override
-  bool shouldRepaint(_PolygonPainter oldDelegate) => false;
+  bool shouldRepaint(_PolygonPainter oldDelegate) =>
+      polygons != oldDelegate.polygons ||
+      triangles != oldDelegate.triangles ||
+      camera != oldDelegate.camera ||
+      bounds != oldDelegate.bounds ||
+      drawLabelsLast != oldDelegate.drawLabelsLast ||
+      polygonLabels != oldDelegate.polygonLabels;
 }

--- a/lib/src/layer/polyline_layer/painter.dart
+++ b/lib/src/layer/polyline_layer/painter.dart
@@ -288,11 +288,12 @@ class _PolylinePainter<R extends Object> extends CustomPainter {
   LatLng _unproject(DoublePoint p0) =>
       camera.crs.projection.unprojectXY(p0.x, p0.y);
 
-  // TODO: Fix bug where wrapping layer in some widgets (eg. opacity) causes the
-  // features to not move unless this is `true`, but `true` significantly impacts
-  // performance
   @override
-  bool shouldRepaint(_PolylinePainter<R> oldDelegate) => false;
+  bool shouldRepaint(_PolylinePainter<R> oldDelegate) =>
+      polylines != oldDelegate.polylines ||
+      camera != oldDelegate.camera ||
+      hitNotifier != oldDelegate.hitNotifier ||
+      minimumHitbox != oldDelegate.minimumHitbox;
 }
 
 const _distance = Distance();


### PR DESCRIPTION
Hi!
Just tested the master version, and I noticed that my polygons no longer moved with the map, so here's the little fix.