### PR TITLE
fix: consider `zoomOffset` & emulated retina mode when generating tile coordinates

### DIFF
--- a/lib/src/layer/tile_layer/tile_coordinates.dart
+++ b/lib/src/layer/tile_layer/tile_coordinates.dart
@@ -61,10 +61,16 @@ class TileCoordinates extends Point<int> {
 /// simplify the tile coordinates: we just return the same value.
 class TileCoordinatesResolver {
   /// Resolves coordinates in the context of world replications.
-  const TileCoordinatesResolver(this.replicatesWorldLongitude);
+  const TileCoordinatesResolver(
+    this.replicatesWorldLongitude, {
+    this.zoomOffset = 0,
+  });
 
   /// True if we simplify the coordinates according to the world replications.
   final bool replicatesWorldLongitude;
+
+  /// The zoom number used for modulus will be offset with this value.
+  final int zoomOffset;
 
   /// Returns the simplification of the coordinates.
   TileCoordinates get(TileCoordinates positionCoordinates) {
@@ -74,7 +80,7 @@ class TileCoordinatesResolver {
     if (positionCoordinates.z < 0) {
       return positionCoordinates;
     }
-    final modulo = 1 << positionCoordinates.z;
+    final modulo = 1 << (positionCoordinates.z + zoomOffset);
     int x = positionCoordinates.x;
     while (x < 0) {
       x += modulo;

--- a/lib/src/layer/tile_layer/tile_image_manager.dart
+++ b/lib/src/layer/tile_layer/tile_image_manager.dart
@@ -30,11 +30,17 @@ class TileImageManager {
   TileCoordinatesResolver _resolver = const TileCoordinatesResolver(false);
 
   /// Sets if we replicate the world longitude in several worlds.
-  void setReplicatesWorldLongitude(bool replicatesWorldLongitude) {
-    if (_resolver.replicatesWorldLongitude == replicatesWorldLongitude) {
-      return;
+  void setReplicatesWorldLongitude(
+    bool replicatesWorldLongitude,
+    int zoomOffset,
+  ) {
+    if (_resolver.replicatesWorldLongitude != replicatesWorldLongitude ||
+        _resolver.zoomOffset != zoomOffset) {
+      _resolver = TileCoordinatesResolver(
+        replicatesWorldLongitude,
+        zoomOffset: zoomOffset,
+      );
     }
-    _resolver = TileCoordinatesResolver(replicatesWorldLongitude);
   }
 
   /// Filter tiles to only tiles that would be visible on screen. Specifically:

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -18,9 +18,7 @@ import 'package:http/retry.dart';
 import 'package:logger/logger.dart';
 
 part 'retina_mode.dart';
-
 part 'tile_error_evict_callback.dart';
-
 part 'wms_tile_layer_options.dart';
 
 /// Describes the needed properties to create a tile-based layer. A tile is an

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -18,7 +18,9 @@ import 'package:http/retry.dart';
 import 'package:logger/logger.dart';
 
 part 'retina_mode.dart';
+
 part 'tile_error_evict_callback.dart';
+
 part 'wms_tile_layer_options.dart';
 
 /// Describes the needed properties to create a tile-based layer. A tile is an
@@ -384,6 +386,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
 
     _tileImageManager.setReplicatesWorldLongitude(
       camera.crs.replicatesWorldLongitude,
+      widget.zoomOffset.round(),
     );
 
     if (_mapControllerHashCode != mapController.hashCode) {


### PR DESCRIPTION
The fix was to add the concept of `zoomOffset` to `TileCoordinatesResolver`, in order to compute correct modulus.
Fixes: #2042

The world as normal:
![Capture d'écran 2025-03-22 091437](https://github.com/user-attachments/assets/39902b0a-98e9-440a-8f0e-10f020c69135)

The world as simulated retina:
![Capture d'écran 2025-03-22 091457](https://github.com/user-attachments/assets/8fd09052-ec04-4996-9244-f1e3c7300251)
