### PR TITLE
fix: prevent null exception when undefined/null `Polygon.hitValue`

### DIFF
--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -92,7 +92,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
       // Second check handles case where polygon outline intersects a hole,
       // ensuring that the hit matches with the visual representation
       if ((isInPolygon && !isInHole) || (!isInPolygon && isInHole)) {
-        _hits.add(polygon.hitValue!);
+        if (polygon.hitValue != null) _hits.add(polygon.hitValue!);
         hasHit = true;
       }
     }


### PR DESCRIPTION
This works in the polyline layer, but I missed out a line copy when carrying some changes over.
Thanks to @mohammedX6 for bringing this to my attention. Replaces #1826.