### PR TITLE
feat: Implement unbounded horizontal scroll #1582

### DIFF
--- a/lib/src/map/options/options.dart
+++ b/lib/src/map/options/options.dart
@@ -176,6 +176,11 @@ class MapOptions {
   /// Gesture and input options for the map widget.
   final InteractionOptions interactionOptions;
 
+  ///Allows infinite horizontal pan.
+  ///Must not set cameraConstraint if this is set to true.
+  ///This will jump cameera to opposite side of the world when it reaches 180 or -180 longitude.
+  final bool? seamlessPanning;
+
   /// Create the map options for [FlutterMap].
   const MapOptions({
     this.crs = const Epsg3857(),
@@ -199,6 +204,7 @@ class MapOptions {
     this.onMapEvent,
     this.onMapReady,
     this.keepAlive = false,
+    this.seamlessPanning,
     @Deprecated(
       'If necessary, manually wrap layers with `TransulcentPointer` widgets. '
       'This parameter will be removed as proper hit detection has now been incorporated into both `PolygonLayer` & `PolylineLayer`, which reduces the need for this workaround, and because it caused issues in some cases. More information about hit detection & interactivity rules can be found in the online documentation. '
@@ -243,6 +249,7 @@ class MapOptions {
       cameraConstraint == other.cameraConstraint &&
       onMapReady == other.onMapReady &&
       keepAlive == other.keepAlive &&
+      seamlessPanning == other.seamlessPanning &&
       interactionOptions == other.interactionOptions &&
       backgroundColor == other.backgroundColor &&
       applyPointerTranslucencyToLayers ==
@@ -270,6 +277,7 @@ class MapOptions {
         cameraConstraint,
         onMapReady,
         keepAlive,
+        seamlessPanning,
         interactionOptions,
         backgroundColor,
         applyPointerTranslucencyToLayers,


### PR DESCRIPTION
An attempt to create seamless horizontal scroll #1582 . 
An optional feature that can be enabled in MapOptions as `bool seamlessPanning`

It works simply by jumping camera to opposite side of the map when crossing +180 or -180 bounds. 

**Currently know problems**

_Flash occurs when jumping camera._ 
This is because tiles on opposite side are discarded or not yet loaded.  

_Fling animation stops on camera jump._ 
I was trying to find where this occurs but without success. 
Animation is interrupted potentially because distance after jump is bigger than distance to target? 

Anyone knowing how to fix these problems are welcome to help resolving them. 
