### PR TITLE
fix: correct display of `StrokePattern.solid` at high zoom levels

### DIFF
--- a/lib/src/layer/misc/line_patterns/pixel_hiker.dart
+++ b/lib/src/layer/misc/line_patterns/pixel_hiker.dart
@@ -237,6 +237,45 @@ class DashedPixelHiker extends _PixelHiker {
   }
 }
 
+/// Pixel hiker that lists the visible solid segments to display on the way.
+@internal
+class SolidPixelHiker extends _PixelHiker {
+  /// Standard Solid Pixel Hiker constructor.
+  SolidPixelHiker({
+    required super.offsets,
+    required super.closePath,
+    required super.canvasSize,
+  }) : super(
+          segmentValues: [],
+          patternFit: PatternFit.none,
+        );
+
+  /// Returns all visible segments.
+  List<VisibleSegment> getAllVisibleSegments() {
+    final List<VisibleSegment> result = [];
+
+    if (offsets.length < 2) {
+      return result;
+    }
+
+    for (int i = 0; i < offsets.length - 1 + (closePath ? 1 : 0); i++) {
+      final VisibleSegment? visibleSegment = VisibleSegment.getVisibleSegment(
+        offsets[i],
+        offsets[(i + 1) % offsets.length],
+        canvasSize,
+      );
+      if (visibleSegment != null) {
+        result.add(visibleSegment);
+      }
+    }
+
+    return result;
+  }
+
+  @override
+  double getFactor() => 1;
+}
+
 /// Pixel hiker that lists the visible items on the way.
 sealed class _PixelHiker {
   _PixelHiker({
@@ -253,6 +292,13 @@ sealed class _PixelHiker {
 
   final List<Offset> offsets;
   final bool closePath;
+
+  /// List of segments' lengths.
+  ///
+  /// Expected number of items:
+  /// * empty for "solid"
+  /// * > 0 and even for "dashed": (dash size _ space size) * n
+  /// * only 1 item for "dotted": the size of the space
   final List<double> segmentValues;
   final Size canvasSize;
   final PatternFit patternFit;
@@ -290,6 +336,9 @@ sealed class _PixelHiker {
 
   @protected
   void nextSegment() {
+    if (segmentValues.isEmpty) {
+      return;
+    }
     _segmentIndex = (_segmentIndex + 1) % segmentValues.length;
     _remaining = segmentValues[_segmentIndex];
   }
@@ -305,7 +354,7 @@ sealed class _PixelHiker {
   @protected
   Offset getIntermediateOffset(final Offset offsetA, final Offset offsetB) {
     final segmentDistance = getDistance(offsetA, offsetB);
-    if (_remaining >= segmentDistance) {
+    if (segmentValues.isEmpty || _remaining >= segmentDistance) {
       _used = segmentDistance;
       return offsetB;
     }

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -315,9 +315,20 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
     Canvas canvas,
     Paint paint,
   ) {
+    final isSolid = polygon.pattern == const StrokePattern.solid();
     final isDashed = polygon.pattern.segments != null;
     final isDotted = polygon.pattern.spacingFactor != null;
-    if (isDotted) {
+    if (isSolid) {
+      final SolidPixelHiker hiker = SolidPixelHiker(
+        offsets: offsets,
+        closePath: true,
+        canvasSize: canvasSize,
+      );
+      for (final visibleSegment in hiker.getAllVisibleSegments()) {
+        path.moveTo(visibleSegment.begin.dx, visibleSegment.begin.dy);
+        path.lineTo(visibleSegment.end.dx, visibleSegment.end.dy);
+      }
+    } else if (isDotted) {
       final DottedPixelHiker hiker = DottedPixelHiker(
         offsets: offsets,
         stepLength: polygon.borderStrokeWidth * polygon.pattern.spacingFactor!,
@@ -341,8 +352,6 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
         path.moveTo(visibleSegment.begin.dx, visibleSegment.begin.dy);
         path.lineTo(visibleSegment.end.dx, visibleSegment.end.dy);
       }
-    } else {
-      _addLineToPath(path, offsets);
     }
   }
 
@@ -364,10 +373,6 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
         paint,
       );
     }
-  }
-
-  void _addLineToPath(Path path, List<Offset> offsets) {
-    path.addPolygon(offsets, true);
   }
 
   ({Offset min, Offset max}) _getBounds(Offset origin, Polygon polygon) {

--- a/lib/src/layer/polyline_layer/painter.dart
+++ b/lib/src/layer/polyline_layer/painter.dart
@@ -159,6 +159,7 @@ class _PolylinePainter<R extends Object> extends CustomPainter {
         strokeWidth = polyline.strokeWidth;
       }
 
+      final isSolid = polyline.pattern == const StrokePattern.solid();
       final isDashed = polyline.pattern.segments != null;
       final isDotted = polyline.pattern.spacingFactor != null;
 
@@ -207,7 +208,19 @@ class _PolylinePainter<R extends Object> extends CustomPainter {
         paths.add(filterPath);
       }
       paths.add(path);
-      if (isDotted) {
+      if (isSolid) {
+        final SolidPixelHiker hiker = SolidPixelHiker(
+          offsets: offsets,
+          closePath: false,
+          canvasSize: size,
+        );
+        for (final visibleSegment in hiker.getAllVisibleSegments()) {
+          for (final path in paths) {
+            path.moveTo(visibleSegment.begin.dx, visibleSegment.begin.dy);
+            path.lineTo(visibleSegment.end.dx, visibleSegment.end.dy);
+          }
+        }
+      } else if (isDotted) {
         final DottedPixelHiker hiker = DottedPixelHiker(
           offsets: offsets,
           stepLength: strokeWidth * polyline.pattern.spacingFactor!,
@@ -242,12 +255,6 @@ class _PolylinePainter<R extends Object> extends CustomPainter {
           for (final path in paths) {
             path.moveTo(visibleSegment.begin.dx, visibleSegment.begin.dy);
             path.lineTo(visibleSegment.end.dx, visibleSegment.end.dy);
-          }
-        }
-      } else {
-        if (offsets.isNotEmpty) {
-          for (final path in paths) {
-            path.addPolygon(offsets, false);
           }
         }
       }


### PR DESCRIPTION
### What
* Changed the way to display the solid style segments (polygon and polyline), in order to fix a display side-effect.
* Some performance test should be performed to see if we're not significantly impacted, as we added a pre-computation step with potentially many allocations.
* That fix works only for lines, not for areas.

### Impacted files
* `polygon_layer/painter.dart`: now using the new `SolidPixelHiker` for solid style display
* `polyline_layer/painter.dart`: now using the new `SolidPixelHiker` for solid style display
* `pixel_hiker.dart`: new `SolidPixelHiker` class

### Screenshots
Example on high zoom level: the `path`s are unstable beyond a certain threshold, and as a side effect some painting are corrupted (in that case, the border). 
| before | after |
| -- | -- |
| ![Screenshot_1714549210](https://github.com/fleaflet/flutter_map/assets/11576431/077163b8-a38f-477c-af0c-07deff72ff76) | ![Screenshot_1714555249](https://github.com/fleaflet/flutter_map/assets/11576431/a010cfb6-cbc8-4fe0-8fe5-6cc0b585b82b) |
