### PR TITLE
fix: fixed multiple issues in `PolygonLayer` and `PolylineLayer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Please consider [donating](https://docs.fleaflet.dev/supporters#support-us) or [
 
 This CHANGELOG does not include every commit and/or PR - it is a hand picked selection of the most important ones. For a full list of changes, please check the GitHub repository releases/tags.
 
+## [7.0.2] - 2024/07/XX
+
+> Note that this version causes a technically breaking change by removing `PolygonLayer.useDynamicUpdate` & `PolylineLayer.useDynamicUpdate`, introduced in v7.0.1. However, the implementations for these was broken on introduction, and their intended purpose no longer exists. Therefore, these should not have been used in any capacity, and should not affect any projects.
+
+Contains the following user-affecting bug fixes:
+
+- Fixed significant performance issues with `PolygonLayer` & `PolylineLayer` inadvertently introduced by v7.0.1 - [#1925](https://github.com/fleaflet/flutter_map/pull/1925) for [#1921](https://github.com/fleaflet/flutter_map/issues/1921)
+- Fixed bug where the holes of a `Polygon` would only appear if their winding direction was opposite to the direction of the `Polygon.points` - [#1925](https://github.com/fleaflet/flutter_map/pull/1925) for [#1924](https://github.com/fleaflet/flutter_map/issues/1924)
+- Relaxed constraint on 'package:logger' dependency - [#1922](https://github.com/fleaflet/flutter_map/pull/1922) for [#1916](https://github.com/fleaflet/flutter_map/issues/1916)
+
 ## [7.0.1] - 2024/06/09
 
 Contains the following user-affecting bug fixes:
@@ -62,9 +72,11 @@ Many thanks to these contributors (in no particular order):
 - @monsieurtanuki
 - ... and all the maintainers
 
-## [6.2.0] - 2024/05/XX
+## [6.2.1] - 2024/05/27
 
 > If possible, prefer to update directly to v7. This version is provided only to enable Flutter 3.22 compatibility without requiring a breaking change.
+
+> v6.2.0 was retracted from pub.dev due to a mistake in the release preparation. For more information, see [this comment](https://github.com/fleaflet/flutter_map/pull/1891#issuecomment-2134069848). v6.2.1 is the replacement without the issues.
 
 Contains the following user-affecting changes:
 

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -20,6 +20,9 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
+  final points = <LatLng>[];
+  final holePoints = <LatLng>[];
+
   @override
   void initState() {
     super.initState();
@@ -42,9 +45,24 @@ class _HomePageState extends State<HomePage> {
                   const LatLng(90, 180),
                 ),
               ),
+              onTap: (_, ll) => setState(() => points.add(ll)),
+              onSecondaryTap: (_, ll) => setState(() => holePoints.add(ll)),
             ),
             children: [
               openStreetMapTileLayer,
+              if (points.length >= 3)
+                PolygonLayer(
+                  polygons: [
+                    Polygon(
+                      points: points,
+                      holePointsList:
+                          holePoints.length >= 3 ? [holePoints] : null,
+                      color: Colors.red,
+                      borderColor: Colors.black,
+                      borderStrokeWidth: 3,
+                    ),
+                  ],
+                ),
               RichAttributionWidget(
                 popupInitialDisplayDuration: const Duration(seconds: 5),
                 animationConfig: const ScaleRAWA(),

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -20,9 +20,6 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  final points = <LatLng>[];
-  final holePoints = <LatLng>[];
-
   @override
   void initState() {
     super.initState();
@@ -45,24 +42,9 @@ class _HomePageState extends State<HomePage> {
                   const LatLng(90, 180),
                 ),
               ),
-              onTap: (_, ll) => setState(() => points.add(ll)),
-              onSecondaryTap: (_, ll) => setState(() => holePoints.add(ll)),
             ),
             children: [
               openStreetMapTileLayer,
-              if (points.length >= 3)
-                PolygonLayer(
-                  polygons: [
-                    Polygon(
-                      points: points,
-                      holePointsList:
-                          holePoints.length >= 3 ? [holePoints] : null,
-                      color: Colors.red,
-                      borderColor: Colors.black,
-                      borderStrokeWidth: 3,
-                    ),
-                  ],
-                ),
               RichAttributionWidget(
                 popupInitialDisplayDuration: const Duration(seconds: 5),
                 animationConfig: const ScaleRAWA(),

--- a/example/lib/pages/polygon.dart
+++ b/example/lib/pages/polygon.dart
@@ -173,6 +173,8 @@ class _PolygonPageState extends State<PolygonPage> {
             (latlngs) => latlngs
                 .map((latlng) =>
                     LatLng(latlng.latitude - 6, latlng.longitude + 8))
+                .toList()
+                .reversed // Test that holes are always cut, no matter winding
                 .toList(),
           )
           .toList(),

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -281,6 +281,11 @@ base class _PolygonPainter<R extends Object>
       // https://github.com/fleaflet/flutter_map/issues/1898.
       final holePointsList = polygon.holePointsList;
       if (holePointsList != null && holePointsList.isNotEmpty) {
+        // See `Path.combine` comments below
+        // Avoids failing to cut holes if the winding directions of the holes
+        // and the normal points are the same
+        filledPath.fillType = PathFillType.evenOdd;
+
         final holeOffsetsList = List<List<Offset>>.generate(
           holePointsList.length,
           (i) => getOffsets(camera, origin, holePointsList[i]),
@@ -293,8 +298,9 @@ base class _PolygonPainter<R extends Object>
           // TODO: Potentially more efficient and may change the need to do
           // opacity checking - needs testing. However,
           // https://github.com/flutter/flutter/issues/44572 prevents this.
+          // Also need to verify if `xor` or `difference` is preferred.
           /*filledPath = Path.combine(
-            PathOperation.difference,
+            PathOperation.xor,
             filledPath,
             Path()..addPolygon(holeOffsets, true),
           );*/

--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -79,7 +79,6 @@ base class PolygonLayer<R extends Object>
     this.drawLabelsLast = false,
     this.hitNotifier,
     super.simplificationTolerance,
-    super.useDynamicUpdate,
   }) : super();
 
   @override

--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -79,6 +79,7 @@ base class PolygonLayer<R extends Object>
     this.drawLabelsLast = false,
     this.hitNotifier,
     super.simplificationTolerance,
+    super.useDynamicUpdate,
   }) : super();
 
   @override

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -53,6 +53,7 @@ base class PolylineLayer<R extends Object>
     this.hitNotifier,
     this.minimumHitbox = 10,
     super.simplificationTolerance,
+    super.useDynamicUpdate,
   }) : super();
 
   @override

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -53,7 +53,6 @@ base class PolylineLayer<R extends Object>
     this.hitNotifier,
     this.minimumHitbox = 10,
     super.simplificationTolerance,
-    super.useDynamicUpdate,
   }) : super();
 
   @override

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -52,7 +52,6 @@ base class PolylineLayer<R extends Object>
     this.cullingMargin = 10,
     this.hitNotifier,
     this.minimumHitbox = 10,
-    super.useDynamicUpdate,
     super.simplificationTolerance,
   }) : super();
 

--- a/lib/src/layer/shared/layer_projection_simplification/widget.dart
+++ b/lib/src/layer/shared/layer_projection_simplification/widget.dart
@@ -16,6 +16,17 @@ abstract base class ProjectionSimplificationManagementSupportedWidget
   /// Defaults to 0.3. Set to 0 to disable simplification.
   final double simplificationTolerance;
 
+  /// `useDynamicUpdate` no longer has any effect, and did not perform its
+  /// intended purpose, which is no longer necessary.
+  ///
+  /// It will be removed in the next major release.
+  @Deprecated(
+    '`useDynamicUpdate` no longer has any effect, and did not perform its '
+    'intended purpose, which is no longer necessary. '
+    'It will be removed in the next major release.',
+  )
+  final bool useDynamicUpdate;
+
   /// A [StatefulWidget] that includes the properties used by the [State]
   /// component which mixes [ProjectionSimplificationManagement] in
   ///
@@ -24,6 +35,7 @@ abstract base class ProjectionSimplificationManagementSupportedWidget
   const ProjectionSimplificationManagementSupportedWidget({
     super.key,
     this.simplificationTolerance = 0.3,
+    this.useDynamicUpdate = false,
   }) : assert(
           simplificationTolerance >= 0,
           'simplificationTolerance cannot be negative: $simplificationTolerance',

--- a/lib/src/layer/shared/layer_projection_simplification/widget.dart
+++ b/lib/src/layer/shared/layer_projection_simplification/widget.dart
@@ -16,17 +16,6 @@ abstract base class ProjectionSimplificationManagementSupportedWidget
   /// Defaults to 0.3. Set to 0 to disable simplification.
   final double simplificationTolerance;
 
-  /// `useDynamicUpdate` no longer has any effect, and did not perform its
-  /// intended purpose, which is no longer necessary.
-  ///
-  /// It will be removed in the next major release.
-  @Deprecated(
-    '`useDynamicUpdate` no longer has any effect, and did not perform its '
-    'intended purpose, which is no longer necessary. '
-    'It will be removed in the next major release.',
-  )
-  final bool useDynamicUpdate;
-
   /// A [StatefulWidget] that includes the properties used by the [State]
   /// component which mixes [ProjectionSimplificationManagement] in
   ///
@@ -35,7 +24,6 @@ abstract base class ProjectionSimplificationManagementSupportedWidget
   const ProjectionSimplificationManagementSupportedWidget({
     super.key,
     this.simplificationTolerance = 0.3,
-    this.useDynamicUpdate = false,
   }) : assert(
           simplificationTolerance >= 0,
           'simplificationTolerance cannot be negative: $simplificationTolerance',

--- a/lib/src/layer/shared/layer_projection_simplification/widget.dart
+++ b/lib/src/layer/shared/layer_projection_simplification/widget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/layer/shared/layer_projection_simplification/state.dart';
 
 /// A [StatefulWidget] that includes the properties used by the [State] component
@@ -7,22 +6,6 @@ import 'package:flutter_map/src/layer/shared/layer_projection_simplification/sta
 @immutable
 abstract base class ProjectionSimplificationManagementSupportedWidget
     extends StatefulWidget {
-  /// Whether to apply the auto-update algorithm to re-paint the necessary
-  /// [Polygon]s when they change
-  ///
-  /// It is recommended to leave this `true`, as default, otherwise changes to
-  /// child polygons may not update. It will detect which polygons have changed,
-  /// and only 'update' (re-project and re-simplify) those that are necessary.
-  ///
-  /// However, where there are a large number of polygons, the majority (or more)
-  /// of which change at the same time, then it is recommended to set this
-  /// `false`. This will avoid a large unnecessary loop to detect changes, and
-  /// is likely to improve performance on state changes. If `false`, then the
-  /// layer will need to be manually rebuilt from scratch using new [Key]s
-  /// whenever necessary. Do not use a [UniqueKey] : this will cause the entire
-  /// widget to reset and rebuild every time the map camera changes.
-  final bool useDynamicUpdate;
-
   /// Distance between two neighboring polyline points, in logical pixels scaled
   /// to floored zoom
   ///
@@ -40,7 +23,6 @@ abstract base class ProjectionSimplificationManagementSupportedWidget
   /// necessary assertions are made.
   const ProjectionSimplificationManagementSupportedWidget({
     super.key,
-    this.useDynamicUpdate = true,
     this.simplificationTolerance = 0.3,
   }) : assert(
           simplificationTolerance >= 0,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_map
 description: A versatile mapping package for Flutter, that's simple and easy to learn, yet completely customizable and configurable
-version: 7.0.1
+version: 7.0.2
 
 repository: https://github.com/fleaflet/flutter_map
 issue_tracker: https://github.com/fleaflet/flutter_map/issues


### PR DESCRIPTION
Fixes #1924 and fixes #1921.

Effectively reverts some broken commits.

Note that `useDynamicUpdate` has been deprecated, but its functionality has changed - it now has no purpose. However, this will not be a breaking change, as `useDynamicUpdate` was broken when initially introduced, so there should be no legitimate users.