### PR TITLE
fix: polygon hit detection when map is rotated

### DIFF
--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -52,7 +52,12 @@ base class _PolygonPainter<R extends Object>
     required math.Point<double> point,
     required LatLng coordinate,
   }) {
-    final polygon = projectedPolygon.polygon;
+    // TODO: We should check the bounding box here, for efficiency
+    // However, we need to account for map rotation
+    //
+    // if (!polygon.boundingBox.contains(touch)) {
+    //   continue;
+    // }
 
     final projectedCoords = getOffsetsXY(
       camera: camera,

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -53,9 +53,6 @@ base class _PolygonPainter<R extends Object>
     required LatLng coordinate,
   }) {
     final polygon = projectedPolygon.polygon;
-    if (!polygon.boundingBox.contains(coordinate)) {
-      return false;
-    }
 
     final projectedCoords = getOffsetsXY(
       camera: camera,

--- a/lib/src/layer/polyline_layer/painter.dart
+++ b/lib/src/layer/polyline_layer/painter.dart
@@ -31,6 +31,8 @@ base class _PolylinePainter<R extends Object>
     // if (!polyline.boundingBox.contains(touch)) {
     //   continue;
     // }
+    // Be careful with map orientation, though, and try to code similar things
+    // for polygons.
 
     final offsets = getOffsetsXY(
       camera: camera,

--- a/lib/src/layer/polyline_layer/painter.dart
+++ b/lib/src/layer/polyline_layer/painter.dart
@@ -25,14 +25,14 @@ base class _PolylinePainter<R extends Object>
   }) {
     final polyline = projectedPolyline.polyline;
 
-    // TODO: For efficiency we'd ideally filter by bounding box here. However
-    // we'd need to compute an extended bounding box that accounts account for
-    // the `borderStrokeWidth` & the `minimumHitbox`
+    // TODO: We should check the bounding box here, for efficiency
+    // However, we need to account for:
+    //  * map rotation
+    //  * extended bbox that accounts for `minimumHitbox`
+    //
     // if (!polyline.boundingBox.contains(touch)) {
     //   continue;
     // }
-    // Be careful with map orientation, though, and try to code similar things
-    // for polygons.
 
     final offsets = getOffsetsXY(
       camera: camera,

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -347,7 +347,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
 
   late final _resetSub = widget.reset?.listen((_) {
     _tileImageManager.removeAll(widget.evictErrorTileStrategy);
-    _loadAndPruneInVisibleBounds(MapCamera.of(context));
+    if (mounted) _loadAndPruneInVisibleBounds(MapCamera.of(context));
   });
 
   // This is called on every map movement so we should avoid expensive logic


### PR DESCRIPTION
Fixes #1934.

Removed an optimization that prevented the hit test to work for polygons on rotated maps.