### PR TITLE
fix: prevent infinite looping when polygon labels displayed on rotated map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ Please consider [donating](https://docs.fleaflet.dev/supporters#support-us) or [
 
 This CHANGELOG does not include every commit and/or PR - it is a hand picked selection of the ones that have an effect on you. For a full list of changes, please check the GitHub repository releases/tags.
 
-## [8.1.0] - 2025/02/XX
+## [8.1.1] - 2025/03/08
+
+Contains the following user-affecting bug fixes:
+
+- Prevent infinite looping when polygon labels displayed on rotated map - [#2054](https://github.com/fleaflet/flutter_map/pull/2054) for [#2052](https://github.com/fleaflet/flutter_map/issues/2052)
+
+Many thanks to these contributors (in no particular order):
+
+- @monsieurtanuki
+
+## [8.1.0] - 2025/02/25
 
 Contains the following user-affecting changes:
 
@@ -12,8 +22,8 @@ Contains the following user-affecting changes:
 
 Contains the following user-affecting bug fixes:
 
-- Ensure movement gestures emit events when starting - [#2035](https://github.com/fleaflet/flutter_map/pull/2035)
-- Ensure `MapController.rotateAroundPoint` does not move map when already rotated - [#2029](https://github.com/fleaflet/flutter_map/pull/2029)
+- Ensure movement gestures emit events when starting - [#2035](https://github.com/fleaflet/flutter_map/pull/2035) for [#1939](https://github.com/fleaflet/flutter_map/issues/1939)
+- Ensure `MapController.rotateAroundPoint` does not move map when already rotated - [#2029](https://github.com/fleaflet/flutter_map/pull/2029) for [#2028](https://github.com/fleaflet/flutter_map/issues/2028)
 
 Many thanks to these contributors (in no particular order):
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_map_example
 description: Example application for 'flutter_map' package
 publish_to: "none"
-version: 8.1.0
+version: 8.1.1
 
 environment:
   sdk: ">=3.6.0 <4.0.0"

--- a/lib/src/layer/polygon_layer/label.dart
+++ b/lib/src/layer/polygon_layer/label.dart
@@ -17,13 +17,26 @@ void Function(Canvas canvas)? _buildLabelTextPainter({
   // Cull labels where the polygon is still on the map but the label would not be.
   // Currently this is only enabled when the map isn't rotated, since the placementOffset
   // is relative to the MobileLayerTransformer rather than in actual screen coordinates.
+  final double textWidth;
+  final double textHeight;
+  final double mapWidth;
+  final double mapHeight;
   if (rotationRad == 0) {
-    if (dx + width / 2 < 0 || dx - width / 2 > mapSize.width) {
-      return null;
-    }
-    if (dy + height / 2 < 0 || dy - height / 2 > mapSize.height) {
-      return null;
-    }
+    textWidth = width;
+    textHeight = height;
+    mapWidth = mapSize.width;
+    mapHeight = mapSize.height;
+  } else {
+    // lazily we imagine the worst case scenario regarding sizes, instead of
+    // computing the angles
+   textWidth = textHeight = max(width, height);
+   mapWidth = mapHeight = max(mapSize.width, mapSize.height);
+  }
+  if (dx + textWidth / 2 < 0 || dx - textWidth / 2 > mapWidth) {
+    return null;
+  }
+  if (dy + textHeight / 2 < 0 || dy - textHeight / 2 > mapHeight) {
+    return null;
   }
 
   // Note: I'm pretty sure this doesn't work for concave shapes. It would be more

--- a/lib/src/layer/polygon_layer/label.dart
+++ b/lib/src/layer/polygon_layer/label.dart
@@ -29,8 +29,8 @@ void Function(Canvas canvas)? _buildLabelTextPainter({
   } else {
     // lazily we imagine the worst case scenario regarding sizes, instead of
     // computing the angles
-   textWidth = textHeight = max(width, height);
-   mapWidth = mapHeight = max(mapSize.width, mapSize.height);
+    textWidth = textHeight = max(width, height);
+    mapWidth = mapHeight = max(mapSize.width, mapSize.height);
   }
   if (dx + textWidth / 2 < 0 || dx - textWidth / 2 > mapWidth) {
     return null;

--- a/lib/src/layer/shared/feature_layer_utils.dart
+++ b/lib/src/layer/shared/feature_layer_utils.dart
@@ -54,29 +54,26 @@ mixin FeatureLayerUtils on CustomPainter {
   /// Internally, the worker is invoked in the 'negative' worlds (worlds to the
   /// left of the 'primary' world) until repetition is stopped, then in the
   /// 'positive' worlds: <--||-->.
-  ///
-  /// In order to avoid potential forever loops (if the `work` method somehow
-  /// fails to return `invisible`), we set an arbitrary limit to the number of
-  /// world replications, and throw an `Exception` when necessary.
-  /// e.g. https://github.com/fleaflet/flutter_map/issues/2052
   bool workAcrossWorlds(
-    WorldWorkControl Function(double shift) work, {
-    int maxOccurrences = 10,
-  }) {
-    int count = 0;
+    WorldWorkControl Function(double shift) work,
+  ) {
+    // Protection in case of unexpected infinite loop if `work` never returns
+    // `invisible`. e.g. https://github.com/fleaflet/flutter_map/issues/2052.
+    const maxShiftsCount = 10;
+    int shiftsCount = 0;
 
-    void checkCount() {
-      if (++count > maxOccurrences) throw Exception('Too many world loops');
+    void protectInfiniteLoop() {
+      if (++shiftsCount > maxShiftsCount) throw const StackOverflowError();
     }
 
-    checkCount();
+    protectInfiniteLoop();
     if (work(0) == WorldWorkControl.hit) return true;
 
     if (worldWidth == 0) return false;
 
     negativeWorldsLoop:
     for (double shift = -worldWidth;; shift -= worldWidth) {
-      checkCount();
+      protectInfiniteLoop();
       switch (work(shift)) {
         case WorldWorkControl.hit:
           return true;
@@ -87,7 +84,7 @@ mixin FeatureLayerUtils on CustomPainter {
     }
 
     for (double shift = worldWidth;; shift += worldWidth) {
-      checkCount();
+      protectInfiniteLoop();
       switch (work(shift)) {
         case WorldWorkControl.hit:
           return true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_map
 description: A versatile mapping package for Flutter, that's simple and easy to learn, yet completely customizable and configurable
-version: 8.1.0
+version: 8.1.1
 
 repository: https://github.com/fleaflet/flutter_map
 issue_tracker: https://github.com/fleaflet/flutter_map/issues

--- a/windowsApplicationInstallerSetup.iss
+++ b/windowsApplicationInstallerSetup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "flutter_map Demo"
-#define MyAppVersion "for 8.1.0"
+#define MyAppVersion "for 8.1.1"
 #define MyAppPublisher "fleaflet"
 #define MyAppURL "https://github.com/fleaflet/flutter_map"
 #define MyAppSupportURL "https://github.com/fleaflet/flutter_map/issues"


### PR DESCRIPTION
This #2052 fix is made of 2 separate parts.

One part is saying "No!" to forever loops: we assume that after trying to display on multiple worlds, if we keep trying it's because we'll never get an exit permit. And in that case we send an exception, which is slightly more refined than an ANR.

The second part deals more specifically with labels.
Only in the "no rotation" case we computed if the label was visible or not.
That means that in all non-0 rotation cases, we presumed that the label was visible, hence the forever loops.
Now we roughly compute cases when the label is invisible in all rotations. No more forever loops for labels.