### PR TITLE
chore(example): updated Android build config & migrated Web URL strategy

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -9,7 +9,7 @@ android {
     namespace = "dev.fleaflet.flutter_map.example"
     compileSdk = flutter.compileSdkVersion
     // ndkVersion = flutter.ndkVersion
-    ndkVersion = "26.1.10909125"
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.5.2' apply false
+    id "com.android.application" version '8.7.3' apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,10 +30,10 @@ import 'package:flutter_map_example/pages/sliding_map.dart';
 import 'package:flutter_map_example/pages/tile_builder.dart';
 import 'package:flutter_map_example/pages/tile_loading_error_handle.dart';
 import 'package:flutter_map_example/pages/wms_tile_layer.dart';
-import 'package:url_strategy/url_strategy.dart';
+import 'package:flutter_web_plugins/url_strategy.dart';
 
 void main() {
-  setPathUrlStrategy();
+  usePathUrlStrategy();
   runApp(const MyApp());
 }
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,12 +13,13 @@ dependencies:
   flutter_map:
   flutter_map_cancellable_tile_provider: ^3.0.2
   flutter_map_geojson: ^1.0.8
+  flutter_web_plugins:
+    sdk: flutter
   http: ^1.2.2
   latlong2: ^0.9.1
   proj4dart: ^2.1.0
-  shared_preferences: ^2.3.2
-  url_launcher: ^6.3.0
-  url_strategy: ^0.3.0
+  shared_preferences: ^2.3.4
+  url_launcher: ^6.3.1
   vector_math: ^2.1.4
 
 dependency_overrides:


### PR DESCRIPTION
- Upgraded Android example Gradle versions
- Migrated away from deprecated 'package:url_strategy' on web

Also confirmed we support 16KB page size for Android 15.