### PR TITLE
chore: prepare for v7 & v6.2.0 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,60 @@
 
 Please consider [donating](https://docs.fleaflet.dev/supporters#support-us) or [contributing](https://docs.fleaflet.dev/credits#contributing) if you're a fan of what we're doing and you'd like to support future releases!
 
-## [7.0.0-dev.1] - 2024/03/13
+This CHANGELOG does not include every commit and/or PR - it is a hand picked selection of the most important ones. For a full list of changes, please check the GitHub repository releases/tags.
 
-We've changed the format of the CHANGELOG, to make releases faster!  
-**Check the [latest GitHub release](https://github.com/fleaflet/flutter_map/releases/tag/v7.0.0-dev.1), where you can find an auto-generated list of all the latest commits.**
+## [7.0.0] - 2024/05/XX
+
+**"`onTap`-ish At Last!"**
+
+Contains the following user-affecting changes:
+
+- 🟢 Added interactivity & hit detection to `Polyline(Layer)`, `Polygon(Layer)`, and `Circle(Layer)` - [#1822](https://github.com/fleaflet/flutter_map/pull/1822) (for [#1740](https://github.com/fleaflet/flutter_map/issues/1740) and [#385](https://github.com/fleaflet/flutter_map/issues/385)), [#1728](https://github.com/fleaflet/flutter_map/pull/1728), [#1886](https://github.com/fleaflet/flutter_map/pull/1886)
+- 🟢 Made `FlutterMap.options` an optional parameter - [#1816](https://github.com/fleaflet/flutter_map/pull/1816)
+- 🟢 Added alternative (`Canvas.drawVertices`) render pathway for `PolygonLayer` - [#1800](https://github.com/fleaflet/flutter_map/pull/1800)
+- 🟢 Added `Scalebar` layer - [#1821](https://github.com/fleaflet/flutter_map/pull/1821)
+- 🟢 Added `TileUpdateTransformers.debounce` to debounce tile requests - [#1850](https://github.com/fleaflet/flutter_map/pull/1850) (replaces [#1840](https://github.com/fleaflet/flutter_map/pull/1840))
+- 🟢 Added static `Marker.computePixelAlignment` method to calculate absolute alignment - [#1847](https://github.com/fleaflet/flutter_map/pull/1847)
+- 🟢 Added `StrokePattern`, which supports `solid`, `dotted`, and `dashed` styles for `Polyline`s and the border of `Polygon`s - [#1855](https://github.com/fleaflet/flutter_map/pull/1855) (replaces [#1845](https://github.com/fleaflet/flutter_map/pull/1845)), [#1865](https://github.com/fleaflet/flutter_map/pull/1865), [#1871](https://github.com/fleaflet/flutter_map/pull/1871), [#1875](https://github.com/fleaflet/flutter_map/pull/1875), [#1876](https://github.com/fleaflet/flutter_map/pull/1876)
+- 🔴 Deprecated `MapOptions.applyPointerTranslucencyToLayers` - [#1822](https://github.com/fleaflet/flutter_map/pull/1822) for [#1740](https://github.com/fleaflet/flutter_map/issues/1740)
+
+Contains the following user-affecting bug fixes:
+
+- Fixed `NetworkTileProvider` poor performance and `ClientException`s/`SocketException`s on disposal - [#1742](https://github.com/fleaflet/flutter_map/pull/1742) for [#1761](https://github.com/fleaflet/flutter_map/issues/1761), [#1703](https://github.com/fleaflet/flutter_map/issues/1703), [#1698](https://github.com/fleaflet/flutter_map/issues/1698)
+- Fixed `Polygon/PolylineLayer` failing to move on changes - [#1825](https://github.com/fleaflet/flutter_map/pull/1825)
+- Prevented fatal crash due to infinite loop/memory leak at high zoom levels over some types of `Polygon` - [#1854](https://github.com/fleaflet/flutter_map/pull/1854) for [#1829](https://github.com/fleaflet/flutter_map/issues/1829)
+- Fixed `PolylineLayer` exception: "The west longitude can't be smaller than the east longitude" - [#1879](https://github.com/fleaflet/flutter_map/pull/1879)
+- Fixed `LatLngBounds.center` to work across world bounds - [#1860](https://github.com/fleaflet/flutter_map/pull/1860)
+
+Contains the following user-affecting performance improvements:
+
+- Added `Polyline` and `Polygon` simplification, and enhanced `Polyline` culling algorithm to work within the same `Polyline` - [#1704](https://github.com/fleaflet/flutter_map/pull/1704), [#1795](https://github.com/fleaflet/flutter_map/pull/1795), [#1805](https://github.com/fleaflet/flutter_map/pull/1805), [#1812](https://github.com/fleaflet/flutter_map/pull/1812)
+- Cached projection of `Polygon` points & improved CRS internals - [#1801](https://github.com/fleaflet/flutter_map/pull/1801)
+- Fixed `PolygonLayer` bundled drawing system - [#1800](https://github.com/fleaflet/flutter_map/pull/1800)
+- Other miscellaneous generic performance enhancements across the board, and addition of stress tests to example application
+
+Contains the following important internal changes (does not include changes to the example app, meta changes to the repo/org configuration, or minor changes):
+
+- Merged `MapInternalController` & `MapControllerImpl`, and removed "FlutterMap" prefix from some members - [#1738](https://github.com/fleaflet/flutter_map/pull/1738)
+- Made `LatLngBounds` mutable - [#1834](https://github.com/fleaflet/flutter_map/pull/1834)
+
+Many thanks to these contributors (in no particular order):
+
+- @androidseb
+- @ignatz
+- @Alexays
+- @ReinisSprogis
+- @gnassro
+- @monsieurtanuki
+- ... and all the maintainers
+
+## [6.2.0] - 2024/05/XX
+
+> If possible, prefer to update directly to v7. This version is provided only to enable Flutter 3.22 compatibility without requiring a breaking change.
+
+Contains the following user-affecting changes:
+
+- Added support for Flutter 2.22 - [#1883](https://github.com/fleaflet/flutter_map/pull/1883)
 
 ## [6.1.0] - 2023/12/02
 
@@ -34,6 +84,7 @@ Many thanks to these contributors (in no particular order):
 - @ignatz
 - @amal-stack
 - @Robbendebiene
+- @leiflinse-trivector
 - ... and all the maintainers
 
 And an additional special thanks to @ignatz for investing so much of their time into this project recently - we appreciate it!

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
     sdk: flutter
   flutter_map:
   flutter_map_cancellable_tile_provider:
-  flutter_map_geojson: ^1.0.6
-  http: ^1.2.0
-  latlong2: ^0.9.0
+  flutter_map_geojson: ^1.0.8
+  http: ^1.2.1
+  latlong2: ^0.9.1
   proj4dart: ^2.1.0
-  shared_preferences: ^2.2.2
-  url_launcher: ^6.2.4
+  shared_preferences: ^2.2.3
+  url_launcher: ^6.2.6
   url_strategy: ^0.2.0
   vector_math: ^2.1.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_map
 description: A versatile mapping package for Flutter, that's simple and easy to learn, yet completely customizable and configurable
-version: 7.0.0-dev.1
+version: 7.0.0
 
 repository: https://github.com/fleaflet/flutter_map
 issue_tracker: https://github.com/fleaflet/flutter_map/issues
@@ -26,25 +26,25 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  async: ^2.9.0
-  collection: ^1.17.1
+  async: ^2.11.0
+  collection: ^1.18.0
   dart_earcut: ^1.1.0
   flutter:
     sdk: flutter
-  http: ^1.0.0
-  latlong2: ^0.9.0
-  logger: ^2.0.1
-  meta: ^1.9.1
+  http: ^1.2.1
+  latlong2: ^0.9.1
+  logger: ^2.3.0
+  meta: ^1.12.0
   polylabel: ^1.0.1
   proj4dart: ^2.1.0
-  vector_math: ^2.1.2
+  vector_math: ^2.1.4
 
 dev_dependencies:
   flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
-  mocktail: ^1.0.1
-  test: ^1.24.3
+  mocktail: ^1.0.3
+  test: ^1.25.0
 
 flutter:
   assets:


### PR DESCRIPTION
v6.2.0 will be a cherry pick of 4f6b524791b851363355e8577fda8e92a80051ba, plus dependency upgrades and necessary pubspec version changes only - these will not be committed.