### PR TITLE
fix: prevent crash when zooming far into `Polygon`s

### DIFF
--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -314,9 +314,6 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
       final spacing = polygon.borderStrokeWidth * 1.5;
       _addDottedLineToPath(
           canvas, paint, offsets, borderRadius, spacing, canvasSize);
-      // final Float32List points = Float32List.fromList(offsets.expand((o) => [o.dx, o.dy]).toList());
-      // final vertices = Vertices.raw(VertexMode.triangleFan, points);
-      // canvas.drawVertices(vertices, BlendMode.src, _getBorderPaint(polygon));
     } else {
       _addLineToPath(path, offsets);
     }

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -447,7 +447,6 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
     if (offsets.isEmpty) {
       return;
     }
-    int x = 0; // Counter for diagnostics
 
     // Calculate for all segments, including closing the loop from the last to the first point
     final int totalOffsets = offsets.length;
@@ -474,13 +473,12 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
       while (traveledDistance < lineLength) {
         // Draw the circle if within the canvas bounds (additional check now redundant)
         canvas.drawCircle(currentPoint, radius, paint);
-        x++;
+
         // Move to the next point
         currentPoint = currentPoint + stepVector;
         traveledDistance += stepLength;
       }
     }
-   // print("Dots calculated: $x");
   }
 
   void _addLineToPath(Path path, List<Offset> offsets) {


### PR DESCRIPTION
fix #1829 
Problem was that as zooming in, path was getting very long and many dots was calculated eventually getting into millions and crashing. This resolves it by drawing points only on visible segment. Directly painting circles rather them on path. Thought this might be better. Any suggestions for improvement are welcome.  Would appreciate some testing as I haven't done much.