### PR TITLE
fix: use `Client` instead of `BaseClient` in network tile/image provider

### DIFF
--- a/lib/src/layer/tile_layer/tile_provider/network_image_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/network_image_provider.dart
@@ -32,7 +32,7 @@ class MapNetworkImageProvider extends ImageProvider<MapNetworkImageProvider> {
   /// The HTTP client to use to make network requests
   ///
   /// Not included in [operator==].
-  final BaseClient httpClient;
+  final Client httpClient;
 
   /// Whether to ignore exceptions and errors that occur whilst fetching tiles
   /// over the network, and just return a transparent tile

--- a/lib/src/layer/tile_layer/tile_provider/network_tile_provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/network_tile_provider.dart
@@ -34,7 +34,7 @@ class NetworkTileProvider extends TileProvider {
   /// [not yet supported in Dart](https://github.com/dart-lang/http/issues/424).
   NetworkTileProvider({
     super.headers,
-    BaseClient? httpClient,
+    Client? httpClient,
     this.silenceExceptions = false,
   }) : _httpClient = httpClient ?? RetryClient(Client());
 
@@ -45,7 +45,7 @@ class NetworkTileProvider extends TileProvider {
   /// Long living client used to make all tile requests by
   /// [MapNetworkImageProvider] for the duration that this provider is
   /// alive
-  final BaseClient _httpClient;
+  final Client _httpClient;
 
   /// Each [Completer] is completed once the corresponding tile has finished
   /// loading


### PR DESCRIPTION
Fixes #2010

## Issue
`NetworkTileProvider` and `MapNetworkImageProvider` cannot be used with implementations of the http `Client` library.

## Resolution
Switch out incorrect `BaseClient` usage with `Client`.

## References

- https://pub.dev/documentation/http/latest/http/BaseClient-class.html
- https://pub.dev/documentation/http/latest/http/Client-class.html

## Notes

This fix uses the interface class and not the mixin implementation class that is used at the moment.

This change is backwards compatible and will not affect current usage of these classes as BaseClient implements Client interface.

@JaffaKetchup I am working on a project that would need this change. I'd be most greatful if we can get this out in a release. Thanks!