### PR TITLE
fix: 1338 - longitude +-180 with correct polylines and polygons

### DIFF
--- a/example/lib/pages/polygon.dart
+++ b/example/lib/pages/polygon.dart
@@ -330,6 +330,35 @@ class _PolygonPageState extends State<PolygonPage> {
                 polygons: [
                   Polygon(
                     points: const [
+                      LatLng(40, 150),
+                      LatLng(45, 160),
+                      LatLng(50, 170),
+                      LatLng(55, 180),
+                      LatLng(50, -170),
+                      LatLng(45, -160),
+                      LatLng(40, -150),
+                      LatLng(35, -160),
+                      LatLng(30, -170),
+                      LatLng(25, -180),
+                      LatLng(30, 170),
+                      LatLng(35, 160),
+                    ],
+                    holePointsList: const [
+                      [
+                        LatLng(45, 175),
+                        LatLng(45, -175),
+                        LatLng(35, -175),
+                        LatLng(35, 175),
+                      ],
+                    ],
+                    color: const Color(0xFFFF0000),
+                    hitValue: (
+                      title: 'Red Line',
+                      subtitle: 'Across the universe...',
+                    ),
+                  ),
+                  Polygon(
+                    points: const [
                       LatLng(50, -18),
                       LatLng(50, -14),
                       LatLng(51.5, -12.5),

--- a/example/lib/pages/polyline.dart
+++ b/example/lib/pages/polyline.dart
@@ -23,6 +23,23 @@ class _PolylinePageState extends State<PolylinePage> {
 
   final _polylinesRaw = <Polyline<HitValue>>[
     Polyline(
+      points: const [
+        LatLng(40, 150),
+        LatLng(45, 160),
+        LatLng(50, 170),
+        LatLng(55, 180),
+        LatLng(50, -170),
+        LatLng(45, -160),
+        LatLng(40, -150),
+      ],
+      strokeWidth: 8,
+      color: const Color(0xFFFF0000),
+      hitValue: (
+        title: 'Red Line',
+        subtitle: 'Across the universe...',
+      ),
+    ),
+    Polyline(
       points: [
         const LatLng(51.5, -0.09),
         const LatLng(53.3498, -6.2603),

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -286,13 +286,12 @@ base class _PolygonPainter<R extends Object>
         // and the normal points are the same
         filledPath.fillType = PathFillType.evenOdd;
 
-        final holeOffsetsList = List<List<Offset>>.generate(
-          holePointsList.length,
-          (i) => getOffsets(camera, origin, holePointsList[i]),
-          growable: false,
-        );
-
-        for (final holeOffsets in holeOffsetsList) {
+        for (final singleHolePoints in projectedPolygon.holePoints) {
+          final holeOffsets = getOffsetsXY(
+            camera: camera,
+            origin: origin,
+            points: singleHolePoints,
+          );
           filledPath.addPolygon(holeOffsets, true);
 
           // TODO: Potentially more efficient and may change the need to do
@@ -307,15 +306,23 @@ base class _PolygonPainter<R extends Object>
         }
 
         if (!polygon.disableHolesBorder && polygon.borderStrokeWidth > 0.0) {
-          _addHoleBordersToPath(
-            borderPath,
-            polygon,
-            holeOffsetsList,
-            size,
-            canvas,
-            _getBorderPaint(polygon),
-            polygon.borderStrokeWidth,
-          );
+          final borderPaint = _getBorderPaint(polygon);
+          for (final singleHolePoints in projectedPolygon.holePoints) {
+            final holeOffsets = getOffsetsXY(
+              camera: camera,
+              origin: origin,
+              points: singleHolePoints,
+            );
+            _addBorderToPath(
+              borderPath,
+              polygon,
+              holeOffsets,
+              size,
+              canvas,
+              borderPaint,
+              polygon.borderStrokeWidth,
+            );
+          }
         }
       }
 
@@ -431,28 +438,6 @@ base class _PolygonPainter<R extends Object>
         path.moveTo(visibleSegment.begin.dx, visibleSegment.begin.dy);
         path.lineTo(visibleSegment.end.dx, visibleSegment.end.dy);
       }
-    }
-  }
-
-  void _addHoleBordersToPath(
-    Path path,
-    Polygon polygon,
-    List<List<Offset>> holeOffsetsList,
-    Size canvasSize,
-    Canvas canvas,
-    Paint paint,
-    double strokeWidth,
-  ) {
-    for (final offsets in holeOffsetsList) {
-      _addBorderToPath(
-        path,
-        polygon,
-        offsets,
-        canvasSize,
-        canvas,
-        paint,
-        strokeWidth,
-      );
     }
   }
 

--- a/lib/src/layer/polygon_layer/projected_polygon.dart
+++ b/lib/src/layer/polygon_layer/projected_polygon.dart
@@ -18,35 +18,22 @@ class _ProjectedPolygon<R extends Object> with HitDetectableElement<R> {
   _ProjectedPolygon._fromPolygon(Projection projection, Polygon<R> polygon)
       : this._(
           polygon: polygon,
-          points: List<DoublePoint>.generate(
-            polygon.points.length,
-            (j) {
-              final (x, y) = projection.projectXY(polygon.points[j]);
-              return DoublePoint(x, y);
-            },
-            growable: false,
-          ),
+          points: projection.projectList(polygon.points),
           holePoints: () {
             final holes = polygon.holePointsList;
             if (holes == null ||
                 holes.isEmpty ||
+                polygon.points.isEmpty ||
                 holes.every((e) => e.isEmpty)) {
               return <List<DoublePoint>>[];
             }
 
             return List<List<DoublePoint>>.generate(
               holes.length,
-              (j) {
-                final points = holes[j];
-                return List<DoublePoint>.generate(
-                  points.length,
-                  (k) {
-                    final (x, y) = projection.projectXY(points[k]);
-                    return DoublePoint(x, y);
-                  },
-                  growable: false,
-                );
-              },
+              (j) => projection.projectList(
+                holes[j],
+                referencePoint: polygon.points[0],
+              ),
               growable: false,
             );
           }(),

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -140,11 +140,19 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>>
       projection.project(boundsAdjusted.northEast),
     );
 
+    final halfWorldWidth = projection.getHalfWorldWidth();
+
     for (final projectedPolyline in polylines) {
       final polyline = projectedPolyline.polyline;
 
       // Gradient poylines cannot be easily segmented
       if (polyline.gradientColors != null) {
+        yield projectedPolyline;
+        continue;
+      }
+
+      // TODO: think about how to cull polylines that go beyond the universe.
+      if (projectedPolyline.goesBeyondTheUniverse(halfWorldWidth)) {
         yield projectedPolyline;
         continue;
       }

--- a/lib/src/layer/polyline_layer/projected_polyline.dart
+++ b/lib/src/layer/polyline_layer/projected_polyline.dart
@@ -16,13 +16,16 @@ class _ProjectedPolyline<R extends Object> with HitDetectableElement<R> {
   _ProjectedPolyline._fromPolyline(Projection projection, Polyline<R> polyline)
       : this._(
           polyline: polyline,
-          points: List<DoublePoint>.generate(
-            polyline.points.length,
-            (j) {
-              final (x, y) = projection.projectXY(polyline.points[j]);
-              return DoublePoint(x, y);
-            },
-            growable: false,
-          ),
+          points: projection.projectList(polyline.points),
         );
+
+  /// Returns true if the points stretch on different versions of the world.
+  bool goesBeyondTheUniverse(double halfWorldWidth) {
+    for (final point in points) {
+      if (point.x > halfWorldWidth || point.x < -halfWorldWidth) {
+        return true;
+      }
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
### What
* This PR deals with polylines and polygons (with or without holes) across longitudes +-180.
* The main issue was that longitudes -179 and 179 were projected in opposite sides of the world, although they are geographically nearby.
* The solution is to build incrementally the list of projected points: if two consecutive projected points are obviously too far away (more than half a world away), we add/remove one world width to the latter point.
* Doing so, we avoid jumping around -180 and +180, and we ensure the continuity among the points.
* The PR doesn't deal with the "teleportation" effect. This will be done in another PR, once we're confident with that "add/remove a world width" strategy.

### Screenshots
| Polyline: before / after |
| -- |
| ![Screenshot_1727023511](https://github.com/user-attachments/assets/ea46c801-61ae-4f06-91cb-f96b8c21794d) |
| ![Screenshot_1727023556](https://github.com/user-attachments/assets/10fb8832-8d3b-4303-a7a4-1d52a3b04e2b) |

| Polygon with hole: before / after |
| -- |
| ![Screenshot_1727023664](https://github.com/user-attachments/assets/94951cd6-8d4c-4c00-bc44-7dfa348c5ab8) |
| ![Screenshot_1727023641](https://github.com/user-attachments/assets/2fbe84d0-04a0-45c4-83cc-033564121991) |

### Impacted files
* `crs.dart`: new methods `getHalfWorldWidth` and `projectList`
* `painter.dart`: refactored using pre-computed `List<Double>`
* `polygon.dart`: added an example around longitude 180
* `polyline.dart`: added an example around longitude 180
* `polyline_layer.dart`: we don't cull polylines that go beyond longitude 180
* `projected_polygon.dart`: using new method `Projection.projectList`
* `projected_polyline.dart`: using new method `Projection.projectList`