### PR TITLE
refactor!: improved interface of cancellable tile loading

### DIFF
--- a/lib/src/layer/tile_layer/tile_image_manager.dart
+++ b/lib/src/layer/tile_layer/tile_image_manager.dart
@@ -118,16 +118,18 @@ class TileImageManager {
     final tilesToReload = List<TileImage>.from(_tiles.values);
 
     for (final tile in tilesToReload) {
-      tile.imageProvider = layer.tileProvider.supportsCancelLoading
-          ? layer.tileProvider.getImageWithCancelLoadingSupport(
-              tileBounds.atZoom(tile.coordinates.z).wrap(tile.coordinates),
-              layer,
-              tile.cancelLoading.future,
-            )
-          : layer.tileProvider.getImage(
-              tileBounds.atZoom(tile.coordinates.z).wrap(tile.coordinates),
-              layer,
-            );
+      if (layer.tileProvider case final CancellableTileLoadingSupport tp) {
+        tile.imageProvider = tp.getImageWithCancelLoadingSupport(
+          tileBounds.atZoom(tile.coordinates.z).wrap(tile.coordinates),
+          layer,
+          tile.cancelLoading.future,
+        );
+      } else {
+        tile.imageProvider = layer.tileProvider.getImage(
+          tileBounds.atZoom(tile.coordinates.z).wrap(tile.coordinates),
+          layer,
+        );
+      }
       tile.load();
     }
   }

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -545,16 +545,19 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }) {
     final cancelLoading = Completer<void>();
 
-    final imageProvider = widget.tileProvider.supportsCancelLoading
-        ? widget.tileProvider.getImageWithCancelLoadingSupport(
-            tileBoundsAtZoom.wrap(coordinates),
-            widget,
-            cancelLoading.future,
-          )
-        : widget.tileProvider.getImage(
-            tileBoundsAtZoom.wrap(coordinates),
-            widget,
-          );
+    late final ImageProvider imageProvider;
+    if (widget.tileProvider case final CancellableTileLoadingSupport tp) {
+      imageProvider = tp.getImageWithCancelLoadingSupport(
+        tileBoundsAtZoom.wrap(coordinates),
+        widget,
+        cancelLoading.future,
+      );
+    } else {
+      imageProvider = widget.tileProvider.getImage(
+        tileBoundsAtZoom.wrap(coordinates),
+        widget,
+      );
+    }
 
     return TileImage(
       vsync: this,


### PR DESCRIPTION
This is probably how I should've implemented it in the first place back in #1622 - it's a much better interface and wouldn't have been breaking. However, it's too late now, so I've opened this as draft.

https://github.com/dart-lang/http/pull/978 has been re-opened. I'm hopeful it will get merged at some point. If it does, we will want to more strongly enforce the cancellable mechanisms, and maybe that will be a good time to switch to an implementation like this.