### PR TITLE
feat: implement efficient(-ish) change detection for `PolygonLayer` & `PolylineLayer`

### DIFF
--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -20,6 +20,8 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
+  final _points = <LatLng>[];
+
   @override
   void initState() {
     super.initState();
@@ -42,9 +44,27 @@ class _HomePageState extends State<HomePage> {
                   const LatLng(90, 180),
                 ),
               ),
+              onTap: (_, pos) => setState(() => _points.add(pos)),
             ),
             children: [
               openStreetMapTileLayer,
+              PolygonLayer(
+                polygons: [
+                  if (_points.length >= 3)
+                    Polygon(
+                      points: List.from(_points),
+                      color: Colors.red,
+                    ),
+                  Polygon(
+                    points: [
+                      LatLng(51.43527063287209, -0.6749922034878753),
+                      LatLng(51.489148544830705, -0.668754861138558),
+                      LatLng(51.382785157810176, -0.5524552832866705),
+                    ],
+                    color: Colors.blue,
+                  ),
+                ],
+              ),
               RichAttributionWidget(
                 popupInitialDisplayDuration: const Duration(seconds: 5),
                 animationConfig: const ScaleRAWA(),

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -52,7 +52,7 @@ class _HomePageState extends State<HomePage> {
                 polygons: [
                   if (_points.length >= 3)
                     Polygon(
-                      points: List.from(_points),
+                      points: _points,
                       color: Colors.red,
                     ),
                   Polygon(
@@ -62,6 +62,14 @@ class _HomePageState extends State<HomePage> {
                       LatLng(51.382785157810176, -0.5524552832866705),
                     ],
                     color: Colors.blue,
+                  ),
+                  Polygon(
+                    points: [
+                      LatLng(51.43527063287209, -0.6749922034878753),
+                      LatLng(51.489148544830705, -0.668754861138558),
+                      LatLng(51.382785157810176, -0.5524552832866705),
+                    ],
+                    color: Colors.red,
                   ),
                 ],
               ),

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -20,8 +20,6 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  final _points = <LatLng>[];
-
   @override
   void initState() {
     super.initState();
@@ -44,35 +42,9 @@ class _HomePageState extends State<HomePage> {
                   const LatLng(90, 180),
                 ),
               ),
-              onTap: (_, pos) => setState(() => _points.add(pos)),
             ),
             children: [
               openStreetMapTileLayer,
-              PolygonLayer(
-                polygons: [
-                  if (_points.length >= 3)
-                    Polygon(
-                      points: _points,
-                      color: Colors.red,
-                    ),
-                  Polygon(
-                    points: [
-                      LatLng(51.43527063287209, -0.6749922034878753),
-                      LatLng(51.489148544830705, -0.668754861138558),
-                      LatLng(51.382785157810176, -0.5524552832866705),
-                    ],
-                    color: Colors.blue,
-                  ),
-                  Polygon(
-                    points: [
-                      LatLng(51.43527063287209, -0.6749922034878753),
-                      LatLng(51.489148544830705, -0.668754861138558),
-                      LatLng(51.382785157810176, -0.5524552832866705),
-                    ],
-                    color: Colors.red,
-                  ),
-                ],
-              ),
               RichAttributionWidget(
                 popupInitialDisplayDuration: const Duration(seconds: 5),
                 animationConfig: const ScaleRAWA(),

--- a/example/lib/pages/polygon_perf_stress.dart
+++ b/example/lib/pages/polygon_perf_stress.dart
@@ -19,7 +19,7 @@ class PolygonPerfStressPage extends StatefulWidget {
 }
 
 class _PolygonPerfStressPageState extends State<PolygonPerfStressPage> {
-  double simplificationTolerance = 0.5;
+  double simplificationTolerance = 0.3;
   bool useAltRendering = true;
   double borderThickness = 1;
 

--- a/example/lib/pages/polygon_perf_stress.dart
+++ b/example/lib/pages/polygon_perf_stress.dart
@@ -63,15 +63,13 @@ class _PolygonPerfStressPageState extends State<PolygonPerfStressPage> {
               openStreetMapTileLayer,
               FutureBuilder(
                 future: geoJsonParser,
-                builder: (context, geoJsonParser) =>
-                    geoJsonParser.connectionState != ConnectionState.done ||
-                            geoJsonParser.data == null
-                        ? const SizedBox.shrink()
-                        : PolygonLayer(
-                            polygons: geoJsonParser.data!.polygons,
-                            useAltRendering: useAltRendering,
-                            simplificationTolerance: simplificationTolerance,
-                          ),
+                builder: (context, geoJsonParser) => geoJsonParser.data == null
+                    ? const SizedBox.shrink()
+                    : PolygonLayer(
+                        polygons: geoJsonParser.data!.polygons,
+                        useAltRendering: useAltRendering,
+                        simplificationTolerance: simplificationTolerance,
+                      ),
               ),
             ],
           ),

--- a/example/lib/pages/polyline_perf_stress.dart
+++ b/example/lib/pages/polyline_perf_stress.dart
@@ -19,7 +19,7 @@ class PolylinePerfStressPage extends StatefulWidget {
 }
 
 class _PolylinePerfStressPageState extends State<PolylinePerfStressPage> {
-  double simplificationTolerance = 0.5;
+  double simplificationTolerance = 0.3;
 
   final _randomWalk = [const LatLng(44.861294, 13.845086)];
 

--- a/lib/src/layer/circle_layer/circle_marker.dart
+++ b/lib/src/layer/circle_layer/circle_marker.dart
@@ -3,7 +3,7 @@ part of 'circle_layer.dart';
 /// Immutable marker options for [CircleMarker]. Circle markers are a more
 /// simple and performant way to draw markers as the regular [Marker]
 @immutable
-base class CircleMarker<R extends Object> extends HitDetectableElement<R> {
+class CircleMarker<R extends Object> with HitDetectableElement<R> {
   /// An optional [Key] for the [CircleMarker].
   /// This key is not used internally.
   final Key? key;
@@ -27,6 +27,9 @@ base class CircleMarker<R extends Object> extends HitDetectableElement<R> {
   /// Set to true if the radius should use the unit meters.
   final bool useRadiusInMeter;
 
+  @override
+  final R? hitValue;
+
   /// Constructor to create a new [CircleMarker] object
   const CircleMarker({
     required this.point,
@@ -36,6 +39,6 @@ base class CircleMarker<R extends Object> extends HitDetectableElement<R> {
     this.color = const Color(0xFF00FF00),
     this.borderStrokeWidth = 0.0,
     this.borderColor = const Color(0xFFFFFF00),
-    super.hitValue,
+    this.hitValue,
   });
 }

--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -23,7 +23,8 @@ part 'projected_polygon.dart';
 
 /// A polygon layer for [FlutterMap].
 @immutable
-base class PolygonLayer<R extends Object> extends PSSupportedWidget {
+base class PolygonLayer<R extends Object>
+    extends ProjectionSimplificationManagementSupportedWidget {
   /// [Polygon]s to draw
   final List<Polygon<R>> polygons;
 

--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -71,6 +71,22 @@ class PolygonLayer<R extends Object> extends StatefulWidget {
   /// {@macro fm.lhn.layerHitNotifier.usage}
   final LayerHitNotifier<R>? hitNotifier;
 
+  /// Whether to apply the auto-update algorithm to re-paint the necessary
+  /// [Polygon]s when they change
+  ///
+  /// It is recommended to leave this `true`, as default, otherwise changes to
+  /// child polygons may not update. It will detect which polygons have changed,
+  /// and only 'update' (re-project and re-simplify) those that are necessary.
+  ///
+  /// However, where there are a large number of polygons, the majority (or more)
+  /// of which change at the same time, then it is recommended to set this
+  /// `false`. This will avoid a large unnecessary loop to detect changes, and
+  /// is likely to improve performance on state changes. If `false`, then the
+  /// layer will need to be manually rebuilt from scratch using new [Key]s
+  /// whenever necessary. Do not use a [UniqueKey] : this will cause the entire
+  /// widget to reset and rebuild every time the map camera changes.
+  final bool useDynamicUpdate;
+
   /// Create a new [PolygonLayer] for the [FlutterMap] widget.
   const PolygonLayer({
     super.key,
@@ -81,6 +97,7 @@ class PolygonLayer<R extends Object> extends StatefulWidget {
     this.polygonLabels = true,
     this.drawLabelsLast = false,
     this.hitNotifier,
+    this.useDynamicUpdate = true,
   }) : assert(
           simplificationTolerance >= 0,
           'simplificationTolerance cannot be negative: $simplificationTolerance',
@@ -100,6 +117,8 @@ class _PolygonLayerState<R extends Object> extends State<PolygonLayer<R>> {
   @override
   void didUpdateWidget(PolygonLayer<R> oldWidget) {
     super.didUpdateWidget(oldWidget);
+
+    if (!widget.useDynamicUpdate) return;
 
     final camera = MapCamera.of(context);
 

--- a/lib/src/layer/polygon_layer/projected_polygon.dart
+++ b/lib/src/layer/polygon_layer/projected_polygon.dart
@@ -1,7 +1,7 @@
 part of 'polygon_layer.dart';
 
 @immutable
-base class _ProjectedPolygon<R extends Object> extends HitDetectableElement<R> {
+class _ProjectedPolygon<R extends Object> with HitDetectableElement<R> {
   final Polygon<R> polygon;
   final List<DoublePoint> points;
   final List<List<DoublePoint>> holePoints;

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -19,7 +19,8 @@ part 'projected_polyline.dart';
 
 /// A [Polyline] (aka. LineString) layer for [FlutterMap].
 @immutable
-base class PolylineLayer<R extends Object> extends PSSupportedWidget {
+base class PolylineLayer<R extends Object>
+    extends ProjectionSimplificationManagementSupportedWidget {
   /// [Polyline]s to draw
   final List<Polyline<R>> polylines;
 

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -6,6 +6,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/layer/shared/layer_interactivity/internal_hit_detectable.dart';
+import 'package:flutter_map/src/layer/shared/layer_projection_simplification/state.dart';
+import 'package:flutter_map/src/layer/shared/layer_projection_simplification/widget.dart';
 import 'package:flutter_map/src/layer/shared/line_patterns/pixel_hiker.dart';
 import 'package:flutter_map/src/misc/offsets.dart';
 import 'package:flutter_map/src/misc/simplify.dart';
@@ -17,7 +19,7 @@ part 'projected_polyline.dart';
 
 /// A [Polyline] (aka. LineString) layer for [FlutterMap].
 @immutable
-class PolylineLayer<R extends Object> extends StatefulWidget {
+base class PolylineLayer<R extends Object> extends PSSupportedWidget {
   /// [Polyline]s to draw
   final List<Polyline<R>> polylines;
 
@@ -29,16 +31,6 @@ class PolylineLayer<R extends Object> extends StatefulWidget {
   ///
   /// Defaults to 10. Set to `null` to disable culling.
   final double? cullingMargin;
-
-  /// Distance between two neighboring polyline points, in logical pixels scaled
-  /// to floored zoom
-  ///
-  /// Increasing this value results in points further apart being collapsed and
-  /// thus more simplified polylines. Higher values improve performance at the
-  /// cost of visual fidelity and vice versa.
-  ///
-  /// Defaults to 0.4. Set to 0 to disable simplification.
-  final double simplificationTolerance;
 
   /// {@macro fm.lhn.layerHitNotifier.usage}
   final LayerHitNotifier<R>? hitNotifier;
@@ -57,83 +49,59 @@ class PolylineLayer<R extends Object> extends StatefulWidget {
     super.key,
     required this.polylines,
     this.cullingMargin = 10,
-    this.simplificationTolerance = 0.4,
     this.hitNotifier,
     this.minimumHitbox = 10,
-  }) : assert(
-          simplificationTolerance >= 0,
-          'simplificationTolerance cannot be negative: $simplificationTolerance',
-        );
+    super.useDynamicUpdate,
+    super.simplificationTolerance,
+  }) : super();
 
   @override
   State<PolylineLayer<R>> createState() => _PolylineLayerState<R>();
 }
 
-class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>> {
-  List<_ProjectedPolyline<R>>? _cachedProjectedPolylines;
-  final _cachedSimplifiedPolylines = <int, List<_ProjectedPolyline<R>>>{};
-
-  double? _devicePixelRatio;
+class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>>
+    with
+        ProjectionSimplificationManagement<_ProjectedPolyline<R>, Polyline<R>,
+            PolylineLayer<R>> {
+  @override
+  _ProjectedPolyline<R> projectElement({
+    required Projection projection,
+    required Polyline<R> element,
+  }) =>
+      _ProjectedPolyline._fromPolyline(projection, element);
 
   @override
-  void didUpdateWidget(PolylineLayer<R> oldWidget) {
-    super.didUpdateWidget(oldWidget);
+  _ProjectedPolyline<R> simplifyProjectedElement({
+    required _ProjectedPolyline<R> projectedElement,
+    required double tolerance,
+  }) =>
+      _ProjectedPolyline._(
+        polyline: projectedElement.polyline,
+        points: simplifyPoints(
+          points: projectedElement.points,
+          tolerance: tolerance,
+          highQuality: true,
+        ),
+      );
 
-    if (!listEquals(oldWidget.polylines, widget.polylines)) {
-      // If the polylines have changed, then both the projections and the
-      // projection-dependendent simplifications must be invalidated
-      _cachedProjectedPolylines = null;
-      _cachedSimplifiedPolylines.clear();
-    } else if (oldWidget.simplificationTolerance !=
-        widget.simplificationTolerance) {
-      // If only the simplification tolerance has changed, this does not affect
-      // the projections (as that is done before simplification), so only
-      // invalidate the simplifications
-      _cachedSimplifiedPolylines.clear();
-    }
-  }
+  @override
+  Iterable<Polyline<R>> getElements(PolylineLayer<R> widget) =>
+      widget.polylines;
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
+
     final camera = MapCamera.of(context);
 
-    final projected = _cachedProjectedPolylines ??= List.generate(
-      widget.polylines.length,
-      (i) => _ProjectedPolyline._fromPolyline(
-        camera.crs.projection,
-        widget.polylines[i],
-      ),
-      growable: false,
-    );
-
-    late final List<_ProjectedPolyline<R>> simplified;
-    if (widget.simplificationTolerance == 0) {
-      simplified = projected;
-    } else {
-      // If the DPR has changed, invalidate the simplification cache
-      final newDPR = MediaQuery.devicePixelRatioOf(context);
-      if (newDPR != _devicePixelRatio) {
-        _devicePixelRatio = newDPR;
-        _cachedSimplifiedPolylines.clear();
-      }
-
-      simplified = _cachedSimplifiedPolylines[camera.zoom.floor()] ??=
-          _computeZoomLevelSimplification(
-        camera: camera,
-        polylines: projected,
-        pixelTolerance: widget.simplificationTolerance,
-        devicePixelRatio: newDPR,
-      );
-    }
-
     final culled = widget.cullingMargin == null
-        ? simplified
+        ? simplifiedElements.toList()
         : _aggressivelyCullPolylines(
             projection: camera.crs.projection,
-            polylines: simplified,
+            polylines: simplifiedElements,
             camera: camera,
             cullingMargin: widget.cullingMargin!,
-          );
+          ).toList();
 
     return MobileLayerTransformer(
       child: CustomPaint(
@@ -148,14 +116,12 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>> {
     );
   }
 
-  List<_ProjectedPolyline<R>> _aggressivelyCullPolylines({
+  Iterable<_ProjectedPolyline<R>> _aggressivelyCullPolylines({
     required Projection projection,
-    required List<_ProjectedPolyline<R>> polylines,
+    required Iterable<_ProjectedPolyline<R>> polylines,
     required MapCamera camera,
     required double cullingMargin,
-  }) {
-    final culledPolylines = <_ProjectedPolyline<R>>[];
-
+  }) sync* {
     final bounds = camera.visibleBounds;
     final margin = cullingMargin / math.pow(2, camera.zoom);
 
@@ -179,7 +145,7 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>> {
 
       // Gradient poylines cannot be easily segmented
       if (polyline.gradientColors != null) {
-        culledPolylines.add(projectedPolyline);
+        yield projectedPolyline;
         continue;
       }
 
@@ -199,11 +165,9 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>> {
         } else {
           // If we cannot see this segment but have seen previous ones, flush the last polyline fragment.
           if (start != -1) {
-            culledPolylines.add(
-              _ProjectedPolyline._(
-                polyline: polyline,
-                points: projectedPolyline.points.sublist(start, i + 1),
-              ),
+            yield _ProjectedPolyline._(
+              polyline: polyline,
+              points: projectedPolyline.points.sublist(start, i + 1),
             );
 
             // Reset start.
@@ -215,49 +179,14 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>> {
       // If the last segment was visible push that last visible polyline
       // fragment, which may also be the entire polyline if `start == 0`.
       if (containsSegment) {
-        culledPolylines.add(
-          start == 0
-              ? projectedPolyline
-              : _ProjectedPolyline._(
-                  polyline: polyline,
-                  // Special case: the entire polyline is visible
-                  points: projectedPolyline.points.sublist(start),
-                ),
-        );
+        yield start == 0
+            ? projectedPolyline
+            : _ProjectedPolyline._(
+                polyline: polyline,
+                // Special case: the entire polyline is visible
+                points: projectedPolyline.points.sublist(start),
+              );
       }
     }
-
-    return culledPolylines;
-  }
-
-  List<_ProjectedPolyline<R>> _computeZoomLevelSimplification({
-    required MapCamera camera,
-    required List<_ProjectedPolyline<R>> polylines,
-    required double pixelTolerance,
-    required double devicePixelRatio,
-  }) {
-    final tolerance = getEffectiveSimplificationTolerance(
-      crs: camera.crs,
-      zoom: camera.zoom.floor(),
-      pixelTolerance: pixelTolerance,
-      devicePixelRatio: devicePixelRatio,
-    );
-
-    return List<_ProjectedPolyline<R>>.generate(
-      polylines.length,
-      (i) {
-        final polyline = polylines[i];
-
-        return _ProjectedPolyline._(
-          polyline: polyline.polyline,
-          points: simplifyPoints(
-            points: polyline.points,
-            tolerance: tolerance,
-            highQuality: true,
-          ),
-        );
-      },
-      growable: false,
-    );
   }
 }

--- a/lib/src/layer/polyline_layer/projected_polyline.dart
+++ b/lib/src/layer/polyline_layer/projected_polyline.dart
@@ -1,8 +1,7 @@
 part of 'polyline_layer.dart';
 
 @immutable
-base class _ProjectedPolyline<R extends Object>
-    extends HitDetectableElement<R> {
+class _ProjectedPolyline<R extends Object> with HitDetectableElement<R> {
   final Polyline<R> polyline;
   final List<DoublePoint> points;
 

--- a/lib/src/layer/shared/layer_interactivity/internal_hit_detectable.dart
+++ b/lib/src/layer/shared/layer_interactivity/internal_hit_detectable.dart
@@ -6,9 +6,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:meta/meta.dart';
 
 @internal
-abstract base class HitDetectableElement<R extends Object> {
-  const HitDetectableElement({this.hitValue});
-
+mixin HitDetectableElement<R extends Object> {
   /// {@template fm.hde.hitValue}
   /// Value to notify layer's `hitNotifier` with (such as
   /// [PolygonLayer.hitNotifier])
@@ -19,7 +17,7 @@ abstract base class HitDetectableElement<R extends Object> {
   /// The object should have a valid & useful equality, as it may be used
   /// by FM internals.
   /// {@endtemplate}
-  final R? hitValue;
+  R? get hitValue;
 }
 
 @internal

--- a/lib/src/layer/shared/layer_projection_simplification/state.dart
+++ b/lib/src/layer/shared/layer_projection_simplification/state.dart
@@ -6,16 +6,19 @@ import 'package:flutter_map/src/layer/shared/layer_projection_simplification/wid
 import 'package:flutter_map/src/misc/simplify.dart';
 import 'package:meta/meta.dart';
 
-/// A mixin to be applied on the [State] of a [PSSupportedWidget], which
-/// provides pre-projection and pre-simplification support for layers that paint
-/// elements (particularly [PolylineLayer] and [PolygonLayer]), and updates them
-/// as necessary
+/// A mixin to be applied on the [State] of a
+/// [ProjectionSimplificationManagementSupportedWidget], which provides
+/// pre-projection and pre-simplification support for layers that paint elements
+/// (particularly [PolylineLayer] and [PolygonLayer]), and updates them as
+/// necessary
 ///
 /// Subclasses must implement [build], and invoke `super.build()` (but ignore
 /// the result) at the start. The `build` method should/can then use
 /// [simplifiedElements].
-mixin ProjectionSimplificationManagement<ProjectedElement extends Object,
-    Element extends Object, W extends PSSupportedWidget> on State<W> {
+mixin ProjectionSimplificationManagement<
+    ProjectedElement extends Object,
+    Element extends Object,
+    W extends ProjectionSimplificationManagementSupportedWidget> on State<W> {
   /// Project [Element] to [ProjectedElement] using the specified [projection]
   ProjectedElement projectElement({
     required Projection projection,
@@ -24,13 +27,15 @@ mixin ProjectionSimplificationManagement<ProjectedElement extends Object,
 
   /// Simplify the points of [ProjectedElement] with the given [tolerance]
   ///
-  /// Does not need to call [getEffectiveSimplificationTolerance] internally.
+  /// Should not call [getEffectiveSimplificationTolerance]; [tolerance] has
+  /// already been processed.
   ProjectedElement simplifyProjectedElement({
     required ProjectedElement projectedElement,
     required double tolerance,
   });
 
-  /// Return the individual elements given the [PSSupportedWidget]
+  /// Return the individual elements given the
+  /// [ProjectionSimplificationManagementSupportedWidget]
   Iterable<Element> getElements(W widget);
 
   /// An iterable of simplified [ProjectedElement]s, which is always ready
@@ -114,8 +119,9 @@ mixin ProjectionSimplificationManagement<ProjectedElement extends Object,
     _cachedProjectedElements
         .removeWhere((k, v) => !elements.map((p) => p.hashCode).contains(k));
 
-    for (final s in _cachedSimplifiedElements.values) {
-      s.removeWhere((k, v) => !elements.map((p) => p.hashCode).contains(k));
+    for (final simplifiedElement in _cachedSimplifiedElements.values) {
+      simplifiedElement
+          .removeWhere((k, v) => !elements.map((p) => p.hashCode).contains(k));
     }
   }
 
@@ -143,7 +149,7 @@ mixin ProjectionSimplificationManagement<ProjectedElement extends Object,
 
     // The `build` method handles initial simplification, re-simplification only
     // when the DPR has changed, and re-simplification implicitly when the
-    // tolerance is changed (and the cache is emptied by `didUpdateWidget`.
+    // tolerance is changed (and the cache is emptied by `didUpdateWidget`).
     if (widget.simplificationTolerance == 0) {
       simplifiedElements = _cachedProjectedElements.values;
     } else {
@@ -189,9 +195,9 @@ mixin ProjectionSimplificationManagement<ProjectedElement extends Object,
       devicePixelRatio: devicePixelRatio,
     );
 
-    for (final pe in projectedElements) {
+    for (final projectedElement in projectedElements) {
       yield simplifyProjectedElement(
-        projectedElement: pe,
+        projectedElement: projectedElement,
         tolerance: tolerance,
       );
     }

--- a/lib/src/layer/shared/layer_projection_simplification/state.dart
+++ b/lib/src/layer/shared/layer_projection_simplification/state.dart
@@ -1,0 +1,199 @@
+import 'dart:collection';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/layer/shared/layer_projection_simplification/widget.dart';
+import 'package:flutter_map/src/misc/simplify.dart';
+import 'package:meta/meta.dart';
+
+/// A mixin to be applied on the [State] of a [PSSupportedWidget], which
+/// provides pre-projection and pre-simplification support for layers that paint
+/// elements (particularly [PolylineLayer] and [PolygonLayer]), and updates them
+/// as necessary
+///
+/// Subclasses must implement [build], and invoke `super.build()` (but ignore
+/// the result) at the start. The `build` method should/can then use
+/// [simplifiedElements].
+mixin ProjectionSimplificationManagement<ProjectedElement extends Object,
+    Element extends Object, W extends PSSupportedWidget> on State<W> {
+  /// Project [Element] to [ProjectedElement] using the specified [projection]
+  ProjectedElement projectElement({
+    required Projection projection,
+    required Element element,
+  });
+
+  /// Simplify the points of [ProjectedElement] with the given [tolerance]
+  ///
+  /// Does not need to call [getEffectiveSimplificationTolerance] internally.
+  ProjectedElement simplifyProjectedElement({
+    required ProjectedElement projectedElement,
+    required double tolerance,
+  });
+
+  /// Return the individual elements given the [PSSupportedWidget]
+  Iterable<Element> getElements(W widget);
+
+  /// An iterable of simplified [ProjectedElement]s, which is always ready
+  /// after the [build] method has been invoked, and should then be used in the
+  /// next [build] stage (usually culling)
+  ///
+  /// Do not use before invoking [build]. Only necessarily up to date directly
+  /// after [build] has been invoked.
+  late Iterable<ProjectedElement> simplifiedElements;
+
+  final _cachedProjectedElements = SplayTreeMap<int, ProjectedElement>();
+  final _cachedSimplifiedElements =
+      <int, SplayTreeMap<int, ProjectedElement>>{};
+
+  double? _devicePixelRatio;
+
+  @mustCallSuper
+  @override
+  void didUpdateWidget(W oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (!widget.useDynamicUpdate) return;
+
+    final camera = MapCamera.of(context);
+
+    // If the simplification tolerance has changed, then clear all
+    // simplifications to allow `build` to re-simplify.
+    final hasSimplficationToleranceChanged =
+        oldWidget.simplificationTolerance != widget.simplificationTolerance;
+    if (hasSimplficationToleranceChanged) _cachedSimplifiedElements.clear();
+
+    final elements = getElements(widget);
+
+    // We specifically only use basic equality here, and not deep, since deep
+    // will always be equal.
+    if (getElements(oldWidget) == elements) return;
+
+    // Loop through all polygons in the new widget
+    // If not in the projection cache, then re-project. Also, do the same for
+    // the simplification cache, across all zoom levels for each polygon.
+    // Then, remove all polygons no longer in the new widget from each cache.
+    //
+    // This is an O(n^3) operation, assuming n is the number of polygons
+    // (assuming they are all similar, otherwise exact runtime will depend on
+    // existing cache lengths, etc.). However, compared to previous versions, it
+    // takes approximately the same duration, as it relieves the work from the
+    // `build` method.
+    for (final element in getElements(widget)) {
+      final existingProjection = _cachedProjectedElements[element.hashCode];
+
+      if (existingProjection == null) {
+        _cachedProjectedElements[element.hashCode] =
+            projectElement(projection: camera.crs.projection, element: element);
+
+        if (hasSimplficationToleranceChanged) continue;
+
+        for (final MapEntry(key: zoomLvl, value: simplifiedElements)
+            in _cachedSimplifiedElements.entries) {
+          final simplificationTolerance = getEffectiveSimplificationTolerance(
+            crs: camera.crs,
+            zoom: zoomLvl,
+            // When the tolerance changes, this method handles resetting and filling
+            pixelTolerance: widget.simplificationTolerance,
+            // When the DPR changes, the `build` method handles resetting and filling
+            devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
+          );
+
+          final existingSimplification = simplifiedElements[element.hashCode];
+
+          if (existingSimplification == null) {
+            _cachedSimplifiedElements[zoomLvl]![element.hashCode] =
+                simplifyProjectedElement(
+              projectedElement: _cachedProjectedElements[element.hashCode]!,
+              tolerance: simplificationTolerance,
+            );
+          }
+        }
+      }
+    }
+
+    _cachedProjectedElements
+        .removeWhere((k, v) => !elements.map((p) => p.hashCode).contains(k));
+
+    for (final s in _cachedSimplifiedElements.values) {
+      s.removeWhere((k, v) => !elements.map((p) => p.hashCode).contains(k));
+    }
+  }
+
+  @mustCallSuper
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    // Performed once only, at load - projects all initial polygons
+    if (_cachedProjectedElements.isEmpty) {
+      final camera = MapCamera.of(context);
+
+      for (final element in getElements(widget)) {
+        _cachedProjectedElements[element.hashCode] =
+            projectElement(projection: camera.crs.projection, element: element);
+      }
+    }
+  }
+
+  @mustBeOverridden
+  @mustCallSuper
+  @override
+  Widget build(BuildContext context) {
+    final camera = MapCamera.of(context);
+
+    // The `build` method handles initial simplification, re-simplification only
+    // when the DPR has changed, and re-simplification implicitly when the
+    // tolerance is changed (and the cache is emptied by `didUpdateWidget`.
+    if (widget.simplificationTolerance == 0) {
+      simplifiedElements = _cachedProjectedElements.values;
+    } else {
+      // If the DPR has changed, invalidate the simplification cache
+      final newDPR = MediaQuery.devicePixelRatioOf(context);
+      if (newDPR != _devicePixelRatio) {
+        _devicePixelRatio = newDPR;
+        _cachedSimplifiedElements.clear();
+      }
+
+      simplifiedElements = (_cachedSimplifiedElements[camera.zoom.floor()] ??=
+              SplayTreeMap.fromIterables(
+        _cachedProjectedElements.keys,
+        _simplifyElements(
+          camera: camera,
+          projectedElements: _cachedProjectedElements.values,
+          pixelTolerance: widget.simplificationTolerance,
+          devicePixelRatio: newDPR,
+        ),
+      ))
+          .values;
+    }
+
+    return Builder(
+      builder: (context) => throw UnimplementedError(
+        'Widgets that mix ProjectionSimplificationManagement into their State '
+        'must call super.build() but must ignore the return value of the '
+        'superclass.',
+      ),
+    );
+  }
+
+  Iterable<ProjectedElement> _simplifyElements({
+    required Iterable<ProjectedElement> projectedElements,
+    required MapCamera camera,
+    required double pixelTolerance,
+    required double devicePixelRatio,
+  }) sync* {
+    final tolerance = getEffectiveSimplificationTolerance(
+      crs: camera.crs,
+      zoom: camera.zoom.floor(),
+      pixelTolerance: pixelTolerance,
+      devicePixelRatio: devicePixelRatio,
+    );
+
+    for (final pe in projectedElements) {
+      yield simplifyProjectedElement(
+        projectedElement: pe,
+        tolerance: tolerance,
+      );
+    }
+  }
+}

--- a/lib/src/layer/shared/layer_projection_simplification/widget.dart
+++ b/lib/src/layer/shared/layer_projection_simplification/widget.dart
@@ -5,7 +5,8 @@ import 'package:flutter_map/src/layer/shared/layer_projection_simplification/sta
 /// A [StatefulWidget] that includes the properties used by the [State] component
 /// which mixes [ProjectionSimplificationManagement] in
 @immutable
-abstract base class PSSupportedWidget extends StatefulWidget {
+abstract base class ProjectionSimplificationManagementSupportedWidget
+    extends StatefulWidget {
   /// Whether to apply the auto-update algorithm to re-paint the necessary
   /// [Polygon]s when they change
   ///
@@ -37,7 +38,7 @@ abstract base class PSSupportedWidget extends StatefulWidget {
   ///
   /// Constructors should call `super()` (the super constructor) to ensure the
   /// necessary assertions are made.
-  const PSSupportedWidget({
+  const ProjectionSimplificationManagementSupportedWidget({
     super.key,
     this.useDynamicUpdate = true,
     this.simplificationTolerance = 0.3,

--- a/lib/src/layer/shared/layer_projection_simplification/widget.dart
+++ b/lib/src/layer/shared/layer_projection_simplification/widget.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/layer/shared/layer_projection_simplification/state.dart';
+
+/// A [StatefulWidget] that includes the properties used by the [State] component
+/// which mixes [ProjectionSimplificationManagement] in
+@immutable
+abstract base class PSSupportedWidget extends StatefulWidget {
+  /// Whether to apply the auto-update algorithm to re-paint the necessary
+  /// [Polygon]s when they change
+  ///
+  /// It is recommended to leave this `true`, as default, otherwise changes to
+  /// child polygons may not update. It will detect which polygons have changed,
+  /// and only 'update' (re-project and re-simplify) those that are necessary.
+  ///
+  /// However, where there are a large number of polygons, the majority (or more)
+  /// of which change at the same time, then it is recommended to set this
+  /// `false`. This will avoid a large unnecessary loop to detect changes, and
+  /// is likely to improve performance on state changes. If `false`, then the
+  /// layer will need to be manually rebuilt from scratch using new [Key]s
+  /// whenever necessary. Do not use a [UniqueKey] : this will cause the entire
+  /// widget to reset and rebuild every time the map camera changes.
+  final bool useDynamicUpdate;
+
+  /// Distance between two neighboring polyline points, in logical pixels scaled
+  /// to floored zoom
+  ///
+  /// Increasing this value results in points further apart being collapsed and
+  /// thus more simplified polylines. Higher values improve performance at the
+  /// cost of visual fidelity and vice versa.
+  ///
+  /// Defaults to 0.3. Set to 0 to disable simplification.
+  final double simplificationTolerance;
+
+  /// A [StatefulWidget] that includes the properties used by the [State]
+  /// component which mixes [ProjectionSimplificationManagement] in
+  ///
+  /// Constructors should call `super()` (the super constructor) to ensure the
+  /// necessary assertions are made.
+  const PSSupportedWidget({
+    super.key,
+    this.useDynamicUpdate = true,
+    this.simplificationTolerance = 0.3,
+  }) : assert(
+          simplificationTolerance >= 0,
+          'simplificationTolerance cannot be negative: $simplificationTolerance',
+        );
+}


### PR DESCRIPTION
The main aim of this change is to enable each element to update independently only when required.

The pre-projection and pre-simplification logic have been refactored into their own state which can be mixed in (and is to `PolylineLayer` and `PolygonLayer`).

Performance results:
 - There is little overall change (perhaps +<1ms on UI/build)
 - On the stress test, update times have not changed much, but may have increased a bit - as expected
 - It is expected that in many cases, this will improve efficiency of updates, because only the elements that have updated will need to be re-projected and re-simplified
 - TLDR; there should be some overall noticeable change, except for extremely large samples where all elements change at once, where the behaviour can be manually controlled instead (see below) - middle-size and smaller samples where only a couple elements change, or normal usage, should be better off (also see below)

Additionally, this fixes #1894. Unless `useDynamicUpdate` is disabled, in which case, `Key`s have been recommended to refresh the widget manually. This approach has been recommended in some cases: see the in-code docs.

The default `simplificationTolerance` has also been lowered to 0.3. This gives perfectly acceptable performance (very similar to 0.5 as before), but reduced visual artifacts.