### PR TITLE
fix: remove deprecated members (for Flutter 3.22)

### DIFF
--- a/example/lib/pages/debouncing_tile_update_transformer.dart
+++ b/example/lib/pages/debouncing_tile_update_transformer.dart
@@ -70,7 +70,7 @@ class _DebouncingTileUpdateTransformerPageState
                   right: 16,
                   child: DecoratedBox(
                     decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.background,
+                      color: Theme.of(context).colorScheme.surface,
                       borderRadius: BorderRadius.circular(32),
                     ),
                     child: Padding(

--- a/example/lib/pages/polygon_perf_stress.dart
+++ b/example/lib/pages/polygon_perf_stress.dart
@@ -96,7 +96,7 @@ class _PolygonPerfStressPageState extends State<PolygonPerfStressPage> {
                       UnconstrainedBox(
                         child: Container(
                           decoration: BoxDecoration(
-                            color: Theme.of(context).colorScheme.background,
+                            color: Theme.of(context).colorScheme.surface,
                             borderRadius: BorderRadius.circular(32),
                           ),
                           padding: const EdgeInsets.symmetric(
@@ -125,7 +125,7 @@ class _PolygonPerfStressPageState extends State<PolygonPerfStressPage> {
                       UnconstrainedBox(
                         child: Container(
                           decoration: BoxDecoration(
-                            color: Theme.of(context).colorScheme.background,
+                            color: Theme.of(context).colorScheme.surface,
                             borderRadius: BorderRadius.circular(32),
                           ),
                           padding: const EdgeInsets.symmetric(

--- a/example/lib/widgets/drawer/floating_menu_button.dart
+++ b/example/lib/widgets/drawer/floating_menu_button.dart
@@ -11,7 +11,7 @@ class FloatingMenuButton extends StatelessWidget {
       child: SafeArea(
         child: Container(
           decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.background,
+            color: Theme.of(context).colorScheme.surface,
             borderRadius: BorderRadius.circular(999),
           ),
           padding: const EdgeInsets.all(8),

--- a/example/lib/widgets/number_of_items_slider.dart
+++ b/example/lib/widgets/number_of_items_slider.dart
@@ -24,7 +24,7 @@ class NumberOfItemsSlider extends StatelessWidget {
   Widget build(BuildContext context) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.background,
+        color: Theme.of(context).colorScheme.surface,
         borderRadius: BorderRadius.circular(32),
       ),
       child: Padding(

--- a/example/lib/widgets/simplification_tolerance_slider.dart
+++ b/example/lib/widgets/simplification_tolerance_slider.dart
@@ -14,7 +14,7 @@ class SimplificationToleranceSlider extends StatelessWidget {
   Widget build(BuildContext context) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.background,
+        color: Theme.of(context).colorScheme.surface,
         borderRadius: BorderRadius.circular(32),
       ),
       child: Padding(

--- a/lib/src/layer/attribution_layer/rich/widget.dart
+++ b/lib/src/layer/attribution_layer/rich/widget.dart
@@ -229,7 +229,7 @@ class _RichAttributionWidgetState extends State<RichAttributionWidget> {
               child: DecoratedBox(
                 decoration: BoxDecoration(
                   color: widget.popupBackgroundColor ??
-                      Theme.of(context).colorScheme.background,
+                      Theme.of(context).colorScheme.surface,
                   border: Border.all(width: 0, style: BorderStyle.none),
                   borderRadius: widget.popupBorderRadius ??
                       BorderRadius.only(

--- a/lib/src/layer/attribution_layer/simple.dart
+++ b/lib/src/layer/attribution_layer/simple.dart
@@ -41,7 +41,7 @@ class SimpleAttributionWidget extends StatelessWidget {
   Widget build(BuildContext context) => Align(
         alignment: alignment,
         child: ColoredBox(
-          color: backgroundColor ?? Theme.of(context).colorScheme.background,
+          color: backgroundColor ?? Theme.of(context).colorScheme.surface,
           child: GestureDetector(
             onTap: onTap,
             child: Padding(


### PR DESCRIPTION
> info: 'background' is deprecated and shouldn't be used. Use surface instead. This feature was deprecated after v3.18.0-0.1.pre. (deprecated_member_use at [flutter_map_example] lib\pages\polygon_perf_stress.dart:99)