### PR TITLE
perf: expose `isPointInPolygon` and make 40% faster (at least in JIT mode)

### DIFF
--- a/benchmark/point_in_polygon.dart
+++ b/benchmark/point_in_polygon.dart
@@ -1,0 +1,75 @@
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:ui';
+
+import 'package:flutter_map/src/misc/point_in_polygon.dart';
+import 'package:logger/logger.dart';
+
+class NoFilter extends LogFilter {
+  @override
+  bool shouldLog(LogEvent event) => true;
+}
+
+typedef Result = ({
+  String name,
+  Duration duration,
+});
+
+Future<Result> timedRun(String name, dynamic Function() body) async {
+  Logger().i('running $name...');
+  final watch = Stopwatch()..start();
+  await body();
+  watch.stop();
+
+  return (name: name, duration: watch.elapsed);
+}
+
+// NOTE: to have a more prod like comparison, run with:
+//     $ dart compile exe benchmark/crs.dart && ./benchmark/crs.exe
+//
+// If you run in JIT mode, the resulting execution times will be a lot more similar.
+Future<void> main() async {
+  Logger.level = Level.all;
+  Logger.defaultFilter = NoFilter.new;
+  Logger.defaultPrinter = SimplePrinter.new;
+
+  final results = <Result>[];
+  const N = 3000000;
+  const points = 1000;
+
+  results.add(await timedRun('In circle', () {
+    final polygon = List.generate(points, (i) {
+      final angle = math.pi * 2 / points * i;
+      return Offset(math.cos(angle), math.sin(angle));
+    });
+
+    const point = math.Point(0, 0);
+
+    bool yesPlease = true;
+    for (int i = 0; i < N; ++i) {
+      yesPlease = yesPlease && pointInPolygon(point, polygon);
+    }
+
+    assert(yesPlease, 'should be in circle');
+    return yesPlease;
+  }));
+
+  results.add(await timedRun('Not in circle', () {
+    final polygon = List.generate(points, (i) {
+      final angle = math.pi * 2 / points * i;
+      return Offset(math.cos(angle), math.sin(angle));
+    });
+
+    const point = math.Point(4, 4);
+
+    bool noSir = false;
+    for (int i = 0; i < N; ++i) {
+      noSir = noSir || pointInPolygon(point, polygon);
+    }
+
+    assert(!noSir, 'should not be in circle');
+    return noSir;
+  }));
+
+  Logger().i('Results:\n${results.map((r) => r.toString()).join('\n')}');
+}

--- a/benchmark/point_in_polygon.dart
+++ b/benchmark/point_in_polygon.dart
@@ -24,6 +24,16 @@ Future<Result> timedRun(String name, dynamic Function() body) async {
   return (name: name, duration: watch.elapsed);
 }
 
+List<Offset> makeCircle(int points, double radius, double phase) {
+  final slice = math.pi * 2 / (points - 1);
+  return List.generate(points, (i) {
+    // Note the modulo is only there to deal with floating point imprecision
+    // and ensure first == last.
+    final angle = slice * (i % (points - 1)) + phase;
+    return Offset(radius * math.cos(angle), radius * math.sin(angle));
+  }, growable: false);
+}
+
 // NOTE: to have a more prod like comparison, run with:
 //     $ dart compile exe benchmark/crs.dart && ./benchmark/crs.exe
 //
@@ -35,19 +45,15 @@ Future<void> main() async {
 
   final results = <Result>[];
   const N = 3000000;
-  const points = 1000;
+
+  final circle = makeCircle(1000, 1, 0);
 
   results.add(await timedRun('In circle', () {
-    final polygon = List.generate(points, (i) {
-      final angle = math.pi * 2 / points * i;
-      return Offset(math.cos(angle), math.sin(angle));
-    });
-
     const point = math.Point(0, 0);
 
     bool yesPlease = true;
     for (int i = 0; i < N; ++i) {
-      yesPlease = yesPlease && isPointInPolygon(point, polygon);
+      yesPlease = yesPlease && isPointInPolygon(point, circle);
     }
 
     assert(yesPlease, 'should be in circle');
@@ -55,16 +61,11 @@ Future<void> main() async {
   }));
 
   results.add(await timedRun('Not in circle', () {
-    final polygon = List.generate(points, (i) {
-      final angle = math.pi * 2 / points * i;
-      return Offset(math.cos(angle), math.sin(angle));
-    });
-
     const point = math.Point(4, 4);
 
     bool noSir = false;
     for (int i = 0; i < N; ++i) {
-      noSir = noSir || isPointInPolygon(point, polygon);
+      noSir = noSir || isPointInPolygon(point, circle);
     }
 
     assert(!noSir, 'should not be in circle');

--- a/benchmark/point_in_polygon.dart
+++ b/benchmark/point_in_polygon.dart
@@ -47,7 +47,7 @@ Future<void> main() async {
 
     bool yesPlease = true;
     for (int i = 0; i < N; ++i) {
-      yesPlease = yesPlease && pointInPolygon(point, polygon);
+      yesPlease = yesPlease && isPointInPolygon(point, polygon);
     }
 
     assert(yesPlease, 'should be in circle');
@@ -64,7 +64,7 @@ Future<void> main() async {
 
     bool noSir = false;
     for (int i = 0; i < N; ++i) {
-      noSir = noSir || pointInPolygon(point, polygon);
+      noSir = noSir || isPointInPolygon(point, polygon);
     }
 
     assert(!noSir, 'should not be in circle');

--- a/lib/src/geo/crs.dart
+++ b/lib/src/geo/crs.dart
@@ -1,7 +1,7 @@
 import 'dart:math' as math hide Point;
 import 'dart:math' show Point;
 
-import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/misc/bounds.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:meta/meta.dart';
 import 'package:proj4dart/proj4dart.dart' as proj4;

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -70,11 +70,9 @@ base class _PolygonPainter<R extends Object>
       }
     }
 
-    final isInPolygon = _isPointInPolygon(point, projectedCoords);
+    final isInPolygon = pointInPolygon(point, projectedCoords);
     final isInHole = hasHoles &&
-        projectedHoleCoords
-            .map((c) => _isPointInPolygon(point, c))
-            .any((e) => e);
+        projectedHoleCoords.map((c) => pointInPolygon(point, c)).any((e) => e);
 
     // Second check handles case where polygon outline intersects a hole,
     // ensuring that the hit matches with the visual representation
@@ -359,24 +357,6 @@ base class _PolygonPainter<R extends Object>
       min: getOffset(camera, origin, bBox.southWest),
       max: getOffset(camera, origin, bBox.northEast),
     );
-  }
-
-  /// Checks whether point [p] is within the specified closed [polygon]
-  ///
-  /// Uses the even-odd algorithm.
-  static bool _isPointInPolygon(math.Point p, List<Offset> polygon) {
-    bool isInPolygon = false;
-
-    for (int i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
-      if ((((polygon[i].dy <= p.y) && (p.y < polygon[j].dy)) ||
-              ((polygon[j].dy <= p.y) && (p.y < polygon[i].dy))) &&
-          (p.x <
-              (polygon[j].dx - polygon[i].dx) *
-                      (p.y - polygon[i].dy) /
-                      (polygon[j].dy - polygon[i].dy) +
-                  polygon[i].dx)) isInPolygon = !isInPolygon;
-    }
-    return isInPolygon;
   }
 
   @override

--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -9,6 +9,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/layer/shared/layer_interactivity/internal_hit_detectable.dart';
 import 'package:flutter_map/src/layer/shared/line_patterns/pixel_hiker.dart';
 import 'package:flutter_map/src/misc/offsets.dart';
+import 'package:flutter_map/src/misc/point_in_polygon.dart';
 import 'package:flutter_map/src/misc/simplify.dart';
 import 'package:latlong2/latlong.dart' hide Path;
 import 'package:polylabel/polylabel.dart';

--- a/lib/src/misc/offsets.dart
+++ b/lib/src/misc/offsets.dart
@@ -25,7 +25,7 @@ List<Offset> getOffsets(MapCamera camera, Offset origin, List<LatLng> points) {
 
   // Optimization: monomorphize the Epsg3857-case to avoid the virtual function overhead.
   if (crs case final Epsg3857 epsg3857) {
-    final v = List<Offset>.filled(len, Offset.zero);
+    final v = List<Offset>.filled(len, Offset.zero, growable: true);
     for (int i = 0; i < len; ++i) {
       final (x, y) = epsg3857.latLngToXY(points[i], zoomScale);
       v[i] = Offset(x + ox, y + oy);
@@ -33,7 +33,7 @@ List<Offset> getOffsets(MapCamera camera, Offset origin, List<LatLng> points) {
     return v;
   }
 
-  final v = List<Offset>.filled(len, Offset.zero);
+  final v = List<Offset>.filled(len, Offset.zero, growable: true);
   for (int i = 0; i < len; ++i) {
     final (x, y) = crs.latLngToXY(points[i], zoomScale);
     v[i] = Offset(x + ox, y + oy);
@@ -63,7 +63,7 @@ List<Offset> getOffsetsXY({
   // Optimization: monomorphize the CrsWithStaticTransformation-case to avoid
   // the virtual function overhead.
   if (crs case final CrsWithStaticTransformation crs) {
-    final v = List<Offset>.filled(len, Offset.zero);
+    final v = List<Offset>.filled(len, Offset.zero, growable: true);
     for (int i = 0; i < len; ++i) {
       final p = realPoints.elementAt(i);
       final (x, y) = crs.transform(p.x, p.y, zoomScale);
@@ -72,7 +72,7 @@ List<Offset> getOffsetsXY({
     return v;
   }
 
-  final v = List<Offset>.filled(len, Offset.zero);
+  final v = List<Offset>.filled(len, Offset.zero, growable: true);
   for (int i = 0; i < len; ++i) {
     final p = realPoints.elementAt(i);
     final (x, y) = crs.transform(p.x, p.y, zoomScale);

--- a/lib/src/misc/point_in_polygon.dart
+++ b/lib/src/misc/point_in_polygon.dart
@@ -3,13 +3,17 @@ import 'dart:ui';
 
 /// Checks whether point [p] is within the specified closed [polygon]
 ///
-/// Uses the even-odd algorithm.
+/// Uses the even-odd algorithm and requires closed loop polygons, i.e.
+/// `polygon.first == polygon.last`.
 bool isPointInPolygon(math.Point p, List<Offset> polygon) {
+  final len = polygon.length;
+  assert(len >= 3, 'not a polygon');
+  assert(polygon.first == polygon.last, 'polygon not closed');
   final double px = p.x.toDouble();
   final double py = p.y.toDouble();
 
   bool isInPolygon = false;
-  for (int i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+  for (int i = 0, j = len - 1; i < len; j = i++) {
     final double poIx = polygon[i].dx;
     final double poIy = polygon[i].dy;
 

--- a/lib/src/misc/point_in_polygon.dart
+++ b/lib/src/misc/point_in_polygon.dart
@@ -4,7 +4,7 @@ import 'dart:ui';
 /// Checks whether point [p] is within the specified closed [polygon]
 ///
 /// Uses the even-odd algorithm.
-bool pointInPolygon(math.Point p, List<Offset> polygon) {
+bool isPointInPolygon(math.Point p, List<Offset> polygon) {
   final double px = p.x.toDouble();
   final double py = p.y.toDouble();
 

--- a/lib/src/misc/point_in_polygon.dart
+++ b/lib/src/misc/point_in_polygon.dart
@@ -1,0 +1,25 @@
+import 'dart:math' as math;
+import 'dart:ui';
+
+/// Checks whether point [p] is within the specified closed [polygon]
+///
+/// Uses the even-odd algorithm.
+bool pointInPolygon(math.Point p, List<Offset> polygon) {
+  final double px = p.x.toDouble();
+  final double py = p.y.toDouble();
+
+  bool isInPolygon = false;
+  for (int i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    final double poIx = polygon[i].dx;
+    final double poIy = polygon[i].dy;
+
+    final double poJx = polygon[j].dx;
+    final double poJy = polygon[j].dy;
+
+    if ((((poIy <= py) && (py < poJy)) || ((poJy <= py) && (py < poIy))) &&
+        (px < (poJx - poIx) * (py - poIy) / (poJy - poIy) + poIx)) {
+      isInPolygon = !isInPolygon;
+    }
+  }
+  return isInPolygon;
+}

--- a/test/misc/point_in_polygon_test.dart
+++ b/test/misc/point_in_polygon_test.dart
@@ -17,22 +17,22 @@ void main() {
     // Inside points
     for (final point in makeCircle(32, 0.8, 0.0001)) {
       final p = math.Point(point.dx, point.dy);
-      expect(pointInPolygon(p, circle), isTrue);
+      expect(isPointInPolygon(p, circle), isTrue);
     }
 
     // Edge-case: check origin
-    expect(pointInPolygon(const math.Point(0, 0), circle), isTrue);
+    expect(isPointInPolygon(const math.Point(0, 0), circle), isTrue);
 
     // Outside points: small radius
     for (final point in makeCircle(32, 1.1, 0.0001)) {
       final p = math.Point(point.dx, point.dy);
-      expect(pointInPolygon(p, circle), isFalse);
+      expect(isPointInPolygon(p, circle), isFalse);
     }
 
     // Outside points: large radius
     for (final point in makeCircle(32, 100000, 0.0001)) {
       final p = math.Point(point.dx, point.dy);
-      expect(pointInPolygon(p, circle), isFalse);
+      expect(isPointInPolygon(p, circle), isFalse);
     }
   });
 }

--- a/test/misc/point_in_polygon_test.dart
+++ b/test/misc/point_in_polygon_test.dart
@@ -1,0 +1,38 @@
+import 'dart:math' as math;
+
+import 'package:flutter_map/src/misc/point_in_polygon.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+List<Offset> makeCircle(int points, double radius, double phase) {
+  return List.generate(points, (i) {
+    final angle = math.pi * 2 / points * i + phase;
+    return Offset(radius * math.cos(angle), radius * math.sin(angle));
+  }, growable: false);
+}
+
+void main() {
+  test('Smoke test for points in and out of polygons', () {
+    final circle = makeCircle(100, 1, 0);
+
+    // Inside points
+    for (final point in makeCircle(32, 0.8, 0.0001)) {
+      final p = math.Point(point.dx, point.dy);
+      expect(pointInPolygon(p, circle), isTrue);
+    }
+
+    // Edge-case: check origin
+    expect(pointInPolygon(const math.Point(0, 0), circle), isTrue);
+
+    // Outside points: small radius
+    for (final point in makeCircle(32, 1.1, 0.0001)) {
+      final p = math.Point(point.dx, point.dy);
+      expect(pointInPolygon(p, circle), isFalse);
+    }
+
+    // Outside points: large radius
+    for (final point in makeCircle(32, 100000, 0.0001)) {
+      final p = math.Point(point.dx, point.dy);
+      expect(pointInPolygon(p, circle), isFalse);
+    }
+  });
+}

--- a/test/misc/point_in_polygon_test.dart
+++ b/test/misc/point_in_polygon_test.dart
@@ -4,8 +4,11 @@ import 'package:flutter_map/src/misc/point_in_polygon.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 List<Offset> makeCircle(int points, double radius, double phase) {
+  final slice = math.pi * 2 / (points - 1);
   return List.generate(points, (i) {
-    final angle = math.pi * 2 / points * i + phase;
+    // Note the modulo is only there to deal with floating point imprecision
+    // and ensure first == last.
+    final angle = slice * (i % (points - 1)) + phase;
     return Offset(radius * math.cos(angle), radius * math.sin(angle));
   }, growable: false);
 }


### PR DESCRIPTION
I mostly looked at the function because I wanted to use it myself but it was private. So I thought, if I expose it then I could at least put a ribbon on it by adding a benchmark and make it go wroom.

Before:

  (duration: 0:00:05.998949, name: In circle)
  (duration: 0:00:06.866919, name: Not in circle)

After:

  (duration: 0:00:03.649496, name: In circle)
  (duration: 0:00:04.611599, name: Not in circle)

Note, I opportunistically touched crs to remove the dart:ui dependency. This way it can be compiled with dart (w/o flutter) rendering the instructions in the benchmark correct again. Unfortunately, pointInPolygon is not so fortunate and needs flutter due to the dependency on ui.Offset. That's why I could only run it with "flutter test" in JIT mode.