### PR TITLE
chore: relax dependency on 'package:logger'

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
     sdk: flutter
   http: ^1.2.1
   latlong2: ^0.9.1
-  logger: ^2.3.0
+  logger: ^2.0.0
   meta: ^1.11.0
   polylabel: ^1.0.1
   proj4dart: ^2.1.0


### PR DESCRIPTION
Unless we have a strong need for a higher version of `logger`, we can lower the dependency to `^2.0.0`
* `2.0.0` having been released in July 2023
* `2.3.0` being the latest version (May 2024)

It's used only for debug or benchmarks.