### PR TITLE
feat: add multi-world support to `CircleMarker`s

### DIFF
--- a/example/lib/pages/circle.dart
+++ b/example/lib/pages/circle.dart
@@ -21,12 +21,15 @@ class _CirclePageState extends State<CirclePage> {
   List<HitValue>? _prevHitValues;
   List<CircleMarker<HitValue>>? _hoverCircles;
 
+  static const double _initialBorderStrokeWidth = 2;
+  static const double _hoverBorderStrokeWidth = 15;
+
   final _circlesRaw = <CircleMarker<HitValue>>[
     CircleMarker(
       point: const LatLng(51.5, -0.09),
       color: Colors.white.withAlpha(178),
       borderColor: Colors.black,
-      borderStrokeWidth: 2,
+      borderStrokeWidth: _initialBorderStrokeWidth,
       useRadiusInMeter: false,
       radius: 100,
       hitValue: (title: 'White', subtitle: 'Radius in logical pixels'),
@@ -35,7 +38,7 @@ class _CirclePageState extends State<CirclePage> {
       point: const LatLng(51.5, -0.09),
       color: Colors.black.withAlpha(178),
       borderColor: Colors.black,
-      borderStrokeWidth: 2,
+      borderStrokeWidth: _initialBorderStrokeWidth,
       useRadiusInMeter: false,
       radius: 50,
       hitValue: (
@@ -48,9 +51,10 @@ class _CirclePageState extends State<CirclePage> {
       // Dorney Lake is ~2km long
       color: Colors.green.withAlpha(229),
       borderColor: Colors.black,
-      borderStrokeWidth: 2,
+      borderStrokeWidth: _initialBorderStrokeWidth,
       useRadiusInMeter: true,
-      radius: 1000, // 1000 meters
+      radius: 1000,
+      // 1000 meters
       hitValue: (
         title: 'Green',
         subtitle: 'Radius in meters, calibrated over ~2km rowing lake'
@@ -87,10 +91,12 @@ class _CirclePageState extends State<CirclePage> {
 
                 return CircleMarker<HitValue>(
                   point: original.point,
-                  radius: original.radius + 6.5,
+                  radius: original.radius +
+                      _initialBorderStrokeWidth / 2 +
+                      _hoverBorderStrokeWidth / 2,
                   useRadiusInMeter: original.useRadiusInMeter,
                   color: Colors.transparent,
-                  borderStrokeWidth: 15,
+                  borderStrokeWidth: _hoverBorderStrokeWidth,
                   borderColor: Colors.green,
                 );
               }).toList();

--- a/example/lib/pages/multi_worlds.dart
+++ b/example/lib/pages/multi_worlds.dart
@@ -47,7 +47,7 @@ class _MultiWorldsPageState extends State<MultiWorldsPage> {
                       radius: 1000000,
                       color: Color.from(alpha: .8, red: 1, green: 1, blue: 0),
                       borderColor: Colors.green,
-                      borderStrokeWidth: 100000,
+                      borderStrokeWidth: 2,
                       hitValue: 'Brisbane',
                       useRadiusInMeter: true,
                     ),

--- a/example/lib/pages/multi_worlds.dart
+++ b/example/lib/pages/multi_worlds.dart
@@ -15,6 +15,8 @@ class MultiWorldsPage extends StatefulWidget {
 }
 
 class _MultiWorldsPageState extends State<MultiWorldsPage> {
+  final LayerHitNotifier<String> _hitNotifier = ValueNotifier(null);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -30,6 +32,36 @@ class _MultiWorldsPageState extends State<MultiWorldsPage> {
             ),
             children: [
               openStreetMapTileLayer,
+              GestureDetector(
+                onTap: () => ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(_hitNotifier.value!.hitValues.join(', ')),
+                    duration: const Duration(seconds: 1),
+                    showCloseIcon: true,
+                  ),
+                ),
+                child: CircleLayer<String>(
+                  circles: [
+                    const CircleMarker(
+                      point: LatLng(-27.466667, 153.033333),
+                      radius: 10,
+                      color: Colors.yellow,
+                      borderColor: Colors.green,
+                      borderStrokeWidth: 2,
+                      hitValue: 'Brisbane',
+                    ),
+                    const CircleMarker(
+                      point: LatLng(45.466667, 9.166667),
+                      radius: 10,
+                      color: Colors.green,
+                      borderColor: Colors.red,
+                      borderStrokeWidth: 2,
+                      hitValue: 'Milan',
+                    ),
+                  ],
+                  hitNotifier: _hitNotifier,
+                ),
+              ),
               MarkerLayer(
                 markers: [
                   Marker(

--- a/example/lib/pages/multi_worlds.dart
+++ b/example/lib/pages/multi_worlds.dart
@@ -44,11 +44,12 @@ class _MultiWorldsPageState extends State<MultiWorldsPage> {
                   circles: [
                     const CircleMarker(
                       point: LatLng(-27.466667, 153.033333),
-                      radius: 10,
-                      color: Colors.yellow,
+                      radius: 1_000_000,
+                      color: Color.from(alpha: .8, red: 1, green: 1, blue: 0),
                       borderColor: Colors.green,
-                      borderStrokeWidth: 2,
+                      borderStrokeWidth: 100_000,
                       hitValue: 'Brisbane',
+                      useRadiusInMeter: true,
                     ),
                     const CircleMarker(
                       point: LatLng(45.466667, 9.166667),

--- a/example/lib/pages/multi_worlds.dart
+++ b/example/lib/pages/multi_worlds.dart
@@ -44,10 +44,10 @@ class _MultiWorldsPageState extends State<MultiWorldsPage> {
                   circles: [
                     const CircleMarker(
                       point: LatLng(-27.466667, 153.033333),
-                      radius: 1_000_000,
+                      radius: 1000000,
                       color: Color.from(alpha: .8, red: 1, green: 1, blue: 0),
                       borderColor: Colors.green,
-                      borderStrokeWidth: 100_000,
+                      borderStrokeWidth: 100000,
                       hitValue: 'Brisbane',
                       useRadiusInMeter: true,
                     ),

--- a/lib/src/layer/circle_layer/painter.dart
+++ b/lib/src/layer/circle_layer/painter.dart
@@ -1,7 +1,6 @@
 part of 'circle_layer.dart';
 
 /// The [CustomPainter] used to draw [CircleMarker] for the [CircleLayer].
-@immutable
 base class CirclePainter<R extends Object>
     extends HitDetectablePainter<R, CircleMarker<R>> {
   /// Reference to the list of [CircleMarker]s of the [CircleLayer].
@@ -23,72 +22,136 @@ base class CirclePainter<R extends Object>
     required Offset point,
     required LatLng coordinate,
   }) {
-    final circle = element; // Should be optimized out by compiler, avoids lint
+    final worldWidth = _getWorldWidth();
 
-    final center = camera.getOffsetFromOrigin(circle.point);
-    final radius = circle.useRadiusInMeter
-        ? (center -
-                camera.getOffsetFromOrigin(
-                    _distance.offset(circle.point, circle.radius, 180)))
-            .distance
-        : circle.radius;
+    /// Returns null if invisible, true if hit, false if not hit.
+    bool? checkIfHit(double worldWidth) {
+      final center = _getOffset(element, worldWidth);
+      final radius = _getRadius(center, element);
+      if (!_isVisible(
+        screenRect: _screenRect,
+        center: center,
+        radius: radius,
+      )) {
+        return null;
+      }
 
-    return pow(point.dx - center.dx, 2) + pow(point.dy - center.dy, 2) <=
-        radius * radius;
+      return pow(point.dx - center.dx, 2) + pow(point.dy - center.dy, 2) <=
+          radius * radius;
+    }
+
+    if (checkIfHit(0) ?? false) {
+      return true;
+    }
+
+    // Repeat over all worlds (<--||-->) until culling determines that
+    // that element is out of view, and therefore all further elements in
+    // that direction will also be
+    if (worldWidth == 0) return false;
+    for (double shift = -worldWidth;; shift -= worldWidth) {
+      final isHit = checkIfHit(shift);
+      if (isHit == null) break;
+      if (isHit) return true;
+    }
+    for (double shift = worldWidth;; shift += worldWidth) {
+      final isHit = checkIfHit(shift);
+      if (isHit == null) break;
+      if (isHit) return true;
+    }
+
+    return false;
   }
 
   @override
   Iterable<CircleMarker<R>> get elements => circles;
 
+  late Rect _screenRect;
+
   @override
   void paint(Canvas canvas, Size size) {
-    final rect = Offset.zero & size;
-    canvas.clipRect(rect);
+    _screenRect = Offset.zero & size;
+    canvas.clipRect(_screenRect);
+
+    final worldWidth = _getWorldWidth();
 
     // Let's calculate all the points grouped by color and radius
     final points = <Color, Map<double, List<Offset>>>{};
     final pointsFilledBorder = <Color, Map<double, List<Offset>>>{};
     final pointsBorder = <Color, Map<double, Map<double, List<Offset>>>>{};
     for (final circle in circles) {
-      final center = camera.getOffsetFromOrigin(circle.point);
-      final radius = circle.useRadiusInMeter
-          ? (center -
-                  camera.getOffsetFromOrigin(
-                      _distance.offset(circle.point, circle.radius, 180)))
-              .distance
-          : circle.radius;
-      points[circle.color] ??= {};
-      points[circle.color]![radius] ??= [];
-      points[circle.color]![radius]!.add(center);
+      bool checkIfVisible(double worldWidth) {
+        bool result = false;
+        final center = _getOffset(circle, worldWidth);
 
-      if (circle.borderStrokeWidth > 0) {
-        // Check if color have some transparency or not
-        // As drawPoints is more efficient than drawCircle
-        if (circle.color.a == 1) {
-          double radiusBorder = circle.radius + circle.borderStrokeWidth;
-          if (circle.useRadiusInMeter) {
-            final rBorder = _distance.offset(circle.point, radiusBorder, 180);
-            final deltaBorder = center - camera.getOffsetFromOrigin(rBorder);
-            radiusBorder = deltaBorder.distance;
+        bool isVisible(double radius) {
+          if (_isVisible(
+            screenRect: _screenRect,
+            center: center,
+            radius: radius,
+          )) {
+            return result = true;
           }
-          pointsFilledBorder[circle.borderColor] ??= {};
-          pointsFilledBorder[circle.borderColor]![radiusBorder] ??= [];
-          pointsFilledBorder[circle.borderColor]![radiusBorder]!.add(center);
-        } else {
-          double realRadius = circle.radius;
-          if (circle.useRadiusInMeter) {
-            final rBorder = _distance.offset(circle.point, realRadius, 180);
-            final deltaBorder = center - camera.getOffsetFromOrigin(rBorder);
-            realRadius = deltaBorder.distance;
-          }
-          pointsBorder[circle.borderColor] ??= {};
-          pointsBorder[circle.borderColor]![circle.borderStrokeWidth] ??= {};
-          pointsBorder[circle.borderColor]![circle.borderStrokeWidth]![
-              realRadius] ??= [];
-          pointsBorder[circle.borderColor]![circle.borderStrokeWidth]![
-                  realRadius]!
-              .add(center);
+          return false;
         }
+
+        final radius = _getRadius(center, circle);
+        if (isVisible(radius)) {
+          points[circle.color] ??= {};
+          points[circle.color]![radius] ??= [];
+          points[circle.color]![radius]!.add(center);
+        }
+
+        if (circle.borderStrokeWidth > 0) {
+          // Check if color have some transparency or not
+          // As drawPoints is more efficient than drawCircle
+          if (circle.color.a == 1) {
+            double radiusBorder = circle.radius + circle.borderStrokeWidth;
+            if (circle.useRadiusInMeter) {
+              final rBorder = _distance.offset(circle.point, radiusBorder, 180);
+              final deltaBorder = center - camera.getOffsetFromOrigin(rBorder);
+              radiusBorder = deltaBorder.distance;
+            }
+            if (isVisible(radiusBorder)) {
+              pointsFilledBorder[circle.borderColor] ??= {};
+              pointsFilledBorder[circle.borderColor]![radiusBorder] ??= [];
+              pointsFilledBorder[circle.borderColor]![radiusBorder]!
+                  .add(center);
+            }
+          } else {
+            double realRadius = circle.radius;
+            if (circle.useRadiusInMeter) {
+              final rBorder = _distance.offset(circle.point, realRadius, 180);
+              final deltaBorder = center - camera.getOffsetFromOrigin(rBorder);
+              realRadius = deltaBorder.distance;
+            }
+            if (isVisible(circle.borderStrokeWidth)) {
+              pointsBorder[circle.borderColor] ??= {};
+              pointsBorder[circle.borderColor]![circle.borderStrokeWidth] ??=
+                  {};
+              pointsBorder[circle.borderColor]![circle.borderStrokeWidth]![
+                  realRadius] ??= [];
+              pointsBorder[circle.borderColor]![circle.borderStrokeWidth]![
+                      realRadius]!
+                  .add(center);
+            }
+          }
+        }
+        return result;
+      }
+
+      checkIfVisible(0);
+
+      // Repeat over all worlds (<--||-->) until culling determines that
+      // that element is out of view, and therefore all further elements in
+      // that direction will also be
+      if (worldWidth == 0) continue;
+      for (double shift = -worldWidth;; shift -= worldWidth) {
+        final isVisible = checkIfVisible(shift);
+        if (!isVisible) break;
+      }
+      for (double shift = worldWidth;; shift += worldWidth) {
+        final isVisible = checkIfVisible(shift);
+        if (!isVisible) break;
       }
     }
 
@@ -145,4 +208,33 @@ base class CirclePainter<R extends Object>
   @override
   bool shouldRepaint(CirclePainter oldDelegate) =>
       circles != oldDelegate.circles || camera != oldDelegate.camera;
+
+  Offset _getOffset(CircleMarker circle, double worldWidth) =>
+      camera.getOffsetFromOrigin(circle.point).translate(
+            worldWidth,
+            0,
+          );
+
+  /// Returns true if a centered circle with this radius is on the screen.
+  bool _isVisible({
+    required Rect screenRect,
+    required Offset center,
+    required double radius,
+  }) =>
+      screenRect.overlaps(
+        Rect.fromCircle(
+          center: center,
+          radius: radius,
+        ),
+      );
+
+  double _getRadius(Offset center, CircleMarker<R> circle) =>
+      circle.useRadiusInMeter
+          ? (center -
+                  camera.getOffsetFromOrigin(
+                      _distance.offset(circle.point, circle.radius, 180)))
+              .distance
+          : circle.radius;
+
+  double _getWorldWidth() => camera.getWorldWidthAtZoom();
 }


### PR DESCRIPTION
Now `CircleMarker`s are replicated on all visible worlds.
That includes both display and hit detection.
Some refactoring involved.

Impacted files:
* `multi_worlds.dart`: added a couple of `CircleMarker`s
* `painter.dart`: added replication of circle display and hit detection on all visible worlds

![Screenshot_1737904593](https://github.com/user-attachments/assets/940bc22d-6c61-4265-a336-735daa6b0a74)

![Screenshot_1737904630](https://github.com/user-attachments/assets/b5a7ea90-6eb1-4b9c-a8d3-c27b2858fc01)