### PR TITLE
chore: prepare v7.0.0-dev.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Please consider [donating](https://docs.fleaflet.dev/supporters#support-us) or [contributing](https://docs.fleaflet.dev/credits#contributing) if you're a fan of what we're doing and you'd like to support future releases!
 
+## [7.0.0-dev.1] - 2024/03/13
+
+We've changed the format of the CHANGELOG, to make releases faster!  
+**Check the [latest GitHub release](https://github.com/fleaflet/flutter_map/releases/tag/v7.0.0-dev.1), where you can find an auto-generated list of all the latest commits.**
+
 ## [6.1.0] - 2023/12/02
 
 Contains the following user-affecting changes:

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -19,7 +19,7 @@ if (flutterVersionCode == null) {
 
 def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
-    flutterVersionName = '6.1.0'
+    flutterVersionName = '7.0.0'
 }
 
 android {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_map_example
 description: Example application for 'flutter_map' package
 publish_to: "none"
-version: 6.1.0
+version: 7.0.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_map
 description: A versatile mapping package for Flutter, that's simple and easy to learn, yet completely customizable and configurable
-version: 6.1.0
+version: 7.0.0-dev.1
 
 repository: https://github.com/fleaflet/flutter_map
 issue_tracker: https://github.com/fleaflet/flutter_map/issues

--- a/windowsApplicationInstallerSetup.iss
+++ b/windowsApplicationInstallerSetup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "flutter_map Demo"
-#define MyAppVersion "for 6.1.0"
+#define MyAppVersion "for 7.0.0"
 #define MyAppPublisher "fleaflet"
 #define MyAppURL "https://github.com/fleaflet/flutter_map"
 #define MyAppSupportURL "https://github.com/fleaflet/flutter_map/issues"


### PR DESCRIPTION
Requires #1850.

I've decided to change the way we do CHANGELOGs. It previously took me an hour or more to rewrite the entire commit list as a more readable format, and organise it. Therefore, I'm now just referring to the auto-generated list, which is now more acceptable that we're using conventional commits.