### PR TITLE
fix(perf): fixed massive performance issue in simplification steps for `Polyline/gonLayer`s

### DIFF
--- a/lib/src/layer/shared/layer_projection_simplification/state.dart
+++ b/lib/src/layer/shared/layer_projection_simplification/state.dart
@@ -42,10 +42,10 @@ mixin ProjectionSimplificationManagement<
   ///
   /// Do not use before invoking [build]. Only necessarily up to date directly
   /// after [build] has been invoked.
-  late Iterable<ProjectedElement> simplifiedElements;
+  late List<ProjectedElement> simplifiedElements;
 
-  Iterable<ProjectedElement>? _cachedProjectedElements;
-  final _cachedSimplifiedElements = <int, Iterable<ProjectedElement>>{};
+  List<ProjectedElement>? _cachedProjectedElements;
+  final _cachedSimplifiedElements = <int, List<ProjectedElement>>{};
 
   double? _devicePixelRatio;
 
@@ -89,12 +89,12 @@ mixin ProjectionSimplificationManagement<
       }
 
       simplifiedElements =
-          (_cachedSimplifiedElements[camera.zoom.floor()] ??= _simplifyElements(
+          _cachedSimplifiedElements[camera.zoom.floor()] ??= _simplifyElements(
         camera: camera,
         projectedElements: projected,
         pixelTolerance: widget.simplificationTolerance,
         devicePixelRatio: newDPR,
-      ));
+      ).toList(growable: false);
     }
 
     return Builder(


### PR DESCRIPTION
The caching of the simplification was not working correctly, and creating massive overheads.
Essentially, we were storing a lazily-generated `Iterable` in the simplification cache. This means that it was fully re-generated (re-simplified) on every cache retrieval: simplification had to run every frame. We now store a non-growable `List`.

Before:
![image](https://github.com/user-attachments/assets/43630c5f-ca4c-4fb4-ac6b-850146c68a7a)

After:
![image](https://github.com/user-attachments/assets/8405361c-fc06-4a1c-9024-4f0f3e140f69)
