### PR TITLE
feat: added `Poly*Layer.drawInSingleWorld`

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,19 +15,19 @@ import 'package:flutter_map_example/pages/many_markers.dart';
 import 'package:flutter_map_example/pages/map_controller.dart';
 import 'package:flutter_map_example/pages/map_inside_listview.dart';
 import 'package:flutter_map_example/pages/markers.dart';
-import 'package:flutter_map_example/pages/multi_worlds.dart';
-import 'package:flutter_map_example/pages/one_world_or_not.dart';
 import 'package:flutter_map_example/pages/overlay_image.dart';
 import 'package:flutter_map_example/pages/plugin_zoombuttons.dart';
 import 'package:flutter_map_example/pages/polygon.dart';
 import 'package:flutter_map_example/pages/polygon_perf_stress.dart';
 import 'package:flutter_map_example/pages/polyline.dart';
 import 'package:flutter_map_example/pages/polyline_perf_stress.dart';
+import 'package:flutter_map_example/pages/repeated_worlds.dart';
 import 'package:flutter_map_example/pages/reset_tile_layer.dart';
 import 'package:flutter_map_example/pages/retina.dart';
 import 'package:flutter_map_example/pages/scalebar.dart';
 import 'package:flutter_map_example/pages/screen_point_to_latlng.dart';
 import 'package:flutter_map_example/pages/secondary_tap.dart';
+import 'package:flutter_map_example/pages/single_world_polys.dart';
 import 'package:flutter_map_example/pages/sliding_map.dart';
 import 'package:flutter_map_example/pages/tile_builder.dart';
 import 'package:flutter_map_example/pages/tile_loading_error_handle.dart';
@@ -55,7 +55,7 @@ class MyApp extends StatelessWidget {
         CancellableTileProviderPage.route: (context) =>
             const CancellableTileProviderPage(),
         PolylinePage.route: (context) => const PolylinePage(),
-        OneWorldOrNotPage.route: (context) => const OneWorldOrNotPage(),
+        SingleWorldPolysPage.route: (context) => const SingleWorldPolysPage(),
         PolylinePerfStressPage.route: (context) =>
             const PolylinePerfStressPage(),
         MapControllerPage.route: (context) => const MapControllerPage(),
@@ -69,7 +69,7 @@ class MyApp extends StatelessWidget {
         CirclePage.route: (context) => const CirclePage(),
         OverlayImagePage.route: (context) => const OverlayImagePage(),
         PolygonPage.route: (context) => const PolygonPage(),
-        MultiWorldsPage.route: (context) => const MultiWorldsPage(),
+        RepeatedWorldsPage.route: (context) => const RepeatedWorldsPage(),
         PolygonPerfStressPage.route: (context) => const PolygonPerfStressPage(),
         SlidingMapPage.route: (_) => const SlidingMapPage(),
         WMSLayerPage.route: (context) => const WMSLayerPage(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:flutter_map_example/pages/map_controller.dart';
 import 'package:flutter_map_example/pages/map_inside_listview.dart';
 import 'package:flutter_map_example/pages/markers.dart';
 import 'package:flutter_map_example/pages/multi_worlds.dart';
+import 'package:flutter_map_example/pages/one_world_or_not.dart';
 import 'package:flutter_map_example/pages/overlay_image.dart';
 import 'package:flutter_map_example/pages/plugin_zoombuttons.dart';
 import 'package:flutter_map_example/pages/polygon.dart';
@@ -54,6 +55,7 @@ class MyApp extends StatelessWidget {
         CancellableTileProviderPage.route: (context) =>
             const CancellableTileProviderPage(),
         PolylinePage.route: (context) => const PolylinePage(),
+        OneWorldOrNotPage.route: (context) => const OneWorldOrNotPage(),
         PolylinePerfStressPage.route: (context) =>
             const PolylinePerfStressPage(),
         MapControllerPage.route: (context) => const MapControllerPage(),

--- a/example/lib/pages/one_world_or_not.dart
+++ b/example/lib/pages/one_world_or_not.dart
@@ -74,44 +74,6 @@ class _OneWorldOrNotPageState extends State<OneWorldOrNotPage> {
             ),
             children: [
               openStreetMapTileLayer,
-              PolylineLayer(
-                hitNotifier: _hitNotifier,
-                simplificationTolerance: 0,
-                oneWorld: false,
-                polylines: <Polyline<HitValue>>[
-                  Polyline(
-                    points: _polylinePoints
-                        .map((latLng) =>
-                            LatLng(latLng.latitude + 25, latLng.longitude))
-                        .toList(),
-                    strokeWidth: 8,
-                    color: const Color(0xFFFF0000),
-                    hitValue: (
-                      title: 'Red Line',
-                      subtitle: 'Across the universe...',
-                    ),
-                  ),
-                ],
-              ),
-              PolylineLayer(
-                hitNotifier: _hitNotifier,
-                simplificationTolerance: 0,
-                oneWorld: true,
-                polylines: <Polyline<HitValue>>[
-                  Polyline(
-                    points: _polylinePoints
-                        .map((latLng) =>
-                            LatLng(latLng.latitude + 0, latLng.longitude))
-                        .toList(),
-                    strokeWidth: 8,
-                    color: const Color(0xFF00FF00),
-                    hitValue: (
-                      title: 'Green Line',
-                      subtitle: 'Across the universe...',
-                    ),
-                  ),
-                ],
-              ),
               PolygonLayer(
                 hitNotifier: _hitNotifier,
                 simplificationTolerance: 0,
@@ -177,6 +139,74 @@ class _OneWorldOrNotPageState extends State<OneWorldOrNotPage> {
                     color: const Color(0xFFFFFF00),
                     hitValue: (
                       title: 'Yellow Line',
+                      subtitle: 'Across the universe...',
+                    ),
+                  ),
+                ],
+              ),
+              PolylineLayer(
+                hitNotifier: _hitNotifier,
+                simplificationTolerance: 0,
+                oneWorld: false,
+                polylines: <Polyline<HitValue>>[
+                  Polyline(
+                    points: _polylinePoints
+                        .map((latLng) =>
+                            LatLng(latLng.latitude + 25, latLng.longitude))
+                        .toList(),
+                    strokeWidth: 8,
+                    color: const Color(0xFFFF0000),
+                    hitValue: (
+                      title: 'Red Line',
+                      subtitle: 'Across the universe...',
+                    ),
+                  ),
+                  Polyline(
+                    points: const [
+                      LatLng(-80, 150),
+                      LatLng(-80, -170),
+                      LatLng(-75, -170),
+                      LatLng(-75, 150),
+                      LatLng(-80, 150),
+                    ],
+                    strokeWidth: 8,
+                    color: Colors.grey,
+                    hitValue: (
+                      title: 'Grey Line',
+                      subtitle: 'Across the universe...',
+                    ),
+                  ),
+                ],
+              ),
+              PolylineLayer(
+                hitNotifier: _hitNotifier,
+                simplificationTolerance: 0,
+                oneWorld: true,
+                polylines: <Polyline<HitValue>>[
+                  Polyline(
+                    points: _polylinePoints
+                        .map((latLng) =>
+                            LatLng(latLng.latitude + 0, latLng.longitude))
+                        .toList(),
+                    strokeWidth: 8,
+                    color: const Color(0xFF00FF00),
+                    hitValue: (
+                      title: 'Green Line',
+                      subtitle: 'Across the universe...',
+                    ),
+                  ),
+                  Polyline(
+                    points: const [
+                      LatLng(80, 150),
+                      LatLng(80, -170),
+                      LatLng(75, -170),
+                      LatLng(75, 150),
+                      LatLng(80, 150),
+                    ],
+                    strokeWidth: 8,
+                    color: Colors.cyan,
+                    hitValue: (
+                      title: 'Cyan Line',
                       subtitle: 'Across the universe...',
                     ),
                   ),

--- a/example/lib/pages/one_world_or_not.dart
+++ b/example/lib/pages/one_world_or_not.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_example/misc/tile_providers.dart';
+import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
+import 'package:latlong2/latlong.dart';
+
+@immutable
+class Epsg3857NoRepeat extends Epsg3857 {
+  @override
+  bool get replicatesWorldLongitude => false;
+}
+
+typedef HitValue = ({String title, String subtitle});
+
+/// Demo of how the new `oneWorld` parameter works on Poly*Layer's.
+///
+/// cf. https://github.com/fleaflet/flutter_map/issues/2067
+class OneWorldOrNotPage extends StatefulWidget {
+  static const String route = '/one_world';
+
+  const OneWorldOrNotPage({super.key});
+
+  @override
+  State<OneWorldOrNotPage> createState() => _OneWorldOrNotPageState();
+}
+
+class _OneWorldOrNotPageState extends State<OneWorldOrNotPage> {
+  final LayerHitNotifier<HitValue> _hitNotifier = ValueNotifier(null);
+
+  static const _polylinePoints = [
+    LatLng(40, 150),
+    LatLng(45, 160),
+    LatLng(50, 170),
+    LatLng(55, 180),
+    LatLng(50, -170),
+    LatLng(45, -160),
+    LatLng(40, -150),
+  ];
+
+  static const _polygonPoints = [
+    LatLng(40, 150),
+    LatLng(45, 160),
+    LatLng(50, 170),
+    LatLng(55, 180),
+    LatLng(50, -170),
+    LatLng(45, -160),
+    LatLng(40, -150),
+    LatLng(35, -160),
+    LatLng(30, -170),
+    LatLng(25, -180),
+    LatLng(30, 170),
+    LatLng(35, 160),
+  ];
+
+  static const _polygonHolePoints = [
+    LatLng(45, 175),
+    LatLng(45, -175),
+    LatLng(35, -175),
+    LatLng(35, 175),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('One World - or not')),
+      drawer: const MenuDrawer(OneWorldOrNotPage.route),
+      body: Stack(
+        children: [
+          FlutterMap(
+            options: MapOptions(
+              initialCenter: const LatLng(0, 0),
+              initialZoom: 0,
+              crs: Epsg3857NoRepeat(),
+            ),
+            children: [
+              openStreetMapTileLayer,
+              PolylineLayer(
+                hitNotifier: _hitNotifier,
+                simplificationTolerance: 0,
+                oneWorld: false,
+                polylines: <Polyline<HitValue>>[
+                  Polyline(
+                    points: _polylinePoints
+                        .map((latLng) =>
+                            LatLng(latLng.latitude + 25, latLng.longitude))
+                        .toList(),
+                    strokeWidth: 8,
+                    color: const Color(0xFFFF0000),
+                    hitValue: (
+                      title: 'Red Line',
+                      subtitle: 'Across the universe...',
+                    ),
+                  ),
+                ],
+              ),
+              PolylineLayer(
+                hitNotifier: _hitNotifier,
+                simplificationTolerance: 0,
+                oneWorld: true,
+                polylines: <Polyline<HitValue>>[
+                  Polyline(
+                    points: _polylinePoints
+                        .map((latLng) =>
+                            LatLng(latLng.latitude + 0, latLng.longitude))
+                        .toList(),
+                    strokeWidth: 8,
+                    color: const Color(0xFF00FF00),
+                    hitValue: (
+                      title: 'Green Line',
+                      subtitle: 'Across the universe...',
+                    ),
+                  ),
+                ],
+              ),
+              PolygonLayer(
+                hitNotifier: _hitNotifier,
+                simplificationTolerance: 0,
+                oneWorld: false,
+                polygons: <Polygon<HitValue>>[
+                  Polygon(
+                    points: _polygonPoints
+                        .map((latLng) =>
+                            LatLng(latLng.latitude - 20, latLng.longitude))
+                        .toList(),
+                    holePointsList: [
+                      _polygonHolePoints
+                          .map((latLng) =>
+                              LatLng(latLng.latitude - 20, latLng.longitude))
+                          .toList(),
+                    ],
+                    color: const Color(0xFF0000FF),
+                    hitValue: (
+                      title: 'Blue Line',
+                      subtitle: 'Across the universe...',
+                    ),
+                  ),
+                  Polygon(
+                    points: _polygonPoints
+                        .map((latLng) =>
+                            LatLng(latLng.latitude - 80, latLng.longitude))
+                        .toList(),
+                    color: const Color(0xFF000000),
+                    hitValue: (
+                      title: 'Black Line',
+                      subtitle: 'Across the universe...',
+                    ),
+                  ),
+                ],
+              ),
+              PolygonLayer(
+                hitNotifier: _hitNotifier,
+                simplificationTolerance: 0,
+                oneWorld: true,
+                polygons: <Polygon<HitValue>>[
+                  Polygon(
+                    points: _polygonPoints
+                        .map((latLng) =>
+                            LatLng(latLng.latitude - 55, latLng.longitude))
+                        .toList(),
+                    holePointsList: [
+                      _polygonHolePoints
+                          .map((latLng) =>
+                              LatLng(latLng.latitude - 55, latLng.longitude))
+                          .toList(),
+                    ],
+                    color: const Color(0xFF00FFFF),
+                    hitValue: (
+                      title: 'Teal Line',
+                      subtitle: 'Across the universe...',
+                    ),
+                  ),
+                  Polygon(
+                    points: _polygonPoints
+                        .map((latLng) =>
+                            LatLng(latLng.latitude - 110, latLng.longitude))
+                        .toList(),
+                    color: const Color(0xFFFFFF00),
+                    hitValue: (
+                      title: 'Yellow Line',
+                      subtitle: 'Across the universe...',
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/pages/repeated_worlds.dart
+++ b/example/lib/pages/repeated_worlds.dart
@@ -5,16 +5,16 @@ import 'package:flutter_map_example/widgets/drawer/menu_drawer.dart';
 import 'package:latlong2/latlong.dart';
 
 /// Example dedicated to replicated worlds and related objects (e.g. Markers).
-class MultiWorldsPage extends StatefulWidget {
-  static const String route = '/multi_worlds';
+class RepeatedWorldsPage extends StatefulWidget {
+  static const String route = '/repeated_worlds';
 
-  const MultiWorldsPage({super.key});
+  const RepeatedWorldsPage({super.key});
 
   @override
-  State<MultiWorldsPage> createState() => _MultiWorldsPageState();
+  State<RepeatedWorldsPage> createState() => _RepeatedWorldsPageState();
 }
 
-class _MultiWorldsPageState extends State<MultiWorldsPage> {
+class _RepeatedWorldsPageState extends State<RepeatedWorldsPage> {
   final LayerHitNotifier<String> _hitNotifier = ValueNotifier(null);
 
   final _customMarkers = <Marker>[];
@@ -38,15 +38,16 @@ class _MultiWorldsPageState extends State<MultiWorldsPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Multi-worlds')),
-      drawer: const MenuDrawer(MultiWorldsPage.route),
+      appBar: AppBar(
+        title: const Text('Repeated Worlds/Longitudes'),
+      ),
+      drawer: const MenuDrawer(RepeatedWorldsPage.route),
       body: Stack(
         children: [
           FlutterMap(
             options: MapOptions(
-              initialCenter: const LatLng(51.5, -0.09),
-              initialZoom: 0,
-              initialRotation: 0,
+              initialCenter: const LatLng(0, 0),
+              initialZoom: 2,
               onTap: (_, p) => setState(() => _customMarkers.add(_buildPin(p))),
             ),
             children: [

--- a/example/lib/pages/single_world_polys.dart
+++ b/example/lib/pages/single_world_polys.dart
@@ -6,26 +6,26 @@ import 'package:latlong2/latlong.dart';
 
 @immutable
 class Epsg3857NoRepeat extends Epsg3857 {
+  const Epsg3857NoRepeat();
+
   @override
   bool get replicatesWorldLongitude => false;
 }
 
-typedef HitValue = ({String title, String subtitle});
-
-/// Demo of how the new `oneWorld` parameter works on Poly*Layer's.
+/// Demo of how the new `drawInSingleWorld` parameter works on Poly*Layer's.
 ///
 /// cf. https://github.com/fleaflet/flutter_map/issues/2067
-class OneWorldOrNotPage extends StatefulWidget {
-  static const String route = '/one_world';
+class SingleWorldPolysPage extends StatefulWidget {
+  static const String route = '/single_world_polys';
 
-  const OneWorldOrNotPage({super.key});
+  const SingleWorldPolysPage({super.key});
 
   @override
-  State<OneWorldOrNotPage> createState() => _OneWorldOrNotPageState();
+  State<SingleWorldPolysPage> createState() => _SingleWorldPolysPageState();
 }
 
-class _OneWorldOrNotPageState extends State<OneWorldOrNotPage> {
-  final LayerHitNotifier<HitValue> _hitNotifier = ValueNotifier(null);
+class _SingleWorldPolysPageState extends State<SingleWorldPolysPage> {
+  bool _repeatLongitudes = false;
 
   static const _polylinePoints = [
     LatLng(40, 150),
@@ -62,23 +62,24 @@ class _OneWorldOrNotPageState extends State<OneWorldOrNotPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('One World - or not')),
-      drawer: const MenuDrawer(OneWorldOrNotPage.route),
+      appBar: AppBar(title: const Text('Single World Polys')),
+      drawer: const MenuDrawer(SingleWorldPolysPage.route),
       body: Stack(
         children: [
           FlutterMap(
             options: MapOptions(
               initialCenter: const LatLng(0, 0),
               initialZoom: 0,
-              crs: Epsg3857NoRepeat(),
+              crs: _repeatLongitudes
+                  ? const Epsg3857()
+                  : const Epsg3857NoRepeat(),
             ),
             children: [
               openStreetMapTileLayer,
               PolygonLayer(
-                hitNotifier: _hitNotifier,
                 simplificationTolerance: 0,
-                oneWorld: false,
-                polygons: <Polygon<HitValue>>[
+                drawInSingleWorld: false,
+                polygons: [
                   Polygon(
                     points: _polygonPoints
                         .map((latLng) =>
@@ -91,10 +92,9 @@ class _OneWorldOrNotPageState extends State<OneWorldOrNotPage> {
                           .toList(),
                     ],
                     color: const Color(0xFF0000FF),
-                    hitValue: (
-                      title: 'Blue Line',
-                      subtitle: 'Across the universe...',
-                    ),
+                    borderColor: Colors.purple,
+                    borderStrokeWidth: 6,
+                    pattern: const StrokePattern.dotted(),
                   ),
                   Polygon(
                     points: _polygonPoints
@@ -102,18 +102,13 @@ class _OneWorldOrNotPageState extends State<OneWorldOrNotPage> {
                             LatLng(latLng.latitude - 80, latLng.longitude))
                         .toList(),
                     color: const Color(0xFF000000),
-                    hitValue: (
-                      title: 'Black Line',
-                      subtitle: 'Across the universe...',
-                    ),
                   ),
                 ],
               ),
               PolygonLayer(
-                hitNotifier: _hitNotifier,
                 simplificationTolerance: 0,
-                oneWorld: true,
-                polygons: <Polygon<HitValue>>[
+                drawInSingleWorld: true,
+                polygons: [
                   Polygon(
                     points: _polygonPoints
                         .map((latLng) =>
@@ -125,30 +120,24 @@ class _OneWorldOrNotPageState extends State<OneWorldOrNotPage> {
                               LatLng(latLng.latitude - 55, latLng.longitude))
                           .toList(),
                     ],
-                    color: const Color(0xFF00FFFF),
-                    hitValue: (
-                      title: 'Teal Line',
-                      subtitle: 'Across the universe...',
-                    ),
+                    color: const Color(0xFF0000FF),
+                    borderColor: Colors.purple,
+                    borderStrokeWidth: 6,
+                    pattern: const StrokePattern.dotted(),
                   ),
                   Polygon(
                     points: _polygonPoints
                         .map((latLng) =>
                             LatLng(latLng.latitude - 110, latLng.longitude))
                         .toList(),
-                    color: const Color(0xFFFFFF00),
-                    hitValue: (
-                      title: 'Yellow Line',
-                      subtitle: 'Across the universe...',
-                    ),
+                    color: const Color(0xFF000000),
                   ),
                 ],
               ),
               PolylineLayer(
-                hitNotifier: _hitNotifier,
                 simplificationTolerance: 0,
-                oneWorld: false,
-                polylines: <Polyline<HitValue>>[
+                drawInSingleWorld: false,
+                polylines: [
                   Polyline(
                     points: _polylinePoints
                         .map((latLng) =>
@@ -156,10 +145,7 @@ class _OneWorldOrNotPageState extends State<OneWorldOrNotPage> {
                         .toList(),
                     strokeWidth: 8,
                     color: const Color(0xFFFF0000),
-                    hitValue: (
-                      title: 'Red Line',
-                      subtitle: 'Across the universe...',
-                    ),
+                    pattern: const StrokePattern.dotted(),
                   ),
                   Polyline(
                     points: const [
@@ -170,30 +156,22 @@ class _OneWorldOrNotPageState extends State<OneWorldOrNotPage> {
                       LatLng(-80, 150),
                     ],
                     strokeWidth: 8,
-                    color: Colors.grey,
-                    hitValue: (
-                      title: 'Grey Line',
-                      subtitle: 'Across the universe...',
-                    ),
+                    color: Colors.yellow,
                   ),
                 ],
               ),
               PolylineLayer(
-                hitNotifier: _hitNotifier,
                 simplificationTolerance: 0,
-                oneWorld: true,
-                polylines: <Polyline<HitValue>>[
+                drawInSingleWorld: true,
+                polylines: [
                   Polyline(
                     points: _polylinePoints
                         .map((latLng) =>
                             LatLng(latLng.latitude + 0, latLng.longitude))
                         .toList(),
                     strokeWidth: 8,
-                    color: const Color(0xFF00FF00),
-                    hitValue: (
-                      title: 'Green Line',
-                      subtitle: 'Across the universe...',
-                    ),
+                    color: Colors.red,
+                    pattern: StrokePattern.dashed(segments: [50, 20]),
                   ),
                   Polyline(
                     points: const [
@@ -204,15 +182,66 @@ class _OneWorldOrNotPageState extends State<OneWorldOrNotPage> {
                       LatLng(80, 150),
                     ],
                     strokeWidth: 8,
-                    color: Colors.cyan,
-                    hitValue: (
-                      title: 'Cyan Line',
-                      subtitle: 'Across the universe...',
+                    color: Colors.yellow,
+                  ),
+                ],
+              ), /*PolygonLayer(
+                drawInSingleWorld: true,
+                polygons: [
+                  Polygon(
+                    points: [
+                      const LatLng(90, -180),
+                      const LatLng(90, 180),
+                      const LatLng(-90, 180),
+                      const LatLng(-90, -180),
+                    ],
+                    color: Colors.amber,
+                    borderColor: Colors.black,
+                    borderStrokeWidth: 5,
+                    holePointsList: [
+                      [
+                        LatLng(46, -9),
+                        LatLng(46, -8),
+                        LatLng(45.5, -7.5),
+                        LatLng(45, -8),
+                        LatLng(45, -9),
+                      ]
+                    ],
+                  ),
+                ],
+              ),*/
+            ],
+          ),
+          Align(
+            alignment: Alignment.topRight,
+            child: Container(
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surface,
+                borderRadius: BorderRadius.circular(32),
+              ),
+              padding: const EdgeInsets.symmetric(
+                vertical: 8,
+                horizontal: 16,
+              ),
+              margin: const EdgeInsets.all(16),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                spacing: 16,
+                children: [
+                  const Tooltip(
+                    message: 'Prevent unbounded horizontal scrolling',
+                    child: Icon(
+                      Icons.screen_lock_landscape,
+                      size: 32,
                     ),
+                  ),
+                  Switch.adaptive(
+                    value: !_repeatLongitudes,
+                    onChanged: (v) => setState(() => _repeatLongitudes = !v),
                   ),
                 ],
               ),
-            ],
+            ),
           ),
         ],
       ),

--- a/example/lib/widgets/drawer/menu_drawer.dart
+++ b/example/lib/widgets/drawer/menu_drawer.dart
@@ -16,19 +16,19 @@ import 'package:flutter_map_example/pages/many_markers.dart';
 import 'package:flutter_map_example/pages/map_controller.dart';
 import 'package:flutter_map_example/pages/map_inside_listview.dart';
 import 'package:flutter_map_example/pages/markers.dart';
-import 'package:flutter_map_example/pages/multi_worlds.dart';
-import 'package:flutter_map_example/pages/one_world_or_not.dart';
 import 'package:flutter_map_example/pages/overlay_image.dart';
 import 'package:flutter_map_example/pages/plugin_zoombuttons.dart';
 import 'package:flutter_map_example/pages/polygon.dart';
 import 'package:flutter_map_example/pages/polygon_perf_stress.dart';
 import 'package:flutter_map_example/pages/polyline.dart';
 import 'package:flutter_map_example/pages/polyline_perf_stress.dart';
+import 'package:flutter_map_example/pages/repeated_worlds.dart';
 import 'package:flutter_map_example/pages/reset_tile_layer.dart';
 import 'package:flutter_map_example/pages/retina.dart';
 import 'package:flutter_map_example/pages/scalebar.dart';
 import 'package:flutter_map_example/pages/screen_point_to_latlng.dart';
 import 'package:flutter_map_example/pages/secondary_tap.dart';
+import 'package:flutter_map_example/pages/single_world_polys.dart';
 import 'package:flutter_map_example/pages/sliding_map.dart';
 import 'package:flutter_map_example/pages/tile_builder.dart';
 import 'package:flutter_map_example/pages/tile_loading_error_handle.dart';
@@ -97,11 +97,6 @@ class MenuDrawer extends StatelessWidget {
             currentRoute: currentRoute,
           ),
           MenuItemWidget(
-            caption: 'One World - or not - Layers',
-            routeName: OneWorldOrNotPage.route,
-            currentRoute: currentRoute,
-          ),
-          MenuItemWidget(
             caption: 'Circle Layer',
             routeName: CirclePage.route,
             currentRoute: currentRoute,
@@ -116,9 +111,15 @@ class MenuDrawer extends StatelessWidget {
             routeName: ScaleBarPage.route,
             currentRoute: currentRoute,
           ),
+          const Divider(),
           MenuItemWidget(
-            caption: 'Multi-world and layers',
-            routeName: MultiWorldsPage.route,
+            caption: 'Repeated Worlds/Longitudes',
+            routeName: RepeatedWorldsPage.route,
+            currentRoute: currentRoute,
+          ),
+          MenuItemWidget(
+            caption: 'Single World Polys',
+            routeName: SingleWorldPolysPage.route,
             currentRoute: currentRoute,
           ),
           const Divider(),

--- a/example/lib/widgets/drawer/menu_drawer.dart
+++ b/example/lib/widgets/drawer/menu_drawer.dart
@@ -17,6 +17,7 @@ import 'package:flutter_map_example/pages/map_controller.dart';
 import 'package:flutter_map_example/pages/map_inside_listview.dart';
 import 'package:flutter_map_example/pages/markers.dart';
 import 'package:flutter_map_example/pages/multi_worlds.dart';
+import 'package:flutter_map_example/pages/one_world_or_not.dart';
 import 'package:flutter_map_example/pages/overlay_image.dart';
 import 'package:flutter_map_example/pages/plugin_zoombuttons.dart';
 import 'package:flutter_map_example/pages/polygon.dart';
@@ -93,6 +94,11 @@ class MenuDrawer extends StatelessWidget {
           MenuItemWidget(
             caption: 'Polyline Layer',
             routeName: PolylinePage.route,
+            currentRoute: currentRoute,
+          ),
+          MenuItemWidget(
+            caption: 'One World - or not - Layers',
+            routeName: OneWorldOrNotPage.route,
             currentRoute: currentRoute,
           ),
           MenuItemWidget(

--- a/lib/src/geo/crs.dart
+++ b/lib/src/geo/crs.dart
@@ -417,7 +417,11 @@ abstract class Projection {
   /// longitudes -179 and 179 to be projected each on one side.
   /// [referencePoint] is used for polygon holes: we want the holes to be
   /// displayed close to the polygon, not on the other side of the world.
-  List<Offset> projectList(List<LatLng> points, {LatLng? referencePoint}) {
+  List<Offset> projectList(
+    List<LatLng> points, {
+    LatLng? referencePoint,
+    required bool oneWorld,
+  }) {
     late double previousX;
     final worldWidth = getWorldWidth();
     return List<Offset>.generate(
@@ -427,6 +431,9 @@ abstract class Projection {
           (previousX, _) = projectXY(referencePoint);
         }
         var (x, y) = projectXY(points[j]);
+        if (oneWorld) {
+          return Offset(x, y);
+        }
         if (j > 0 || referencePoint != null) {
           if (x - previousX > worldWidth / 2) {
             x -= worldWidth;

--- a/lib/src/geo/crs.dart
+++ b/lib/src/geo/crs.dart
@@ -69,7 +69,8 @@ abstract class Crs {
   /// Rescales the bounds to a given zoom value.
   Rect? getProjectedBounds(double zoom);
 
-  /// Returns true if we want the world to be replicated, longitude-wise.
+  /// Whether this CRS supports repeating worlds: repeated (feature) layers and
+  /// unbounded horizontal scrolling along the longitude axis
   bool get replicatesWorldLongitude => false;
 }
 
@@ -420,7 +421,7 @@ abstract class Projection {
   List<Offset> projectList(
     List<LatLng> points, {
     LatLng? referencePoint,
-    bool oneWorld = false,
+    bool projectToSingleWorld = false,
   }) {
     late double previousX;
     final worldWidth = getWorldWidth();
@@ -431,7 +432,7 @@ abstract class Projection {
           (previousX, _) = projectXY(referencePoint);
         }
         var (x, y) = projectXY(points[j]);
-        if (oneWorld) {
+        if (projectToSingleWorld) {
           return Offset(x, y);
         }
         if (j > 0 || referencePoint != null) {

--- a/lib/src/geo/crs.dart
+++ b/lib/src/geo/crs.dart
@@ -420,7 +420,7 @@ abstract class Projection {
   List<Offset> projectList(
     List<LatLng> points, {
     LatLng? referencePoint,
-    required bool oneWorld,
+    bool oneWorld = false,
   }) {
     late double previousX;
     final worldWidth = getWorldWidth();

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -113,6 +113,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter
         origin: origin,
         points: projectedPolygon.points,
         shift: shift,
+        forcedAddedWorldWidth: oneWorld ? 0 : null,
       );
       if (!areOffsetsVisible(projectedCoords)) {
         return WorldWorkControl.invisible;
@@ -133,6 +134,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter
             origin: origin,
             points: points,
             shift: shift,
+            forcedAddedWorldWidth: oneWorld ? 0 : null,
           );
           if (projectedHoleCoords.first != projectedHoleCoords.last) {
             projectedHoleCoords.add(projectedHoleCoords.first);
@@ -322,6 +324,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter
         camera: camera,
         origin: origin,
         points: minMaxProjected,
+        forcedAddedWorldWidth: oneWorld ? 0 : null,
       );
       final maxX = viewportRect.right;
       final minX = viewportRect.left;
@@ -341,6 +344,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter
             origin: origin,
             points: projectedPolygon.points,
             shift: shift,
+            forcedAddedWorldWidth: oneWorld ? 0 : null,
           );
           if (!areOffsetsVisible(fillOffsets)) {
             return WorldWorkControl.invisible;
@@ -355,6 +359,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter
                 origin: origin,
                 points: singleHolePoints,
                 shift: shift,
+                forcedAddedWorldWidth: oneWorld ? 0 : null,
               );
               unfillPolygon(holeOffsets);
               invertFillPolygonHole(holeOffsets);
@@ -389,6 +394,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter
 
       /// Draws on a "single-world"
       WorldWorkControl drawIfVisible(double shift) {
+        final MyLousyDouble computedAddedWorldWidth = MyLousyDouble();
         final fillOffsets = getOffsetsXY(
           camera: camera,
           origin: origin,
@@ -396,6 +402,8 @@ class _PolygonPainter<R extends Object> extends CustomPainter
           holePoints:
               polygonTriangles != null ? projectedPolygon.holePoints : null,
           shift: shift,
+          forcedAddedWorldWidth: oneWorld ? 0 : null,
+          computedAddedWorldWidth: computedAddedWorldWidth,
         );
         if (!areOffsetsVisible(fillOffsets)) {
           return WorldWorkControl.invisible;
@@ -463,6 +471,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter
               origin: origin,
               points: projectedPolygon.points,
               shift: shift,
+              forcedAddedWorldWidth: oneWorld ? 0 : null,
             ),
           );
         }
@@ -477,6 +486,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter
             origin: origin,
             points: singleHolePoints,
             shift: shift,
+            forcedAddedWorldWidth: computedAddedWorldWidth.value,
           );
           unfillPolygon(holeOffsets);
           if (!polygon.disableHolesBorder && borderPaint != null) {

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -314,7 +314,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter
       final minMaxProjected = camera.crs.projection.projectList(
         _minMaxLatitude,
         // ignore: avoid_redundant_argument_values
-        oneWorld: false,
+        projectToSingleWorld: false,
       );
       final (minMaxY, _) = _helper.getOffsetsXY(
         points: minMaxProjected,

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -313,6 +313,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter
       filledPath.reset();
       final minMaxProjected = camera.crs.projection.projectList(
         _minMaxLatitude,
+        // ignore: avoid_redundant_argument_values
         oneWorld: false,
       );
       final (minMaxY, _) = _helper.getOffsetsXY(

--- a/lib/src/layer/polygon_layer/painter.dart
+++ b/lib/src/layer/polygon_layer/painter.dart
@@ -41,6 +41,9 @@ class _PolygonPainter<R extends Object> extends CustomPainter
   /// See [PolygonLayer.invertedFill]
   final Color? invertedFill;
 
+  /// See [PolygonLayer.oneWorld]
+  final bool oneWorld;
+
   @override
   final MapCamera camera;
 
@@ -57,6 +60,7 @@ class _PolygonPainter<R extends Object> extends CustomPainter
     required this.camera,
     required this.invertedFill,
     required this.hitNotifier,
+    required this.oneWorld,
   }) : bounds = camera.visibleBounds;
 
   /// Corner coordinates of the polygon painted onto the entire world when using
@@ -310,8 +314,10 @@ class _PolygonPainter<R extends Object> extends CustomPainter
     // Specific map treatment with `invertFill`.
     if (invertedFill != null) {
       filledPath.reset();
-      final minMaxProjected =
-          camera.crs.projection.projectList(_minMaxLatitude);
+      final minMaxProjected = camera.crs.projection.projectList(
+        _minMaxLatitude,
+        oneWorld: oneWorld,
+      );
       final minMaxY = getOffsetsXY(
         camera: camera,
         origin: origin,

--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -19,11 +19,8 @@ import 'package:logger/logger.dart';
 import 'package:polylabel/polylabel.dart';
 
 part 'label.dart';
-
 part 'painter.dart';
-
 part 'polygon.dart';
-
 part 'projected_polygon.dart';
 
 /// A polygon layer for [FlutterMap].
@@ -70,6 +67,17 @@ base class PolygonLayer<R extends Object>
   /// Defaults to `false`.
   final bool drawLabelsLast;
 
+  /// Whether polygons should only be drawn/projected onto a single world
+  /// instead of potentially being drawn onto adjacent worlds (based on the
+  /// shortest distance)
+  ///
+  /// When set `true` with a CRS which does support
+  /// [Crs.replicatesWorldLongitude], polygons will still be repeated across
+  /// worlds, but each polygon will only be drawn within one world.
+  ///
+  /// Defaults to `false`.
+  final bool drawInSingleWorld;
+
   /// Color to apply to the map where not covered by a polygon
   ///
   /// > [!WARNING]
@@ -84,9 +92,6 @@ base class PolygonLayer<R extends Object>
   /// {@macro fm.lhn.layerHitNotifier.usage}
   final LayerHitNotifier<R>? hitNotifier;
 
-  /// Should all the coordinates be projected on a single world?
-  final bool oneWorld;
-
   /// Create a new [PolygonLayer] for the [FlutterMap] widget.
   const PolygonLayer({
     super.key,
@@ -98,7 +103,7 @@ base class PolygonLayer<R extends Object>
     this.drawLabelsLast = false,
     this.invertedFill,
     this.hitNotifier,
-    this.oneWorld = false,
+    this.drawInSingleWorld = false,
     super.simplificationTolerance,
   }) : super();
 
@@ -137,7 +142,7 @@ class _PolygonLayerState<R extends Object> extends State<PolygonLayer<R>>
       _ProjectedPolygon._fromPolygon(
         projection,
         element,
-        widget.oneWorld,
+        widget.drawInSingleWorld,
       );
 
   @override

--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -220,7 +220,6 @@ class _PolygonLayerState<R extends Object> extends State<PolygonLayer<R>>
           invertedFill: widget.invertedFill,
           debugAltRenderer: widget.debugAltRenderer,
           hitNotifier: widget.hitNotifier,
-          oneWorld: widget.oneWorld,
         ),
         size: camera.size,
       ),

--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -19,8 +19,11 @@ import 'package:logger/logger.dart';
 import 'package:polylabel/polylabel.dart';
 
 part 'label.dart';
+
 part 'painter.dart';
+
 part 'polygon.dart';
+
 part 'projected_polygon.dart';
 
 /// A polygon layer for [FlutterMap].
@@ -81,6 +84,9 @@ base class PolygonLayer<R extends Object>
   /// {@macro fm.lhn.layerHitNotifier.usage}
   final LayerHitNotifier<R>? hitNotifier;
 
+  /// Should all the coordinates be projected on a single world?
+  final bool oneWorld;
+
   /// Create a new [PolygonLayer] for the [FlutterMap] widget.
   const PolygonLayer({
     super.key,
@@ -92,6 +98,7 @@ base class PolygonLayer<R extends Object>
     this.drawLabelsLast = false,
     this.invertedFill,
     this.hitNotifier,
+    this.oneWorld = false,
     super.simplificationTolerance,
   }) : super();
 
@@ -127,7 +134,11 @@ class _PolygonLayerState<R extends Object> extends State<PolygonLayer<R>>
     required Projection projection,
     required Polygon<R> element,
   }) =>
-      _ProjectedPolygon._fromPolygon(projection, element);
+      _ProjectedPolygon._fromPolygon(
+        projection,
+        element,
+        widget.oneWorld,
+      );
 
   @override
   _ProjectedPolygon<R> simplifyProjectedElement({
@@ -209,6 +220,7 @@ class _PolygonLayerState<R extends Object> extends State<PolygonLayer<R>>
           invertedFill: widget.invertedFill,
           debugAltRenderer: widget.debugAltRenderer,
           hitNotifier: widget.hitNotifier,
+          oneWorld: widget.oneWorld,
         ),
         size: camera.size,
       ),

--- a/lib/src/layer/polygon_layer/projected_polygon.dart
+++ b/lib/src/layer/polygon_layer/projected_polygon.dart
@@ -15,10 +15,16 @@ class _ProjectedPolygon<R extends Object> with HitDetectableElement<R> {
     required this.holePoints,
   });
 
-  _ProjectedPolygon._fromPolygon(Projection projection, Polygon<R> polygon)
-      : this._(
+  _ProjectedPolygon._fromPolygon(
+    Projection projection,
+    Polygon<R> polygon,
+    bool oneWorld,
+  ) : this._(
           polygon: polygon,
-          points: projection.projectList(polygon.points),
+          points: projection.projectList(
+            polygon.points,
+            oneWorld: oneWorld,
+          ),
           holePoints: () {
             final holes = polygon.holePointsList;
             if (holes == null ||
@@ -33,6 +39,7 @@ class _ProjectedPolygon<R extends Object> with HitDetectableElement<R> {
               (j) => projection.projectList(
                 holes[j],
                 referencePoint: polygon.points[0],
+                oneWorld: oneWorld,
               ),
               growable: false,
             );

--- a/lib/src/layer/polygon_layer/projected_polygon.dart
+++ b/lib/src/layer/polygon_layer/projected_polygon.dart
@@ -18,12 +18,12 @@ class _ProjectedPolygon<R extends Object> with HitDetectableElement<R> {
   _ProjectedPolygon._fromPolygon(
     Projection projection,
     Polygon<R> polygon,
-    bool oneWorld,
+    bool drawInSingleWorld,
   ) : this._(
           polygon: polygon,
           points: projection.projectList(
             polygon.points,
-            oneWorld: oneWorld,
+            projectToSingleWorld: drawInSingleWorld,
           ),
           holePoints: () {
             final holes = polygon.holePointsList;
@@ -39,7 +39,7 @@ class _ProjectedPolygon<R extends Object> with HitDetectableElement<R> {
               (j) => projection.projectList(
                 holes[j],
                 referencePoint: polygon.points[0],
-                oneWorld: oneWorld,
+                projectToSingleWorld: drawInSingleWorld,
               ),
               growable: false,
             );

--- a/lib/src/layer/polyline_layer/painter.dart
+++ b/lib/src/layer/polyline_layer/painter.dart
@@ -14,17 +14,20 @@ class _PolylinePainter<R extends Object> extends CustomPainter
   @override
   final LayerHitNotifier<R>? hitNotifier;
 
-  /// See [PolylineLayer.oneWorld]
-  final bool oneWorld;
-
   /// Create a new [_PolylinePainter] instance
   _PolylinePainter({
     required this.polylines,
     required this.minimumHitbox,
     required this.camera,
     required this.hitNotifier,
-    required this.oneWorld,
-  });
+  }) {
+    _helper = OffsetHelper(
+      camera: camera,
+      origin: origin,
+    );
+  }
+
+  late final OffsetHelper _helper;
 
   @override
   bool elementHitTest(
@@ -44,12 +47,9 @@ class _PolylinePainter<R extends Object> extends CustomPainter
     // }
 
     WorldWorkControl checkIfHit(double shift) {
-      final offsets = getOffsetsXY(
-        camera: camera,
-        origin: origin,
+      final (offsets, _) = _helper.getOffsetsXY(
         points: projectedPolyline.points,
         shift: shift,
-        forcedAddedWorldWidth: oneWorld ? 0 : null,
       );
       if (!areOffsetsVisible(offsets)) return WorldWorkControl.invisible;
 
@@ -132,12 +132,9 @@ class _PolylinePainter<R extends Object> extends CustomPainter
 
       /// Draws on a "single-world"
       WorldWorkControl drawIfVisible(double shift) {
-        final offsets = getOffsetsXY(
-          camera: camera,
-          origin: origin,
+        final (offsets, _) = _helper.getOffsetsXY(
           points: projectedPolyline.points,
           shift: shift,
-          forcedAddedWorldWidth: oneWorld ? 0 : null,
         );
         if (!areOffsetsVisible(offsets)) return WorldWorkControl.invisible;
 

--- a/lib/src/layer/polyline_layer/painter.dart
+++ b/lib/src/layer/polyline_layer/painter.dart
@@ -14,12 +14,16 @@ class _PolylinePainter<R extends Object> extends CustomPainter
   @override
   final LayerHitNotifier<R>? hitNotifier;
 
+  /// See [PolylineLayer.oneWorld]
+  final bool oneWorld;
+
   /// Create a new [_PolylinePainter] instance
   _PolylinePainter({
     required this.polylines,
     required this.minimumHitbox,
     required this.camera,
     required this.hitNotifier,
+    required this.oneWorld,
   });
 
   @override
@@ -45,6 +49,7 @@ class _PolylinePainter<R extends Object> extends CustomPainter
         origin: origin,
         points: projectedPolyline.points,
         shift: shift,
+        forcedAddedWorldWidth: oneWorld ? 0 : null,
       );
       if (!areOffsetsVisible(offsets)) return WorldWorkControl.invisible;
 
@@ -132,6 +137,7 @@ class _PolylinePainter<R extends Object> extends CustomPainter
           origin: origin,
           points: projectedPolyline.points,
           shift: shift,
+          forcedAddedWorldWidth: oneWorld ? 0 : null,
         );
         if (!areOffsetsVisible(offsets)) return WorldWorkControl.invisible;
 

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -122,7 +122,6 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>>
           camera: camera,
           hitNotifier: widget.hitNotifier,
           minimumHitbox: widget.minimumHitbox,
-          oneWorld: widget.oneWorld,
         ),
         size: camera.size,
       ),

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -167,6 +167,13 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>>
         continue;
       }
 
+      // TODO: think about how to cull polylines in a forced "oneWorld".
+      // As what may be culled in a world may not be culled in a next world.
+      if (widget.oneWorld) {
+        yield projectedPolyline;
+        continue;
+      }
+
       /// Returns true if the points stretch on different versions of the world.
       bool stretchesBeyondTheLimits() {
         for (final point in projectedPolyline.points) {
@@ -178,6 +185,7 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>>
       }
 
       // TODO: think about how to cull polylines that go beyond -180/180.
+      // As the notions of projected west/east as min/max are not reliable.
       if (stretchesBeyondTheLimits()) {
         yield projectedPolyline;
         continue;

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -56,9 +56,6 @@ base class PolylineLayer<R extends Object>
   /// [Crs.replicatesWorldLongitude], polylines will still be repeated across
   /// worlds, but each polyline will only be drawn within one world.
   ///
-  /// Enabling this may impact performance by reducing the effectiveness of
-  /// culling.
-  ///
   /// Defaults to `false`.
   final bool drawInSingleWorld;
 
@@ -207,13 +204,6 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>>
 
       // Gradient polylines cannot be easily segmented
       if (polyline.gradientColors != null) {
-        yield projectedPolyline;
-        continue;
-      }
-
-      // TODO: think about how to cull polylines in a forced "drawInSingleWorld".
-      // As what may be culled in a world may not be culled in a next world.
-      if (widget.drawInSingleWorld) {
         yield projectedPolyline;
         continue;
       }

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -16,9 +16,7 @@ import 'package:flutter_map/src/misc/simplify.dart';
 import 'package:latlong2/latlong.dart';
 
 part 'painter.dart';
-
 part 'polyline.dart';
-
 part 'projected_polyline.dart';
 
 /// A [Polyline] (aka. LineString) layer for [FlutterMap].
@@ -50,8 +48,19 @@ base class PolylineLayer<R extends Object>
   /// Defaults to 10.
   final double minimumHitbox;
 
-  /// Should all the coordinates be projected on a single world?
-  final bool oneWorld;
+  /// Whether polylines should only be drawn/projected onto a single world
+  /// instead of potentially being drawn onto adjacent worlds (based on the
+  /// shortest distance)
+  ///
+  /// When set `true` with a CRS which does support
+  /// [Crs.replicatesWorldLongitude], polylines will still be repeated across
+  /// worlds, but each polyline will only be drawn within one world.
+  ///
+  /// Enabling this may impact performance by reducing the effectiveness of
+  /// culling.
+  ///
+  /// Defaults to `false`.
+  final bool drawInSingleWorld;
 
   /// Create a new [PolylineLayer] to use as child inside [FlutterMap.children].
   const PolylineLayer({
@@ -60,7 +69,7 @@ base class PolylineLayer<R extends Object>
     this.cullingMargin = 10,
     this.hitNotifier,
     this.minimumHitbox = 10,
-    this.oneWorld = false,
+    this.drawInSingleWorld = false,
     super.simplificationTolerance,
   }) : super();
 
@@ -80,7 +89,7 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>>
       _ProjectedPolyline._fromPolyline(
         projection,
         element,
-        widget.oneWorld,
+        widget.drawInSingleWorld,
       );
 
   @override
@@ -202,9 +211,9 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>>
         continue;
       }
 
-      // TODO: think about how to cull polylines in a forced "oneWorld".
+      // TODO: think about how to cull polylines in a forced "drawInSingleWorld".
       // As what may be culled in a world may not be culled in a next world.
-      if (widget.oneWorld) {
+      if (widget.drawInSingleWorld) {
         yield projectedPolyline;
         continue;
       }

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -122,6 +122,7 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>>
           camera: camera,
           hitNotifier: widget.hitNotifier,
           minimumHitbox: widget.minimumHitbox,
+          oneWorld: widget.oneWorld,
         ),
         size: camera.size,
       ),

--- a/lib/src/layer/polyline_layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer/polyline_layer.dart
@@ -16,7 +16,9 @@ import 'package:flutter_map/src/misc/simplify.dart';
 import 'package:latlong2/latlong.dart';
 
 part 'painter.dart';
+
 part 'polyline.dart';
+
 part 'projected_polyline.dart';
 
 /// A [Polyline] (aka. LineString) layer for [FlutterMap].
@@ -48,6 +50,9 @@ base class PolylineLayer<R extends Object>
   /// Defaults to 10.
   final double minimumHitbox;
 
+  /// Should all the coordinates be projected on a single world?
+  final bool oneWorld;
+
   /// Create a new [PolylineLayer] to use as child inside [FlutterMap.children].
   const PolylineLayer({
     super.key,
@@ -55,6 +60,7 @@ base class PolylineLayer<R extends Object>
     this.cullingMargin = 10,
     this.hitNotifier,
     this.minimumHitbox = 10,
+    this.oneWorld = false,
     super.simplificationTolerance,
   }) : super();
 
@@ -71,7 +77,11 @@ class _PolylineLayerState<R extends Object> extends State<PolylineLayer<R>>
     required Projection projection,
     required Polyline<R> element,
   }) =>
-      _ProjectedPolyline._fromPolyline(projection, element);
+      _ProjectedPolyline._fromPolyline(
+        projection,
+        element,
+        widget.oneWorld,
+      );
 
   @override
   _ProjectedPolyline<R> simplifyProjectedElement({

--- a/lib/src/layer/polyline_layer/projected_polyline.dart
+++ b/lib/src/layer/polyline_layer/projected_polyline.dart
@@ -13,9 +13,15 @@ class _ProjectedPolyline<R extends Object> with HitDetectableElement<R> {
     required this.points,
   });
 
-  _ProjectedPolyline._fromPolyline(Projection projection, Polyline<R> polyline)
-      : this._(
+  _ProjectedPolyline._fromPolyline(
+    Projection projection,
+    Polyline<R> polyline,
+    bool oneWorld,
+  ) : this._(
           polyline: polyline,
-          points: projection.projectList(polyline.points),
+          points: projection.projectList(
+            polyline.points,
+            oneWorld: oneWorld,
+          ),
         );
 }

--- a/lib/src/layer/polyline_layer/projected_polyline.dart
+++ b/lib/src/layer/polyline_layer/projected_polyline.dart
@@ -16,12 +16,12 @@ class _ProjectedPolyline<R extends Object> with HitDetectableElement<R> {
   _ProjectedPolyline._fromPolyline(
     Projection projection,
     Polyline<R> polyline,
-    bool oneWorld,
+    bool drawInSingleWorld,
   ) : this._(
           polyline: polyline,
           points: projection.projectList(
             polyline.points,
-            oneWorld: oneWorld,
+            projectToSingleWorld: drawInSingleWorld,
           ),
         );
 }

--- a/lib/src/layer/shared/feature_layer_utils.dart
+++ b/lib/src/layer/shared/feature_layer_utils.dart
@@ -59,7 +59,8 @@ mixin FeatureLayerUtils on CustomPainter {
   ) {
     // Protection in case of unexpected infinite loop if `work` never returns
     // `invisible`. e.g. https://github.com/fleaflet/flutter_map/issues/2052.
-    const maxShiftsCount = 10;
+    //! This can produce false positives - but it's better than a crash.
+    const maxShiftsCount = 30;
     int shiftsCount = 0;
 
     void protectInfiniteLoop() {

--- a/lib/src/misc/offsets.dart
+++ b/lib/src/misc/offsets.dart
@@ -3,16 +3,19 @@ import 'dart:ui';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/geo/crs.dart';
 import 'package:latlong2/latlong.dart';
-import 'package:meta/meta.dart';
 
-@internal
+/// Helper around offsets, projection and multi-worlds.
 class OffsetHelper {
+  /// Standard constructor for [OffsetHelper].
   OffsetHelper({
     required this.camera,
     required this.origin,
   }) : _replicatesWorldLongitude = camera.crs.replicatesWorldLongitude;
 
+  /// Camera.
   final MapCamera camera;
+
+  /// Origin.
   final Offset origin;
 
   final bool _replicatesWorldLongitude;
@@ -135,3 +138,35 @@ class OffsetHelper {
     return (v, addedWorldWidth);
   }
 }
+
+/// Calculate the [Offset] for the [LatLng] point.
+@Deprecated('Use OffsetHelper.getOffset instead')
+Offset getOffset(
+  MapCamera camera,
+  Offset origin,
+  LatLng point, {
+  double shift = 0,
+}) =>
+    OffsetHelper(camera: camera, origin: origin).getOffset(point, shift: shift);
+
+/// Calculate the [Offset]s for the list of [LatLng] points.
+@Deprecated('Use OffsetHelper.getOffsets instead')
+List<Offset> getOffsets(MapCamera camera, Offset origin, List<LatLng> points) =>
+    OffsetHelper(camera: camera, origin: origin).getOffsets(points);
+
+/// Suitable for both lines, filled polygons, and holed polygons
+@Deprecated('Use OffsetHelper.getOffsetsXY instead')
+List<Offset> getOffsetsXY({
+  required MapCamera camera,
+  required Offset origin,
+  required List<Offset> points,
+  List<List<Offset>>? holePoints,
+  double shift = 0,
+}) =>
+    OffsetHelper(camera: camera, origin: origin)
+        .getOffsetsXY(
+          points: points,
+          holePoints: holePoints,
+          shift: shift,
+        )
+        .$1;

--- a/lib/src/misc/offsets.dart
+++ b/lib/src/misc/offsets.dart
@@ -4,131 +4,132 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/geo/crs.dart';
 import 'package:latlong2/latlong.dart';
 
-/// Calculate the [Offset] for the [LatLng] point.
-Offset getOffset(
-  MapCamera camera,
-  Offset origin,
-  LatLng point, {
-  double shift = 0,
-}) {
-  final crs = camera.crs;
-  final zoomScale = crs.scale(camera.zoom);
-  final (x, y) = crs.latLngToXY(point, zoomScale);
-  return Offset(x - origin.dx + shift, y - origin.dy);
-}
+class OffsetHelper {
+  OffsetHelper({
+    required this.camera,
+    required this.origin,
+  }) : _replicatesWorldLongitude = camera.crs.replicatesWorldLongitude;
+
+  final MapCamera camera;
+  final Offset origin;
+
+  final bool _replicatesWorldLongitude;
+
+  /// Calculate the [Offset] for the [LatLng] point.
+  Offset getOffset(
+    LatLng point, {
+    double shift = 0,
+  }) {
+    final crs = camera.crs;
+    final zoomScale = crs.scale(camera.zoom);
+    final (x, y) = crs.latLngToXY(point, zoomScale);
+    return Offset(x - origin.dx + shift, y - origin.dy);
+  }
 
 // TODO not sure if still relevant
-/// Calculate the [Offset]s for the list of [LatLng] points.
-List<Offset> getOffsets(MapCamera camera, Offset origin, List<LatLng> points) {
-  // Critically create as little garbage as possible. This is called on every frame.
-  final crs = camera.crs;
-  final zoomScale = crs.scale(camera.zoom);
+  /// Calculate the [Offset]s for the list of [LatLng] points.
+  List<Offset> getOffsets(List<LatLng> points) {
+    // Critically create as little garbage as possible. This is called on every frame.
+    final crs = camera.crs;
+    final zoomScale = crs.scale(camera.zoom);
 
-  final ox = -origin.dx;
-  final oy = -origin.dy;
-  final len = points.length;
+    final ox = -origin.dx;
+    final oy = -origin.dy;
+    final len = points.length;
 
-  // Optimization: monomorphize the Epsg3857-case to avoid the virtual function overhead.
-  if (crs case final Epsg3857 epsg3857) {
+    // Optimization: monomorphize the Epsg3857-case to avoid the virtual function overhead.
+    if (crs case final Epsg3857 epsg3857) {
+      final v = List<Offset>.filled(len, Offset.zero, growable: true);
+      for (int i = 0; i < len; ++i) {
+        final (x, y) = epsg3857.latLngToXY(points[i], zoomScale);
+        v[i] = Offset(x + ox, y + oy);
+      }
+      return v;
+    }
+
     final v = List<Offset>.filled(len, Offset.zero, growable: true);
     for (int i = 0; i < len; ++i) {
-      final (x, y) = epsg3857.latLngToXY(points[i], zoomScale);
+      final (x, y) = crs.latLngToXY(points[i], zoomScale);
       v[i] = Offset(x + ox, y + oy);
     }
     return v;
   }
 
-  final v = List<Offset>.filled(len, Offset.zero, growable: true);
-  for (int i = 0; i < len; ++i) {
-    final (x, y) = crs.latLngToXY(points[i], zoomScale);
-    v[i] = Offset(x + ox, y + oy);
-  }
-  return v;
-}
+  /// Suitable for polylines, filled polygons, and holed polygons
+  (List<Offset>, double) getOffsetsXY({
+    required List<Offset> points,
+    List<List<Offset>>? holePoints,
+    double shift = 0,
+    // most of the time will be null, except for polygon holes
+    double? forcedAddedWorldWidth,
+  }) {
+    // Critically create as little garbage as possible. This is called on every frame.
+    final crs = camera.crs;
+    final zoomScale = crs.scale(camera.zoom);
 
-// TODO find something more elegant
-class MyLousyDouble {
-  late double value;
-}
+    final realPoints = holePoints == null || holePoints.isEmpty
+        ? points
+        : points.followedBy(holePoints.expand((e) => e));
 
-/// Suitable for both lines, filled polygons, and holed polygons
-List<Offset> getOffsetsXY({
-  required MapCamera camera,
-  required Offset origin,
-  required List<Offset> points,
-  List<List<Offset>>? holePoints,
-  double shift = 0,
-  // most of the time will be null, except for polygon holes
-  required double? forcedAddedWorldWidth,
-  // the point of this lousy class is to return an additional value:
-  // the actually computed "added world width" value.
-  // useful for polygon holes that need to match their polygon fulls
-  MyLousyDouble? computedAddedWorldWidth,
-}) {
-  // Critically create as little garbage as possible. This is called on every frame.
-  final crs = camera.crs;
-  final zoomScale = crs.scale(camera.zoom);
+    final ox = -origin.dx;
+    final oy = -origin.dy;
+    final len = realPoints.length;
 
-  final realPoints = holePoints == null || holePoints.isEmpty
-      ? points
-      : points.followedBy(holePoints.expand((e) => e));
-
-  final ox = -origin.dx;
-  final oy = -origin.dy;
-  final len = realPoints.length;
-
-  /// Returns additional world width in order to have visible points.
-  double getAddedWorldWidth() {
-    if (forcedAddedWorldWidth != null) {
-      return forcedAddedWorldWidth;
-    }
-    final worldWidth = crs.projection.getWorldWidth();
-    final List<double> addedWidths = [
-      0,
-      worldWidth,
-      -worldWidth,
-    ];
-    final halfScreenWidth = camera.size.width / 2;
-    final p = realPoints.elementAt(0);
-    late double result;
-    late double bestX;
-    for (int i = 0; i < addedWidths.length; i++) {
-      final addedWidth = addedWidths[i];
-      final (x, _) = crs.transform(p.dx + addedWidth, p.dy, zoomScale);
-      if (i == 0) {
-        result = addedWidth;
-        bestX = x;
-        continue;
+    /// Returns additional world width in order to have visible points.
+    double getAddedWorldWidth() {
+      if (!_replicatesWorldLongitude) {
+        return 0;
       }
-      if ((bestX + ox - halfScreenWidth).abs() >
-          (x + ox - halfScreenWidth).abs()) {
-        result = addedWidth;
-        bestX = x;
+      if (forcedAddedWorldWidth != null) {
+        return forcedAddedWorldWidth;
       }
+      final worldWidth = crs.projection.getWorldWidth();
+      final List<double> addedWidths = [
+        0,
+        worldWidth,
+        -worldWidth,
+      ];
+      final halfScreenWidth = camera.size.width / 2;
+      final p = realPoints.elementAt(0);
+      late double result;
+      late double bestX;
+      for (int i = 0; i < addedWidths.length; i++) {
+        final addedWidth = addedWidths[i];
+        final (x, _) = crs.transform(p.dx + addedWidth, p.dy, zoomScale);
+        if (i == 0) {
+          result = addedWidth;
+          bestX = x;
+          continue;
+        }
+        if ((bestX + ox - halfScreenWidth).abs() >
+            (x + ox - halfScreenWidth).abs()) {
+          result = addedWidth;
+          bestX = x;
+        }
+      }
+      return result;
     }
-    return result;
-  }
 
-  final double addedWorldWidth = getAddedWorldWidth();
-  computedAddedWorldWidth?.value = addedWorldWidth;
+    final addedWorldWidth = getAddedWorldWidth();
 
-  // Optimization: monomorphize the CrsWithStaticTransformation-case to avoid
-  // the virtual function overhead.
-  if (crs case final CrsWithStaticTransformation crs) {
+    // Optimization: monomorphize the CrsWithStaticTransformation-case to avoid
+    // the virtual function overhead.
+    if (crs case final CrsWithStaticTransformation crs) {
+      final v = List<Offset>.filled(len, Offset.zero, growable: true);
+      for (int i = 0; i < len; ++i) {
+        final p = realPoints.elementAt(i);
+        final (x, y) = crs.transform(p.dx + addedWorldWidth, p.dy, zoomScale);
+        v[i] = Offset(x + ox + shift, y + oy);
+      }
+      return (v, addedWorldWidth);
+    }
+
     final v = List<Offset>.filled(len, Offset.zero, growable: true);
     for (int i = 0; i < len; ++i) {
       final p = realPoints.elementAt(i);
       final (x, y) = crs.transform(p.dx + addedWorldWidth, p.dy, zoomScale);
       v[i] = Offset(x + ox + shift, y + oy);
     }
-    return v;
+    return (v, addedWorldWidth);
   }
-
-  final v = List<Offset>.filled(len, Offset.zero, growable: true);
-  for (int i = 0; i < len; ++i) {
-    final p = realPoints.elementAt(i);
-    final (x, y) = crs.transform(p.dx + addedWorldWidth, p.dy, zoomScale);
-    v[i] = Offset(x + ox + shift, y + oy);
-  }
-  return v;
 }

--- a/lib/src/misc/offsets.dart
+++ b/lib/src/misc/offsets.dart
@@ -3,19 +3,17 @@ import 'dart:ui';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/geo/crs.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:meta/meta.dart';
 
-/// Helper around offsets, projection and multi-worlds.
+@internal
 class OffsetHelper {
-  /// Standard constructor for [OffsetHelper].
   OffsetHelper({
     required this.camera,
     required this.origin,
   }) : _replicatesWorldLongitude = camera.crs.replicatesWorldLongitude;
 
-  /// Camera.
   final MapCamera camera;
 
-  /// Origin.
   final Offset origin;
 
   final bool _replicatesWorldLongitude;
@@ -138,35 +136,3 @@ class OffsetHelper {
     return (v, addedWorldWidth);
   }
 }
-
-/// Calculate the [Offset] for the [LatLng] point.
-@Deprecated('Use OffsetHelper.getOffset instead')
-Offset getOffset(
-  MapCamera camera,
-  Offset origin,
-  LatLng point, {
-  double shift = 0,
-}) =>
-    OffsetHelper(camera: camera, origin: origin).getOffset(point, shift: shift);
-
-/// Calculate the [Offset]s for the list of [LatLng] points.
-@Deprecated('Use OffsetHelper.getOffsets instead')
-List<Offset> getOffsets(MapCamera camera, Offset origin, List<LatLng> points) =>
-    OffsetHelper(camera: camera, origin: origin).getOffsets(points);
-
-/// Suitable for both lines, filled polygons, and holed polygons
-@Deprecated('Use OffsetHelper.getOffsetsXY instead')
-List<Offset> getOffsetsXY({
-  required MapCamera camera,
-  required Offset origin,
-  required List<Offset> points,
-  List<List<Offset>>? holePoints,
-  double shift = 0,
-}) =>
-    OffsetHelper(camera: camera, origin: origin)
-        .getOffsetsXY(
-          points: points,
-          holePoints: holePoints,
-          shift: shift,
-        )
-        .$1;

--- a/lib/src/misc/offsets.dart
+++ b/lib/src/misc/offsets.dart
@@ -3,7 +3,9 @@ import 'dart:ui';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/geo/crs.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:meta/meta.dart';
 
+@internal
 class OffsetHelper {
   OffsetHelper({
     required this.camera,

--- a/lib/src/misc/offsets.dart
+++ b/lib/src/misc/offsets.dart
@@ -46,6 +46,11 @@ List<Offset> getOffsets(MapCamera camera, Offset origin, List<LatLng> points) {
   return v;
 }
 
+// TODO find something more elegant
+class MyLousyDouble {
+  late double value;
+}
+
 /// Suitable for both lines, filled polygons, and holed polygons
 List<Offset> getOffsetsXY({
   required MapCamera camera,
@@ -53,6 +58,12 @@ List<Offset> getOffsetsXY({
   required List<Offset> points,
   List<List<Offset>>? holePoints,
   double shift = 0,
+  // most of the time will be null, except for polygon holes
+  required double? forcedAddedWorldWidth,
+  // the point of this lousy class is to return an additional value:
+  // the actually computed "added world width" value.
+  // useful for polygon holes that need to match their polygon fulls
+  MyLousyDouble? computedAddedWorldWidth,
 }) {
   // Critically create as little garbage as possible. This is called on every frame.
   final crs = camera.crs;
@@ -68,6 +79,9 @@ List<Offset> getOffsetsXY({
 
   /// Returns additional world width in order to have visible points.
   double getAddedWorldWidth() {
+    if (forcedAddedWorldWidth != null) {
+      return forcedAddedWorldWidth;
+    }
     final worldWidth = crs.projection.getWorldWidth();
     final List<double> addedWidths = [
       0,
@@ -96,6 +110,7 @@ List<Offset> getOffsetsXY({
   }
 
   final double addedWorldWidth = getAddedWorldWidth();
+  computedAddedWorldWidth?.value = addedWorldWidth;
 
   // Optimization: monomorphize the CrsWithStaticTransformation-case to avoid
   // the virtual function overhead.


### PR DESCRIPTION
### What
- We have a new `bool oneWorld` parameter for `PolygonLayer`s and `PolylineLayer`s.
- Default value is `false`.
- If that parameter is `true`, each list of points will be projected in the same (central) world - for instance, -179 and 179 longitudes will be considered almost a world away for 2 consecutive points.
- If that parameter is `false`, each "next" point will be as close as possible to the "previous" point of the list - for instance, -179 and 179 longitudes will be considered very close for 2 consecutive points.
- As it's a parameter at the level of `PolygonLayer`s and `PolylineLayer`s, we can display both "oneWorld" behaviors on the same map (if needed).
- Closes: #2067

### Screenshot
Taken from the new "One World - or not - Layers" demo:
![image](https://github.com/user-attachments/assets/19257e53-59f4-4fc8-ad57-f0126abe9dfe)

### Files
New file:
* `one_world_or_not.dart`: Demo of how the new `oneWorld` parameter works on Poly*Layer's.

Impacted files:
* `crs.dart`: added a `bool oneWorld` parameter to `projectList` method, and that's where the list of continuous segments are computed.
* `main.dart`: added `OneWorldOrNotPage` demo.
* `menu_drawer.dart`: added `OneWorldOrNotPage` demo.
* `polygon_layer/painter.dart`: added a `bool oneWorld` parameter.
* `polygon_layer.dart`: added a `bool oneWorld` parameter.
* `polyline_layer.dart`: added a `bool oneWorld` parameter.
* `projected_polygon.dart`: added a `bool oneWorld` parameter.
* `projected_polyline.dart`: added a `bool oneWorld` parameter.