### PR TITLE
fix: remove `hitValue` from `Polyline.renderHashCode`

### DIFF
--- a/lib/src/layer/polyline_layer/polyline.dart
+++ b/lib/src/layer/polyline_layer/polyline.dart
@@ -91,7 +91,6 @@ class Polyline<R extends Object> {
         strokeCap,
         strokeJoin,
         useStrokeWidthInMeter,
-        hitValue,
       );
 
   int? _hashCode;


### PR DESCRIPTION
Should result in a performance improvement when using interactive polylines.