### PR TITLE
fix: invoke map interaction callbacks with coordinates in primary world

### DIFF
--- a/example/lib/pages/multi_worlds.dart
+++ b/example/lib/pages/multi_worlds.dart
@@ -17,6 +17,24 @@ class MultiWorldsPage extends StatefulWidget {
 class _MultiWorldsPageState extends State<MultiWorldsPage> {
   final LayerHitNotifier<String> _hitNotifier = ValueNotifier(null);
 
+  final _customMarkers = <Marker>[];
+
+  Marker _buildPin(LatLng point) => Marker(
+        point: point,
+        width: 60,
+        height: 60,
+        child: GestureDetector(
+          onTap: () => ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Tapped existing marker'),
+              duration: Duration(seconds: 1),
+              showCloseIcon: true,
+            ),
+          ),
+          child: const Icon(Icons.location_pin, color: Colors.red),
+        ),
+      );
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -25,10 +43,11 @@ class _MultiWorldsPageState extends State<MultiWorldsPage> {
       body: Stack(
         children: [
           FlutterMap(
-            options: const MapOptions(
-              initialCenter: LatLng(51.5, -0.09),
+            options: MapOptions(
+              initialCenter: const LatLng(51.5, -0.09),
               initialZoom: 0,
               initialRotation: 0,
+              onTap: (_, p) => setState(() => _customMarkers.add(_buildPin(p))),
             ),
             children: [
               openStreetMapTileLayer,
@@ -105,6 +124,7 @@ class _MultiWorldsPageState extends State<MultiWorldsPage> {
                       child: const Icon(Icons.backpack_outlined),
                     ),
                   ),
+                  ..._customMarkers,
                 ],
               ),
             ],

--- a/lib/src/map/camera/camera.dart
+++ b/lib/src/map/camera/camera.dart
@@ -240,12 +240,12 @@ class MapCamera {
       crs.offsetToLatLng(point, zoom ?? this.zoom);
 
   /// Returns the width of the world at the current zoom, or 0 if irrelevant.
-  double getWorldWidthAtZoom() {
+  double getWorldWidthAtZoom([double? zoom]) {
     if (!crs.replicatesWorldLongitude) {
       return 0;
     }
-    final offset0 = projectAtZoom(const LatLng(0, 0));
-    final offset180 = projectAtZoom(const LatLng(0, 180));
+    final offset0 = projectAtZoom(const LatLng(0, 0), zoom ?? this.zoom);
+    final offset180 = projectAtZoom(const LatLng(0, 180), zoom ?? this.zoom);
     return 2 * (offset180.dx - offset0.dx).abs();
   }
 
@@ -357,7 +357,17 @@ class MapCamera {
         (offset - nonRotatedSize.center(Offset.zero)).rotate(rotationRad);
 
     final newCenterPt = focalStartPt + point;
-    return unprojectAtZoom(newCenterPt, zoom ?? this.zoom);
+    final worldWidth = getWorldWidthAtZoom(zoom ?? this.zoom);
+    double bestX = newCenterPt.dx;
+    if (worldWidth != 0) {
+      while (bestX > worldWidth) {
+        bestX -= worldWidth;
+      }
+      while (bestX < 0) {
+        bestX += worldWidth;
+      }
+    }
+    return unprojectAtZoom(Offset(bestX, newCenterPt.dy), zoom ?? this.zoom);
   }
 
   /// Calculate the center point which would keep the same point of the map


### PR DESCRIPTION
### What
- Tapping on the map will be redirected to the main world, instead of being truncated on a -180 or 180 longitude.
- Fixes #2008.

### Impacted files
* `camera.dart`: now looking for the best world before unprojecting a pixel
* `multi_worlds.dart`: added an `onTap` event to create on the fly markers

### Adding markers around New Zealand and longitude 180
![Screenshot_1738239927](https://github.com/user-attachments/assets/32090a80-5faf-4f0e-b450-b81a4eabcd7c)

### Adding markers in a multi-world
![Screenshot_1738236612](https://github.com/user-attachments/assets/de55d866-389f-4b66-bfe3-4e1a3e406f62)
