### PR TITLE
fix: ensure `MapController.rotateAroundPoint` does not move map when already rotated

### DIFF
--- a/lib/src/map/controller/map_controller_impl.dart
+++ b/lib/src/map/controller/map_controller_impl.dart
@@ -245,8 +245,8 @@ class MapControllerImpl extends ValueNotifier<_MapControllerState>
     }
 
     final rotationDiff = degree - camera.rotation;
-    final rotationCenter = (camera.projectAtZoom(camera.center) + offset!)
-        .rotate(camera.rotationRad);
+    final rotationCenter = camera.projectAtZoom(camera.center) +
+        offset!.rotate(camera.rotationRad);
 
     return (
       moveSuccess: moveRaw(


### PR DESCRIPTION
fix #2028