### PR TITLE
feat: add double tap zoom specificity

### DIFF
--- a/lib/src/gestures/map_interactive_viewer.dart
+++ b/lib/src/gestures/map_interactive_viewer.dart
@@ -919,7 +919,9 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
     final flags = _interactionOptions.flags;
     if (InteractiveFlag.hasDoubleTapDragZoom(flags)) {
       final verticalOffset = (_focalStartLocal - details.localFocalPoint).dy;
-      final newZoom = _mapZoomStart - verticalOffset / 360 * _camera.zoom;
+      final zoomSpeed = 1 / _options.doubleTapZoomSpecificity;
+
+      final newZoom = _mapZoomStart - verticalOffset * zoomSpeed * _camera.zoom;
 
       final min = _options.minZoom ?? 0.0;
       final max = _options.maxZoom ?? double.infinity;

--- a/lib/src/map/options/options.dart
+++ b/lib/src/map/options/options.dart
@@ -78,6 +78,9 @@ class MapOptions {
   /// yellow grey-ish color.
   final Color backgroundColor;
 
+  /// The specificity with which the zoom happens. A higher value means slower zooming.
+  final double doubleTapZoomSpecificity;
+
   /// Callback that fires when the map gets tapped or clicked with the
   /// primary mouse button. This is normally the left mouse button. This
   /// callback does not fire if the gesture is recognized as a double click.
@@ -151,6 +154,7 @@ class MapOptions {
     this.minZoom,
     this.maxZoom,
     this.backgroundColor = const Color(0xFFE0E0E0),
+    this.doubleTapZoomSpecificity = 360.0,
     this.onTap,
     this.onSecondaryTap,
     this.onLongPress,
@@ -162,7 +166,7 @@ class MapOptions {
     this.onMapEvent,
     this.onMapReady,
     this.keepAlive = false,
-  });
+  }) : assert(doubleTapZoomSpecificity != 0, 'This value cannot be zero.');
 
   /// The options of the closest [FlutterMap] ancestor. If this is called from a
   /// context with no [FlutterMap] ancestor, null is returned.
@@ -187,6 +191,7 @@ class MapOptions {
       minZoom == other.minZoom &&
       maxZoom == other.maxZoom &&
       backgroundColor == other.backgroundColor &&
+      doubleTapZoomSpecificity == other.doubleTapZoomSpecificity &&
       onTap == other.onTap &&
       onSecondaryTap == other.onSecondaryTap &&
       onLongPress == other.onLongPress &&
@@ -211,6 +216,7 @@ class MapOptions {
         minZoom,
         maxZoom,
         backgroundColor,
+        doubleTapZoomSpecificity,
         onTap,
         onSecondaryTap,
         onLongPress,


### PR DESCRIPTION
Right now there is no option to configure the zoom speed for double tap zooming. This PR adds it to the MapOptions as a double.

We use this in our project as a result of a request from the client.