### PR TITLE
feat: expose `BaseOverlayImage` for external implementation

### DIFF
--- a/lib/src/layer/overlay_image_layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer/overlay_image_layer.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';


### PR DESCRIPTION
* Switch to `abstract` instead of `sealed`
* Renamed `_render` to `layout` (added protected metadata)
* Removed non-virtual metadata from `build`
* Replaced `Image.color` & `.colorBlendMode` for `opacity` support with normal `.opacity` field using `AlwaysStoppedAnimation`
* Removed ambient `MapCamera` from `layout` arguments

I feel like we're overcomplicating things, and maybe doing too much for the user? It's much more flexible if we allow the user to pass their own `Image`, and not much more difficult if we allow them to do so. I'm not sure if it would work, but then wouldn't any widget work (like https://github.com/TimBaumgart/flutter_map_polywidget), not just images?