### PR TITLE
feat: add lint rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -42,5 +42,14 @@ linter:
     use_if_null_to_convert_nulls_to_bools: true
     matching_super_parameters: true
     prefer_const_constructors: true
+    use_decorated_box: true
+    use_is_even_rather_than_modulo: true
+    unnecessary_lambdas: true
+    sort_pub_dependencies: true
+    prefer_void_to_null: true
+    unnecessary_raw_strings: true
+    comment_references: true
+    parameter_assignments: true
+    avoid_unused_constructor_parameters: true
     # TODO: enable the following lint when all public APIs are documented
     # public_member_api_docs: true

--- a/benchmark/crs.dart
+++ b/benchmark/crs.dart
@@ -30,8 +30,8 @@ Future<Result> timedRun(String name, dynamic Function() body) async {
 // If you run in JIT mode, the resulting execution times will be a lot more similar.
 Future<void> main() async {
   Logger.level = Level.all;
-  Logger.defaultFilter = () => NoFilter();
-  Logger.defaultPrinter = () => SimplePrinter();
+  Logger.defaultFilter = NoFilter.new;
+  Logger.defaultPrinter = SimplePrinter.new;
 
   final results = <Result>[];
   const N = 100000000;

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -52,7 +52,7 @@ class _HomePageState extends State<HomePage> {
                 attributions: [
                   TextSourceAttribution(
                     'OpenStreetMap contributors',
-                    onTap: () => launchUrl(
+                    onTap: () async => launchUrl(
                       Uri.parse('https://openstreetmap.org/copyright'),
                     ),
                   ),

--- a/example/lib/pages/moving_markers.dart
+++ b/example/lib/pages/moving_markers.dart
@@ -16,8 +16,13 @@ class MovingMarkersPage extends StatefulWidget {
 }
 
 class MovingMarkersPageState extends State<MovingMarkersPage> {
-  Marker? _marker;
-  late final Timer _timer;
+  late Marker _marker = _markers[_markerIndex];
+  late final Timer _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+    setState(() {
+      _marker = _markers[_markerIndex];
+      _markerIndex = (_markerIndex + 1) % _markers.length;
+    });
+  });
   int _markerIndex = 0;
 
   static const _markers = [
@@ -42,18 +47,6 @@ class MovingMarkersPageState extends State<MovingMarkersPage> {
   ];
 
   @override
-  void initState() {
-    super.initState();
-    _marker = _markers[_markerIndex];
-    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
-      setState(() {
-        _marker = _markers[_markerIndex];
-        _markerIndex = (_markerIndex + 1) % _markers.length;
-      });
-    });
-  }
-
-  @override
   void dispose() {
     super.dispose();
     _timer.cancel();
@@ -71,7 +64,7 @@ class MovingMarkersPageState extends State<MovingMarkersPage> {
         ),
         children: [
           openStreetMapTileLayer,
-          MarkerLayer(markers: [_marker!]),
+          MarkerLayer(markers: [_marker]),
         ],
       ),
     );

--- a/example/lib/pages/retina.dart
+++ b/example/lib/pages/retina.dart
@@ -210,8 +210,7 @@ class InputFieldStylizer extends TextEditingController {
   final Pattern pattern;
 
   InputFieldStylizer(this.mapping, {String? initialValue})
-      : pattern =
-            RegExp(mapping.keys.map((key) => RegExp.escape(key)).join('|')),
+      : pattern = RegExp(mapping.keys.map(RegExp.escape).join('|')),
         super(text: initialValue);
 
   @override

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,19 +12,19 @@ dependencies:
     sdk: flutter
   flutter_map:
   flutter_map_cancellable_tile_provider:
+  flutter_map_geojson: ^1.0.6
+  http: ^1.2.0
   latlong2: ^0.9.0
   proj4dart: ^2.1.0
-  url_launcher: ^6.2.4
   shared_preferences: ^2.2.2
+  url_launcher: ^6.2.4
   url_strategy: ^0.2.0
-  http: ^1.2.0
   vector_math: ^2.1.4
-  flutter_map_geojson: ^1.0.6
 
 dependency_overrides:
-  flutter_map_cancellable_tile_provider:
   flutter_map:
     path: ../
+  flutter_map_cancellable_tile_provider:
 
 dev_dependencies:
   flutter_lints: ^3.0.0

--- a/lib/src/gestures/interactive_flag.dart
+++ b/lib/src/gestures/interactive_flag.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_map/flutter_map.dart';
+
 /// Use [InteractiveFlag] to disable / enable certain events Use
 /// [InteractiveFlag.all] to enable all events, use [InteractiveFlag.none] to
 /// disable all events

--- a/lib/src/gestures/map_events.dart
+++ b/lib/src/gestures/map_events.dart
@@ -1,6 +1,6 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
-import 'package:meta/meta.dart';
 
 /// Event sources which are used to identify different types of
 /// [MapEvent] events

--- a/lib/src/gestures/map_interactive_viewer.dart
+++ b/lib/src/gestures/map_interactive_viewer.dart
@@ -141,8 +141,8 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
   bool cursorKeyboardRotationTriggerHandler(KeyEvent event) {
     _ckrTriggered.value = (event is KeyRepeatEvent || event is KeyDownEvent) &&
         (_interactionOptions.cursorKeyboardRotationOptions.isKeyTrigger ??
-            (key) => CursorKeyboardRotationOptions.defaultTriggerKeys
-                .contains(key))(event.logicalKey);
+            CursorKeyboardRotationOptions
+                .defaultTriggerKeys.contains)(event.logicalKey);
     return false;
   }
 

--- a/lib/src/layer/attribution_layer/rich/source.dart
+++ b/lib/src/layer/attribution_layer/rich/source.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:meta/meta.dart';
 
 /// Base class for attributions that render themselves as widgets in a

--- a/lib/src/layer/attribution_layer/rich/widget.dart
+++ b/lib/src/layer/attribution_layer/rich/widget.dart
@@ -152,7 +152,7 @@ class _RichAttributionWidgetState extends State<RichAttributionWidget> {
 
   @override
   void dispose() {
-    mapEventSubscription?.cancel();
+    unawaited(mapEventSubscription?.cancel());
     super.dispose();
   }
 
@@ -204,10 +204,11 @@ class _RichAttributionWidgetState extends State<RichAttributionWidget> {
                 context,
                 () {
                   setState(() => popupExpanded = true);
-                  mapEventSubscription =
-                      MapController.of(context).mapEventStream.listen((e) {
+                  mapEventSubscription = MapController.of(context)
+                      .mapEventStream
+                      .listen((e) async {
                     setState(() => popupExpanded = false);
-                    mapEventSubscription?.cancel();
+                    await mapEventSubscription?.cancel();
                   });
                 },
               ),
@@ -225,7 +226,7 @@ class _RichAttributionWidgetState extends State<RichAttributionWidget> {
               context: context,
               isExpanded: popupExpanded,
               config: widget,
-              child: Container(
+              child: DecoratedBox(
                 decoration: BoxDecoration(
                   color: widget.popupBackgroundColor ??
                       Theme.of(context).colorScheme.background,

--- a/lib/src/layer/attribution_layer/simple.dart
+++ b/lib/src/layer/attribution_layer/simple.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 
 /// A simple, classic style, attribution layer
 ///

--- a/lib/src/layer/marker_layer/marker.dart
+++ b/lib/src/layer/marker_layer/marker.dart
@@ -44,7 +44,7 @@ class Marker {
   /// user's perspective. Defaults to `false` if also unset by [MarkerLayer].
   ///
   /// Note that this is not used to apply a custom rotation in degrees to the
-  /// marker. Use a widget inside [builder] to perform this.
+  /// marker. Use a widget inside [child] to perform this.
   final bool? rotate;
 
   /// Creates a container for a [child] widget located at a geographic coordinate

--- a/lib/src/layer/marker_layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer/marker_layer.dart
@@ -29,7 +29,7 @@ class MarkerLayer extends StatelessWidget {
   /// user's perspective. Defaults to `false`. Overriden by [Marker.rotate].
   ///
   /// Note that this is not used to apply a custom rotation in degrees to the
-  /// markers. Use a widget inside [Marker.builder] to perform this.
+  /// markers. Use a widget inside [Marker.child] to perform this.
   final bool rotate;
 
   /// Create a new [MarkerLayer] to use inside of [FlutterMap.children].

--- a/lib/src/layer/polygon_layer/polygon.dart
+++ b/lib/src/layer/polygon_layer/polygon.dart
@@ -179,7 +179,7 @@ class Polygon<R extends Object> {
   // Used to batch draw calls to the canvas
   int? _renderHashCode;
 
-  /// An optimized hash code dedicated to be used inside the [PolygonPainter].
+  /// An optimized hash code dedicated to be used inside the [_PolygonPainter].
   int get renderHashCode => _renderHashCode ??= Object.hash(
         color,
         borderStrokeWidth,

--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -175,7 +175,7 @@ class _PolygonLayerState<R extends Object> extends State<PolygonLayer<R>> {
               return Earcut.triangulateRaw(
                 List.generate(
                   points.length * 2,
-                  (ii) => ii % 2 == 0
+                  (ii) => ii.isEven
                       ? points.elementAt(ii ~/ 2).x
                       : points.elementAt(ii ~/ 2).y,
                   growable: false,

--- a/lib/src/layer/tile_layer/tile_bounds/tile_bounds.dart
+++ b/lib/src/layer/tile_layer/tile_bounds/tile_bounds.dart
@@ -12,7 +12,7 @@ abstract class TileBounds {
   final LatLngBounds? _latLngBounds;
 
   /// Constructor that creates an instance of a subclass of [TileBounds]:
-  /// [InfiniteTileBounds] if the CRS is [infinite].
+  /// [InfiniteTileBounds] if the CRS is infinite.
   /// [DiscreteTileBounds] if the CRS has hard borders.
   /// [WrappedTileBounds] if the CRS is wrapped.
   factory TileBounds({

--- a/lib/src/layer/tile_layer/tile_display.dart
+++ b/lib/src/layer/tile_layer/tile_display.dart
@@ -1,5 +1,5 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
-import 'package:meta/meta.dart';
 
 @immutable
 sealed class TileDisplay {
@@ -37,14 +37,12 @@ sealed class TileDisplay {
     /// range is (0.0 - 1.0).
     double startOpacity,
 
-    /// Opacity start value when a tile is reloaded, default 1.0. A tile reload
-    /// will occur when the provider tile url changes and
-    /// [TileLayer.overrideTilesWhenUrlChanges] is true. Valid range is
+    /// Opacity start value when a tile is reloaded, default 1.0. Valid range is
     /// (0.0 - 1.0).
     double reloadStartOpacity,
   }) = FadeInTileDisplay._;
 
-  /// Output a value of type [T] dependent on [this] and its type
+  /// Output a value of type [T] dependent on this and its type
   T? when<T>({
     T? Function(InstantaneousTileDisplay instantaneous)? instantaneous,
     T? Function(FadeInTileDisplay fadeIn)? fadeIn,

--- a/lib/src/layer/tile_layer/tile_error_evict_callback.dart
+++ b/lib/src/layer/tile_layer/tile_error_evict_callback.dart
@@ -11,7 +11,7 @@ enum EvictErrorTileStrategy {
   /// Evict images for tiles which failed to load and:
   ///   - do not belong to the current zoom level AND/OR
   ///   - are not visible, respecting the pruning buffer (the maximum of the
-  ///     [keepBuffer] and [panBuffer].
+  ///     keepBuffer and panBuffer.
   notVisibleRespectMargin,
 
   /// Evict images for tiles which failed to load and:

--- a/lib/src/layer/tile_layer/tile_provider/base_tile_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/base_tile_provider.dart
@@ -140,7 +140,7 @@ abstract class TileProvider {
   /// [70339807ed6b](https://github.com/Leaflet/Leaflet/commit/70339807ed6bec630ee9c2e96a9cb8356fa6bd86).
   /// It is never mentioned why this regex was used or changed in Leaflet.
   /// This regex is more permissive of the characters it allows.
-  static final templatePlaceholderElement = RegExp(r'{([^{}]*)}');
+  static final templatePlaceholderElement = RegExp('{([^{}]*)}');
 
   /// Replaces placeholders in the form [templatePlaceholderElement] with their
   /// corresponding values

--- a/lib/src/layer/tile_layer/tile_provider/network_tile_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/network_tile_provider.dart
@@ -43,7 +43,7 @@ class NetworkTileProvider extends TileProvider {
   final bool silenceExceptions;
 
   /// Long living client used to make all tile requests by
-  /// [FlutterMapNetworkImageProvider] for the duration that this provider is
+  /// [MapNetworkImageProvider] for the duration that this provider is
   /// alive
   final BaseClient _httpClient;
 

--- a/lib/src/layer/tile_layer/tile_range_calculator.dart
+++ b/lib/src/layer/tile_layer/tile_range_calculator.dart
@@ -12,7 +12,7 @@ class TileRangeCalculator {
 
   /// Calculates the visible pixel bounds at the [tileZoom] zoom level when
   /// viewing the map from the [viewingZoom] centered at the [center]. The
-  /// resulting tile range is expanded by [panBuffer].
+  /// resulting tile range is expanded by panBuffer.
   DiscreteTileRange calculate({
     // The map camera used to calculate the bounds.
     required MapCamera camera,

--- a/lib/src/layer/tile_layer/tile_scale_calculator.dart
+++ b/lib/src/layer/tile_layer/tile_scale_calculator.dart
@@ -15,7 +15,7 @@ class TileScaleCalculator {
     required this.tileSize,
   });
 
-  /// If [true] indicates that the TileSizeCache should be replaced.
+  /// If true it indicates that the TileSizeCache should be replaced.
   bool shouldReplace(Crs crs, double tileSize) =>
       this.crs != crs || this.tileSize != tileSize;
 

--- a/lib/src/map/camera/camera.dart
+++ b/lib/src/map/camera/camera.dart
@@ -207,7 +207,7 @@ class MapCamera {
   /// The current rotation value in radians
   double get rotationRad => rotation * degrees2Radians;
 
-  /// Calculates point value for the given [latLng] using this camera's
+  /// Calculates point value for the given [latlng] using this camera's
   /// [crs] and [zoom] (or the provided [zoom]).
   Point<double> project(LatLng latlng, [double? zoom]) =>
       crs.latLngToPoint(latlng, zoom ?? this.zoom);

--- a/lib/src/map/camera/camera_fit.dart
+++ b/lib/src/map/camera/camera_fit.dart
@@ -47,7 +47,7 @@ abstract class CameraFit {
   /// Allows for more fine grained boundaries when the camera is rotated. See
   /// https://github.com/fleaflet/flutter_map/pull/1549 for more information.
   ///
-  /// [inside] is not supported due to lack of implementation.
+  /// `inside` is not supported due to lack of implementation.
   const factory CameraFit.coordinates({
     required List<LatLng> coordinates,
     EdgeInsets padding,

--- a/lib/src/map/controller/map_controller_impl.dart
+++ b/lib/src/map/controller/map_controller_impl.dart
@@ -150,9 +150,10 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
     String? id,
   }) {
     // Algorithm thanks to https://github.com/tlserver/flutter_map_location_marker
+    LatLng center = newCenter;
     if (offset != Offset.zero) {
       final newPoint = camera.project(newCenter, newZoom);
-      newCenter = camera.unproject(
+      center = camera.unproject(
         camera.rotatePoint(
           newPoint,
           newPoint - Point(offset.dx, offset.dy),
@@ -162,7 +163,7 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
     }
 
     MapCamera? newCamera = camera.withPosition(
-      center: newCenter,
+      center: center,
       zoom: camera.clampZoom(newZoom),
     );
 

--- a/lib/src/map/options/interaction.dart
+++ b/lib/src/map/options/interaction.dart
@@ -20,9 +20,11 @@ final class InteractionOptions {
 
   /// Rotation threshold in degree default is 20.0 Map starts to rotate when
   /// [rotationThreshold] has been achieved or another multi finger gesture wins
-  /// which allows [MultiFingerGesture.rotate] Note: if [interactiveFlags]
-  /// doesn't contain [InteractiveFlag.rotate] or [enableMultiFingerGestureRace]
-  /// is false then rotate cannot win
+  /// which allows [MultiFingerGesture.rotate].
+  ///
+  /// Note: if [MapOptions.interactiveFlags.flags] doesn't contain
+  /// [InteractiveFlag.rotate] or [enableMultiFingerGestureRace]
+  /// is false then rotate cannot win.
   final double rotationThreshold;
 
   /// When [rotationThreshold] wins over [pinchZoomThreshold] and
@@ -34,8 +36,9 @@ final class InteractionOptions {
   /// Pinch Zoom threshold default is 0.5 Map starts to zoom when
   /// [pinchZoomThreshold] has been achieved or another multi finger gesture
   /// wins which allows [MultiFingerGesture.pinchZoom] Note: if
-  /// [interactiveFlags] doesn't contain [InteractiveFlag.pinchZoom] or
-  /// [enableMultiFingerGestureRace] is false then zoom cannot win
+  /// [MapOptions.interactiveFlags.flags] doesn't contain
+  /// [InteractiveFlag.pinchZoom] or [enableMultiFingerGestureRace] is false
+  /// then zoom cannot win.
   final double pinchZoomThreshold;
 
   /// When [pinchZoomThreshold] wins over [rotationThreshold] and
@@ -47,7 +50,9 @@ final class InteractionOptions {
   /// Pinch Move threshold default is 40.0 (note: this doesn't take any effect
   /// on drag) Map starts to move when [pinchMoveThreshold] has been achieved or
   /// another multi finger gesture wins which allows
-  /// [MultiFingerGesture.pinchMove] Note: if [interactiveFlags] doesn't contain
+  /// [MultiFingerGesture.pinchMove].
+  ///
+  /// Note: if [MapOptions.interactiveFlags.flags] doesn't contain
   /// [InteractiveFlag.pinchMove] or [enableMultiFingerGestureRace] is false
   /// then pinch move cannot win
   final double pinchMoveThreshold;

--- a/lib/src/misc/move_and_rotate_result.dart
+++ b/lib/src/misc/move_and_rotate_result.dart
@@ -1,2 +1,4 @@
+import 'package:flutter_map/flutter_map.dart';
+
 /// The result of the `moveAndRotate` [MapController] endpoint.
 typedef MoveAndRotateResult = ({bool moveSuccess, bool rotateSuccess});

--- a/test/layer/tile_layer/tile_image_view_test.dart
+++ b/test/layer/tile_layer/tile_image_view_test.dart
@@ -183,7 +183,6 @@ class MockTileImage extends TileImage {
     void Function(TileCoordinates coordinates)? onLoadComplete,
     void Function(TileImage tile, Object error, StackTrace? stackTrace)?
         onLoadError,
-    TileDisplay? tileDisplay,
     super.errorImage,
   }) : super(
           coordinates: TileCoordinates(x, y, zoom),

--- a/test/layer/tile_layer/tile_provider/network_image_provider_test.dart
+++ b/test/layer/tile_layer/tile_provider/network_image_provider_test.dart
@@ -86,7 +86,7 @@ void main() {
       expect(img, isNotNull);
       expect(img!.image.width, equals(256));
       expect(img.image.height, equals(256));
-      expect(tester.takeException(), isInstanceOf<Null>());
+      expect(tester.takeException(), isInstanceOf<void>());
 
       verify(() => mockClient.readBytes(url, headers: headers)).called(1);
     },
@@ -158,7 +158,7 @@ void main() {
       expect(finishedLoadingTriggered, true);
 
       expect(img, isNotNull);
-      expect(tester.takeException(), isInstanceOf<Null>());
+      expect(tester.takeException(), isInstanceOf<void>());
 
       verify(() => mockClient.readBytes(url, headers: headers)).called(1);
     },
@@ -203,7 +203,7 @@ void main() {
       expect(img, isNotNull);
       expect(img!.image.width, equals(256));
       expect(img.image.height, equals(256));
-      expect(tester.takeException(), isInstanceOf<Null>());
+      expect(tester.takeException(), isInstanceOf<void>());
 
       verify(() => mockClient.readBytes(url, headers: headers)).called(1);
       verify(() => mockClient.readBytes(fallbackUrl, headers: headers))
@@ -247,7 +247,7 @@ void main() {
       expect(finishedLoadingTriggered, true);
 
       expect(img, isNotNull);
-      expect(tester.takeException(), isInstanceOf<Null>());
+      expect(tester.takeException(), isInstanceOf<void>());
 
       verify(() => mockClient.readBytes(url, headers: headers)).called(1);
       verify(() => mockClient.readBytes(fallbackUrl, headers: headers))
@@ -323,7 +323,7 @@ void main() {
       expect(finishedLoadingTriggered, true);
 
       expect(img, isNotNull);
-      expect(tester.takeException(), isInstanceOf<Null>());
+      expect(tester.takeException(), isInstanceOf<void>());
 
       verify(() => mockClient.readBytes(url, headers: headers)).called(1);
       verify(() => mockClient.readBytes(fallbackUrl, headers: headers))
@@ -406,7 +406,7 @@ void main() {
       expect(finishedLoadingTriggered, true);
 
       expect(img, isNotNull);
-      expect(tester.takeException(), isInstanceOf<Null>());
+      expect(tester.takeException(), isInstanceOf<void>());
 
       verify(() => mockClient.readBytes(url, headers: headers)).called(1);
     },
@@ -453,7 +453,7 @@ void main() {
       expect(img, isNotNull);
       expect(img!.image.width, equals(256));
       expect(img.image.height, equals(256));
-      expect(tester.takeException(), isInstanceOf<Null>());
+      expect(tester.takeException(), isInstanceOf<void>());
 
       verify(() => mockClient.readBytes(url, headers: headers)).called(1);
       verify(() => mockClient.readBytes(fallbackUrl, headers: headers))
@@ -500,7 +500,7 @@ void main() {
       expect(finishedLoadingTriggered, true);
 
       expect(img, isNotNull);
-      expect(tester.takeException(), isInstanceOf<Null>());
+      expect(tester.takeException(), isInstanceOf<void>());
 
       verify(() => mockClient.readBytes(url, headers: headers)).called(1);
       verify(() => mockClient.readBytes(fallbackUrl, headers: headers))
@@ -587,7 +587,7 @@ void main() {
       expect(finishedLoadingTriggered, true);
 
       expect(img, isNotNull);
-      expect(tester.takeException(), isInstanceOf<Null>());
+      expect(tester.takeException(), isInstanceOf<void>());
 
       verify(() => mockClient.readBytes(url, headers: headers)).called(1);
       verify(() => mockClient.readBytes(fallbackUrl, headers: headers))
@@ -596,5 +596,5 @@ void main() {
     timeout: defaultTimeout,
   );
 
-  tearDownAll(() => mockClient.close());
+  tearDownAll(mockClient.close);
 }


### PR DESCRIPTION
Lint rules in concideration:
- use_decorated_box
- use_is_even_rather_than_modulo
- unnecessary_lambdas
- sort_pub_dependencies
- prefer_void_to_null
- unnecessary_raw_strings
- comment_references
- parameter_assignments
- avoid_unused_constructor_parameters

Let me know if you want any of them not included.

edit: Having all these manual lint rules it might help to concider using more restrictive lint list than the default flutter list.