### PR TITLE
fix: resolve most tile pruning/state issues

### DIFF
--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -749,6 +749,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       pruneBuffer: max(widget.panBuffer, widget.keepBuffer),
       evictStrategy: widget.evictErrorTileStrategy,
     );
+    setState(() {});
   }
 
   bool _outsideZoomLimits(num zoom) =>


### PR DESCRIPTION
fixes #1837

there are still some instances I can get the tiles to not prune when zooming, but i am not sure the exact conditions. it might be related to multi-level zooms, or prune timers? though it seems like they all appropriately callback.

As part of this PR i also looked to add optimistic tile pruning of the parent when all 4 children are loaded, however quickly ran into state consistency issues. This is a simple quick fix to resolve most of the problem, but the tile layer really needs a rewrite as some of the state is held inside of a `Manager` which cannot call setState when making changes to the tiles, leading to visual bugs, like this one. I tried to add a setState callback, but ran into flutter issues (as it is generally bad practice) to do this.

So as a mostly-fix, I am adding a setState callback, which adds a few more calls to setState, but the performance impact is minimal (meaning only causing a few more widget draws, which isn't a big deal at all, however we should be able to just call setState under the manager and only update when we update the tiles), and not making the widget drawing slower. I did not notice a meaningful difference in the numbe of rendered frames after moving the map/zooming/animating when profiling.

This setState call also conveniently fixes another bug where changing the tileUrl didn't always update the drawing when it finishes loading.