### PR TITLE
feat: add `BlendMode` support to `CircleLayer`

### DIFF
--- a/lib/src/layer/circle_layer/painter.dart
+++ b/lib/src/layer/circle_layer/painter.dart
@@ -103,6 +103,7 @@ class CirclePainter extends CustomPainter {
       for (final radius in pointsByRadius.keys) {
         final pointsByRadiusColor = pointsByRadius[radius]!;
         final radiusPaint = paint..strokeWidth = radius * 2;
+        radiusPaint.blendMode = BlendMode.luminosity;
         _paintPoints(canvas, pointsByRadiusColor, radiusPaint);
       }
     }

--- a/lib/src/layer/circle_layer/painter.dart
+++ b/lib/src/layer/circle_layer/painter.dart
@@ -73,6 +73,7 @@ class CirclePainter extends CustomPainter {
       for (final borderWidth in pointsBorder[color]!.keys) {
         final pointsByRadius = pointsBorder[color]![borderWidth]!;
         final radiusPaint = paint..strokeWidth = borderWidth;
+        radiusPaint.blendMode = BlendMode.src;
         for (final radius in pointsByRadius.keys) {
           final pointsByRadiusColor = pointsByRadius[radius]!;
           for (final offset in pointsByRadiusColor) {
@@ -92,6 +93,7 @@ class CirclePainter extends CustomPainter {
       for (final radius in pointsByRadius.keys) {
         final pointsByRadiusColor = pointsByRadius[radius]!;
         final radiusPaint = paint..strokeWidth = radius * 2;
+        radiusPaint.blendMode = BlendMode.src;
         _paintPoints(canvas, pointsByRadiusColor, radiusPaint);
       }
     }
@@ -103,7 +105,7 @@ class CirclePainter extends CustomPainter {
       for (final radius in pointsByRadius.keys) {
         final pointsByRadiusColor = pointsByRadius[radius]!;
         final radiusPaint = paint..strokeWidth = radius * 2;
-        radiusPaint.blendMode = BlendMode.luminosity;
+        radiusPaint.blendMode = BlendMode.src;
         _paintPoints(canvas, pointsByRadiusColor, radiusPaint);
       }
     }


### PR DESCRIPTION
Currently overlapping Polygons are adding up in stroke color. To fix this it adds the BlendMode.src to all so this should not happen anymore.
Before:

![image](https://github.com/fleaflet/flutter_map/assets/34318751/d77aa729-67a0-4d0d-bf5e-0878770938ad)