### PR TITLE
fix: `PolylineLayer` throws exception: "The west longitude can't be smaller than the east longitude"

### DIFF
--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -6,6 +6,18 @@ import 'package:vector_math/vector_math_64.dart';
 /// Data structure representing rectangular bounding box constrained by its
 /// northwest and southeast corners
 class LatLngBounds {
+  /// minimum latitude value, south
+  static const double minLatitude = -90;
+
+  /// maximum latitude value, north
+  static const double maxLatitude = 90;
+
+  /// minimum longitude value, west
+  static const double minLongitude = -180;
+
+  /// maximum longitude value, east
+  static const double maxLongitude = 180;
+
   /// The latitude north edge of the bounds
   double north;
 
@@ -61,21 +73,21 @@ class LatLngBounds {
     required this.south,
     required this.east,
     required this.west,
-  })  : assert(
-            north <= 90, "The north latitude can't be bigger than 90: $north"),
-        assert(north >= -90,
+  })  : assert(north <= maxLatitude,
+            "The north latitude can't be bigger than 90: $north"),
+        assert(north >= minLatitude,
             "The north latitude can't be smaller than -90: $north"),
-        assert(
-            south <= 90, "The south latitude can't be bigger than 90: $south"),
-        assert(south >= -90,
+        assert(south <= maxLatitude,
+            "The south latitude can't be bigger than 90: $south"),
+        assert(south >= minLatitude,
             "The south latitude can't be smaller than -90: $south"),
-        assert(
-            east <= 180, "The east longitude can't be bigger than 180: $east"),
-        assert(east >= -180,
+        assert(east <= maxLongitude,
+            "The east longitude can't be bigger than 180: $east"),
+        assert(east >= minLongitude,
             "The east longitude can't be smaller than -180: $east"),
-        assert(
-            west <= 180, "The west longitude can't be bigger than 180: $west"),
-        assert(west >= -180,
+        assert(west <= maxLongitude,
+            "The west longitude can't be bigger than 180: $west"),
+        assert(west >= minLongitude,
             "The west longitude can't be smaller than -180: $west"),
         assert(north >= south,
             "The north latitude can't be smaller than the south latitude"),
@@ -90,10 +102,10 @@ class LatLngBounds {
       'LatLngBounds cannot be created with an empty List of LatLng',
     );
     // initialize bounds with max values.
-    double minX = 180;
-    double maxX = -180;
-    double minY = 90;
-    double maxY = -90;
+    double minX = maxLongitude;
+    double maxX = minLongitude;
+    double minY = maxLatitude;
+    double maxY = minLatitude;
     // find the largest and smallest latitude and longitude
     for (final point in points) {
       if (point.longitude < minX) minX = point.longitude;
@@ -112,20 +124,20 @@ class LatLngBounds {
   /// Expands bounding box by [latLng] coordinate point. This method mutates
   /// the bounds object on which it is called.
   void extend(LatLng latLng) {
-    north = min(90, max(north, latLng.latitude));
-    south = max(-90, min(south, latLng.latitude));
-    east = min(180, max(east, latLng.longitude));
-    west = max(-180, min(west, latLng.longitude));
+    north = min(maxLatitude, max(north, latLng.latitude));
+    south = max(minLatitude, min(south, latLng.latitude));
+    east = min(maxLongitude, max(east, latLng.longitude));
+    west = max(minLongitude, min(west, latLng.longitude));
   }
 
   /// Expands bounding box by other [bounds] object. If provided [bounds] object
   /// is smaller than current one, it is not shrunk. This method mutates
   /// the bounds object on which it is called.
   void extendBounds(LatLngBounds bounds) {
-    north = min(90, max(north, bounds.north));
-    south = max(-90, min(south, bounds.south));
-    east = min(180, max(east, bounds.east));
-    west = max(-180, min(west, bounds.west));
+    north = min(maxLatitude, max(north, bounds.north));
+    south = max(minLatitude, min(south, bounds.south));
+    east = min(maxLongitude, max(east, bounds.east));
+    west = max(minLongitude, min(west, bounds.west));
   }
 
   /// Obtain coordinates of southwest corner of the bounds.

--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -74,25 +74,31 @@ class LatLngBounds {
     required this.east,
     required this.west,
   })  : assert(north <= maxLatitude,
-            "The north latitude can't be bigger than 90: $north"),
+            "The north latitude can't be bigger than $maxLatitude: $north"),
         assert(north >= minLatitude,
-            "The north latitude can't be smaller than -90: $north"),
+            "The north latitude can't be smaller than $minLatitude: $north"),
         assert(south <= maxLatitude,
-            "The south latitude can't be bigger than 90: $south"),
+            "The south latitude can't be bigger than $maxLatitude: $south"),
         assert(south >= minLatitude,
-            "The south latitude can't be smaller than -90: $south"),
+            "The south latitude can't be smaller than $minLatitude: $south"),
         assert(east <= maxLongitude,
-            "The east longitude can't be bigger than 180: $east"),
+            "The east longitude can't be bigger than $maxLongitude: $east"),
         assert(east >= minLongitude,
-            "The east longitude can't be smaller than -180: $east"),
+            "The east longitude can't be smaller than $minLongitude: $east"),
         assert(west <= maxLongitude,
-            "The west longitude can't be bigger than 180: $west"),
+            "The west longitude can't be bigger than $maxLongitude: $west"),
         assert(west >= minLongitude,
-            "The west longitude can't be smaller than -180: $west"),
-        assert(north >= south,
-            "The north latitude can't be smaller than the south latitude"),
-        assert(east >= west,
-            "The west longitude can't be smaller than the east longitude");
+            "The west longitude can't be smaller than $minLongitude: $west"),
+        assert(
+          north >= south,
+          "The north latitude ($north) can't be smaller than the "
+          'south latitude ($south)',
+        ),
+        assert(
+          east >= west,
+          "The west longitude ($west) can't be smaller than the "
+          'east longitude ($east)',
+        );
 
   /// Create a new [LatLngBounds] from a list of [LatLng] points. This
   /// calculates the bounding box of the provided points.

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -170,9 +170,9 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>> {
     // the value cannot be greater or smaller than that
     final boundsAdjusted = LatLngBounds.unsafe(
       west: math.max(-180, bounds.west - margin),
-      east: math.min(90, bounds.east + margin),
+      east: math.min(180, bounds.east + margin),
       south: math.max(-90, bounds.south - margin),
-      north: math.min(180, bounds.north + margin),
+      north: math.min(90, bounds.north + margin),
     );
 
     // segment is visible

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -169,10 +169,10 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>> {
     // The min(-90), max(180), ... are used to get around the limits of LatLng
     // the value cannot be greater or smaller than that
     final boundsAdjusted = LatLngBounds.unsafe(
-      west: math.max(-180, bounds.west - margin),
-      east: math.min(180, bounds.east + margin),
-      south: math.max(-90, bounds.south - margin),
-      north: math.min(90, bounds.north + margin),
+      west: math.max(LatLngBounds.minLongitude, bounds.west - margin),
+      east: math.min(LatLngBounds.maxLongitude, bounds.east + margin),
+      south: math.max(LatLngBounds.minLatitude, bounds.south - margin),
+      north: math.min(LatLngBounds.maxLatitude, bounds.north + margin),
     );
 
     // segment is visible


### PR DESCRIPTION
Some linestrings caused the PolylineLayer to throw an assertion exception.
```console
Assertion failed: file:///Users/matthiaskoch/.pub-cache/git/flutter_map-930e8b60e125e630e3c85ab373c0ebb8e9b08d70/lib/src/geo/latlng_bounds.dart:82:16
east >= west
"The west longitude can't be smaller than the east longitude"

packages/flutter_map/src/geo/latlng_bounds.dart 82:28                             unsafe
packages/flutter_map/src/layer/polyline_layer/polyline_layer.dart 171:41          [_aggressivelyCullPolylines]
packages/flutter_map/src/layer/polyline_layer/polyline_layer.dart 138:11          build
```

This bug was reported by borg_1of3 on discord: https://discord.com/channels/951867686378409984/1235305884620689558/1235305884620689558

The bug sneaked into the code base in https://github.com/fleaflet/flutter_map/pull/1834.