### PR TITLE
feat: optimization of "solid" polygon/polyline display

### DIFF
--- a/lib/src/layer/misc/line_patterns/pixel_hiker.dart
+++ b/lib/src/layer/misc/line_patterns/pixel_hiker.dart
@@ -250,12 +250,24 @@ class SolidPixelHiker extends _PixelHiker {
           patternFit: PatternFit.none,
         );
 
-  /// Returns all visible segments.
-  List<VisibleSegment> getAllVisibleSegments() {
-    final List<VisibleSegment> result = [];
-
+  /// Adds all visible segments to [paths].
+  void addAllVisibleSegments(final List<Path> paths) {
     if (offsets.length < 2) {
-      return result;
+      return;
+    }
+
+    double? latestX;
+    double? latestY;
+    List<Offset> polygons = [];
+
+    void addPolygons() {
+      if (polygons.isEmpty) {
+        return;
+      }
+      for (final path in paths) {
+        path.addPolygon(polygons, false);
+      }
+      polygons = [];
     }
 
     for (int i = 0; i < offsets.length - 1 + (closePath ? 1 : 0); i++) {
@@ -264,12 +276,19 @@ class SolidPixelHiker extends _PixelHiker {
         offsets[(i + 1) % offsets.length],
         canvasSize,
       );
-      if (visibleSegment != null) {
-        result.add(visibleSegment);
+      if (visibleSegment == null) {
+        continue;
       }
+      if (latestX != visibleSegment.begin.dx ||
+          latestY != visibleSegment.begin.dy) {
+        addPolygons();
+        polygons.add(visibleSegment.begin);
+      }
+      polygons.add(visibleSegment.end);
+      latestX = visibleSegment.end.dx;
+      latestY = visibleSegment.end.dy;
     }
-
-    return result;
+    addPolygons();
   }
 
   @override

--- a/lib/src/layer/misc/line_patterns/pixel_hiker.dart
+++ b/lib/src/layer/misc/line_patterns/pixel_hiker.dart
@@ -13,6 +13,7 @@ class DottedPixelHiker extends _PixelHiker {
     required super.closePath,
     required super.canvasSize,
     required super.patternFit,
+    required super.strokeWidth,
     required double stepLength,
   }) : super(segmentValues: [stepLength]);
 
@@ -25,7 +26,7 @@ class DottedPixelHiker extends _PixelHiker {
     }
 
     void addVisibleOffset(final Offset offset) {
-      if (VisibleSegment.isVisible(offset, canvasSize)) {
+      if (VisibleSegment.isVisible(offset, canvasSize, strokeWidth)) {
         result.add(offset);
       }
     }
@@ -69,8 +70,8 @@ class DottedPixelHiker extends _PixelHiker {
   ///
   /// Most important method of the class.
   List<Offset>? _getVisibleDotList(Offset offset0, Offset offset1) {
-    final VisibleSegment? visibleSegment =
-        VisibleSegment.getVisibleSegment(offset0, offset1, canvasSize);
+    final VisibleSegment? visibleSegment = VisibleSegment.getVisibleSegment(
+        offset0, offset1, canvasSize, strokeWidth);
     if (visibleSegment == null) {
       addDistance(getDistance(offset0, offset1));
       return null;
@@ -131,6 +132,7 @@ class DashedPixelHiker extends _PixelHiker {
     required super.canvasSize,
     required super.segmentValues,
     required super.patternFit,
+    required super.strokeWidth,
   });
 
   /// Returns all visible segments.
@@ -155,7 +157,7 @@ class DashedPixelHiker extends _PixelHiker {
     if (_segmentIndex.isOdd) {
       if (patternFit == PatternFit.appendDot) {
         if (!closePath) {
-          if (VisibleSegment.isVisible(offsets.last, canvasSize)) {
+          if (VisibleSegment.isVisible(offsets.last, canvasSize, strokeWidth)) {
             result.add(VisibleSegment(offsets.last, offsets.last));
           }
         }
@@ -187,10 +189,7 @@ class DashedPixelHiker extends _PixelHiker {
     final Offset offset1,
   ) {
     final VisibleSegment? visibleSegment = VisibleSegment.getVisibleSegment(
-      offset0,
-      offset1,
-      canvasSize,
-    );
+        offset0, offset1, canvasSize, strokeWidth);
     if (visibleSegment == null) {
       addDistance(getDistance(offset0, offset1));
       return null;
@@ -257,6 +256,7 @@ class SolidPixelHiker extends _PixelHiker {
     required super.offsets,
     required super.closePath,
     required super.canvasSize,
+    required super.strokeWidth,
   }) : super(
           segmentValues: [],
           patternFit: PatternFit.none,
@@ -287,6 +287,7 @@ class SolidPixelHiker extends _PixelHiker {
         offsets[i],
         offsets[(i + 1) % offsets.length],
         canvasSize,
+        strokeWidth,
       );
       if (visibleSegment == null) {
         continue;
@@ -315,6 +316,7 @@ sealed class _PixelHiker {
     required this.closePath,
     required this.canvasSize,
     required this.patternFit,
+    required this.strokeWidth,
   }) {
     _polylinePixelDistance = _getPolylinePixelDistance();
     _init();
@@ -333,6 +335,7 @@ sealed class _PixelHiker {
   final List<double> segmentValues;
   final Size canvasSize;
   final PatternFit patternFit;
+  final double strokeWidth;
 
   /// Factor to be used on offset distances.
   late final double _factor;

--- a/lib/src/layer/misc/line_patterns/visible_segment.dart
+++ b/lib/src/layer/misc/line_patterns/visible_segment.dart
@@ -39,23 +39,28 @@ class VisibleSegment {
     return code;
   }
 
-  /// Returns true if the [offset] is inside the [canvasSize].
-  static bool isVisible(Offset offset, Size canvasSize) =>
+  /// Returns true if the [offset] is inside the [canvasSize] + [strokeWidth].
+  static bool isVisible(Offset offset, Size canvasSize, double strokeWidth) =>
       _computeOutCode(
-          offset.dx, offset.dy, 0, 0, canvasSize.width, canvasSize.height) ==
+          offset.dx,
+          offset.dy,
+          -strokeWidth / 2,
+          -strokeWidth / 2,
+          canvasSize.width + strokeWidth / 2,
+          canvasSize.height + strokeWidth / 2) ==
       _inside;
 
   /// Clips a line segment to a rectangular area (canvas).
   ///
   /// Returns null if the segment is invisible.
   static VisibleSegment? getVisibleSegment(
-      Offset p0, Offset p1, Size canvasSize) {
+      Offset p0, Offset p1, Size canvasSize, double strokeWidth) {
     // Function to compute the outCode for a point relative to the canvas
 
-    const double xMin = 0;
-    const double yMin = 0;
-    final double xMax = canvasSize.width;
-    final double yMax = canvasSize.height;
+    final double xMin = -strokeWidth / 2;
+    final double yMin = -strokeWidth / 2;
+    final double xMax = canvasSize.width + strokeWidth / 2;
+    final double yMax = canvasSize.height + strokeWidth / 2;
 
     double x0 = p0.dx;
     double y0 = p0.dy;

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -324,10 +324,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
         closePath: true,
         canvasSize: canvasSize,
       );
-      for (final visibleSegment in hiker.getAllVisibleSegments()) {
-        path.moveTo(visibleSegment.begin.dx, visibleSegment.begin.dy);
-        path.lineTo(visibleSegment.end.dx, visibleSegment.end.dy);
-      }
+      hiker.addAllVisibleSegments([path]);
     } else if (isDotted) {
       final DottedPixelHiker hiker = DottedPixelHiker(
         offsets: offsets,

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -215,6 +215,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
           size,
           canvas,
           _getBorderPaint(polygon),
+          polygon.borderStrokeWidth,
         );
       }
 
@@ -238,7 +239,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
 
         if (!polygon.disableHolesBorder && polygon.borderStrokeWidth > 0.0) {
           _addHoleBordersToPath(borderPath, polygon, holeOffsetsList, size,
-              canvas, _getBorderPaint(polygon));
+              canvas, _getBorderPaint(polygon), polygon.borderStrokeWidth);
         }
       }
 
@@ -314,6 +315,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
     Size canvasSize,
     Canvas canvas,
     Paint paint,
+    double strokeWidth,
   ) {
     final isSolid = polygon.pattern == const StrokePattern.solid();
     final isDashed = polygon.pattern.segments != null;
@@ -323,6 +325,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
         offsets: offsets,
         closePath: true,
         canvasSize: canvasSize,
+        strokeWidth: strokeWidth,
       );
       hiker.addAllVisibleSegments([path]);
     } else if (isDotted) {
@@ -332,6 +335,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
         patternFit: polygon.pattern.patternFit!,
         closePath: true,
         canvasSize: canvasSize,
+        strokeWidth: strokeWidth,
       );
       for (final visibleDot in hiker.getAllVisibleDots()) {
         canvas.drawCircle(visibleDot, polygon.borderStrokeWidth / 2, paint);
@@ -343,6 +347,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
         patternFit: polygon.pattern.patternFit!,
         closePath: true,
         canvasSize: canvasSize,
+        strokeWidth: strokeWidth,
       );
 
       for (final visibleSegment in hiker.getAllVisibleSegments()) {
@@ -359,6 +364,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
     Size canvasSize,
     Canvas canvas,
     Paint paint,
+    double strokeWidth,
   ) {
     for (final offsets in holeOffsetsList) {
       _addBorderToPath(
@@ -368,6 +374,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter {
         canvasSize,
         canvas,
         paint,
+        strokeWidth,
       );
     }
   }

--- a/lib/src/layer/polyline_layer/painter.dart
+++ b/lib/src/layer/polyline_layer/painter.dart
@@ -214,12 +214,7 @@ class _PolylinePainter<R extends Object> extends CustomPainter {
           closePath: false,
           canvasSize: size,
         );
-        for (final visibleSegment in hiker.getAllVisibleSegments()) {
-          for (final path in paths) {
-            path.moveTo(visibleSegment.begin.dx, visibleSegment.begin.dy);
-            path.lineTo(visibleSegment.end.dx, visibleSegment.end.dy);
-          }
-        }
+        hiker.addAllVisibleSegments(paths);
       } else if (isDotted) {
         final DottedPixelHiker hiker = DottedPixelHiker(
           offsets: offsets,

--- a/lib/src/layer/polyline_layer/painter.dart
+++ b/lib/src/layer/polyline_layer/painter.dart
@@ -147,6 +147,9 @@ class _PolylinePainter<R extends Object> extends CustomPainter {
       needsLayerSaving = polyline.color.opacity < 1.0 ||
           (polyline.gradientColors?.any((c) => c.opacity < 1.0) ?? false);
 
+      // strokeWidth, or strokeWidth + borderWidth if relevant.
+      late double largestStrokeWidth;
+
       late final double strokeWidth;
       if (polyline.useStrokeWidthInMeter) {
         strokeWidth = _metersToStrokeWidth(
@@ -158,6 +161,7 @@ class _PolylinePainter<R extends Object> extends CustomPainter {
       } else {
         strokeWidth = polyline.strokeWidth;
       }
+      largestStrokeWidth = strokeWidth;
 
       final isSolid = polyline.pattern == const StrokePattern.solid();
       final isDashed = polyline.pattern.segments != null;
@@ -182,6 +186,7 @@ class _PolylinePainter<R extends Object> extends CustomPainter {
         // Outlined lines are drawn by drawing a thicker path underneath, then
         // stenciling the middle (in case the line fill is transparent), and
         // finally drawing the line fill.
+        largestStrokeWidth = strokeWidth + polyline.borderStrokeWidth;
         borderPaint = Paint()
           ..color = polyline.borderColor
           ..strokeWidth = strokeWidth + polyline.borderStrokeWidth
@@ -213,6 +218,7 @@ class _PolylinePainter<R extends Object> extends CustomPainter {
           offsets: offsets,
           closePath: false,
           canvasSize: size,
+          strokeWidth: largestStrokeWidth,
         );
         hiker.addAllVisibleSegments(paths);
       } else if (isDotted) {
@@ -222,6 +228,7 @@ class _PolylinePainter<R extends Object> extends CustomPainter {
           patternFit: polyline.pattern.patternFit!,
           closePath: false,
           canvasSize: size,
+          strokeWidth: largestStrokeWidth,
         );
 
         final List<double> radii = [];
@@ -244,6 +251,7 @@ class _PolylinePainter<R extends Object> extends CustomPainter {
           patternFit: polyline.pattern.patternFit!,
           closePath: false,
           canvasSize: size,
+          strokeWidth: largestStrokeWidth,
         );
 
         for (final visibleSegment in hiker.getAllVisibleSegments()) {


### PR DESCRIPTION
### What
Optimized the algorithm for "solid" polygon/polyline display.
The trick is to use `addPolygon` instead of numerous `moveTo`/`lineTo`. It looked like removing redundant `moveTo`s was quite effective, too.

Following are some perf tests. We're getting closer to the old solid algorithm (that we had to dismiss because of bugs in 25+ zooms).
| x | old solid algo | new solid algo | current PR |
| -- | -- | -- | -- |
| Raster (ms) | 206.2 | 578.9 | 208.6 |
| UI (ms) | 42.1 | 53.2 | 49.6 |




### Impacted files
* `polygon_layer/painter.dart`: minor refactoring
* `polyline_layer/painter.dart`: minor refactoring
* `pixel_hiker.dart`: optimized the "solid pixel hiker" relying on `addPolygon` instead of numerous `moveTo`/`lineTo`

### Screenshots
![Screenshot_20240507_160145](https://github.com/fleaflet/flutter_map/assets/11576431/3c43c761-2148-4e6f-ba5c-eb9081d9077c)
