### PR TITLE
chore(meta): start all PR workflow jobs simultaneously, use java 21

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,8 +1,7 @@
 name: "Branch & Fork CI/CD"
 on:
   push:
-    branches:
-      - '!master'
+    branches: [ '!master' ]
   pull_request:
   workflow_dispatch:
 
@@ -72,18 +71,17 @@ jobs:
   build-android:
     name: "Build Android Example App"
     runs-on: ubuntu-latest
-    needs: [ run-tests, analyse-code, score-package ]
     defaults:
       run:
         working-directory: ./example
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: Setup Java 17 Environment
+      - name: Setup Java 21 Environment
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
           cache: 'gradle'
       - name: Setup Flutter Environment
         uses: subosito/flutter-action@v2
@@ -102,7 +100,6 @@ jobs:
   build-windows:
     name: "Build Windows Example App"
     runs-on: windows-latest
-    needs: [ run-tests, analyse-code, score-package ]
     defaults:
       run:
         working-directory: ./example
@@ -129,7 +126,6 @@ jobs:
   build-web:
     name: "Build Web Example App"
     runs-on: ubuntu-latest
-    needs: [ run-tests, analyse-code, score-package ]
     defaults:
       run:
         working-directory: ./example

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -39,11 +39,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: Setup Java 17 Environment
+      - name: Setup Java 21 Environment
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
           cache: 'gradle'
       - name: Setup Flutter Environment
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
To speed up workflows for PRs even further, we can start all jobs simultaneously.
We can't do this for the master branch CI to ensure, delivered builds have succeeded testing.

Before: [6m 47s](https://github.com/fleaflet/flutter_map/actions/runs/9095809907/usage)
![image](https://github.com/fleaflet/flutter_map/assets/34318751/aa289124-e8c0-4492-8235-1845dfcd3894)

After: [5m 57s](https://github.com/fleaflet/flutter_map/actions/runs/9111371623/usage)
![image](https://github.com/fleaflet/flutter_map/assets/34318751/c3431419-d760-416c-bc80-235b202c0346)
