### PR TITLE
fix: consider multi-worlds when constructing camera bounds & allow bounds wider than a world

### DIFF
--- a/example/lib/pages/polygon.dart
+++ b/example/lib/pages/polygon.dart
@@ -300,24 +300,6 @@ class _PolygonPageState extends State<PolygonPage> {
             ),
             children: [
               openStreetMapTileLayer,
-              Builder(
-                builder: (context) => PolygonLayer(
-                  drawInSingleWorld: true,
-                  polygons: [
-                    Polygon(
-                      points: [
-                        MapCamera.of(context).visibleBounds.northWest,
-                        MapCamera.of(context).visibleBounds.northEast,
-                        MapCamera.of(context).visibleBounds.southEast,
-                        MapCamera.of(context).visibleBounds.southWest,
-                      ],
-                      color: Colors.orange.withAlpha(255 ~/ 3),
-                      borderColor: Colors.black,
-                      borderStrokeWidth: 10,
-                    ),
-                  ],
-                ),
-              ),
               MouseRegion(
                 hitTestBehavior: HitTestBehavior.deferToChild,
                 cursor: SystemMouseCursors.click,
@@ -381,9 +363,10 @@ class _PolygonPageState extends State<PolygonPage> {
                       LatLng(50, -123),
                       LatLng(50, -121),
                     ],
-                    borderStrokeWidth: 4,
+                    borderStrokeWidth: 3,
                     borderColor: Colors.red,
-                    color: Colors.red,
+                    color: Colors.orange,
+                    label: 'Culling tester',
                   ),
                   Polygon(
                     points: const [

--- a/example/lib/pages/polygon.dart
+++ b/example/lib/pages/polygon.dart
@@ -278,8 +278,8 @@ class _PolygonPageState extends State<PolygonPage> {
       ],
       color: const Color(0xFFFF0000),
       hitValue: (
-        title: 'Red Line',
-        subtitle: 'Across the universe...',
+        title: 'Big Red Diamond',
+        subtitle: 'Across the anti-meridian boundary',
       ),
     ),
   ];
@@ -295,8 +295,8 @@ class _PolygonPageState extends State<PolygonPage> {
         children: [
           FlutterMap(
             options: const MapOptions(
-              initialCenter: LatLng(51.5, -2),
-              initialZoom: 1,
+              initialCenter: LatLng(51.5, -7),
+              initialZoom: 4,
             ),
             children: [
               openStreetMapTileLayer,

--- a/example/lib/pages/polygon.dart
+++ b/example/lib/pages/polygon.dart
@@ -296,10 +296,28 @@ class _PolygonPageState extends State<PolygonPage> {
           FlutterMap(
             options: const MapOptions(
               initialCenter: LatLng(51.5, -2),
-              initialZoom: 5,
+              initialZoom: 1,
             ),
             children: [
               openStreetMapTileLayer,
+              Builder(
+                builder: (context) => PolygonLayer(
+                  drawInSingleWorld: true,
+                  polygons: [
+                    Polygon(
+                      points: [
+                        MapCamera.of(context).visibleBounds.northWest,
+                        MapCamera.of(context).visibleBounds.northEast,
+                        MapCamera.of(context).visibleBounds.southEast,
+                        MapCamera.of(context).visibleBounds.southWest,
+                      ],
+                      color: Colors.orange.withAlpha(255 ~/ 3),
+                      borderColor: Colors.black,
+                      borderStrokeWidth: 10,
+                    ),
+                  ],
+                ),
+              ),
               MouseRegion(
                 hitTestBehavior: HitTestBehavior.deferToChild,
                 cursor: SystemMouseCursors.click,
@@ -357,6 +375,16 @@ class _PolygonPageState extends State<PolygonPage> {
                 simplificationTolerance: 0,
                 useAltRendering: true,
                 polygons: [
+                  Polygon(
+                    points: const [
+                      LatLng(51.5, -122),
+                      LatLng(50, -123),
+                      LatLng(50, -121),
+                    ],
+                    borderStrokeWidth: 4,
+                    borderColor: Colors.red,
+                    color: Colors.red,
+                  ),
                   Polygon(
                     points: const [
                       LatLng(50, -18),

--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -30,6 +30,12 @@ class LatLngBounds {
   /// The longitude west edge of the bounds
   double west;
 
+  /// Longitude center.
+  final double longitudeCenter;
+
+  /// Longitude width. Can be more than one world, e.g. more than 360.
+  final double longitudeWidth;
+
   /// Create new [LatLngBounds] by providing two corners. Both corners have to
   /// be on opposite sites but it doesn't matter which opposite corners or in
   /// what order the corners are provided.
@@ -62,6 +68,33 @@ class LatLngBounds {
       west: minX,
     );
   }
+
+  /// Creates bounds that can be larger than the world, longitude-wise.
+  LatLngBounds.worldSafe({
+    required this.north,
+    required this.south,
+    required this.longitudeCenter,
+    required this.longitudeWidth,
+  })  : assert(north <= maxLatitude,
+            "The north latitude can't be bigger than $maxLatitude: $north"),
+        assert(north >= minLatitude,
+            "The north latitude can't be smaller than $minLatitude: $north"),
+        assert(south <= maxLatitude,
+            "The south latitude can't be bigger than $maxLatitude: $south"),
+        assert(south >= minLatitude,
+            "The south latitude can't be smaller than $minLatitude: $south"),
+        assert(longitudeCenter <= maxLongitude,
+            "The longitude center can't be bigger than $maxLongitude: $longitudeCenter"),
+        assert(longitudeCenter >= minLongitude,
+            "The longitude center can't be smaller than $minLongitude: $longitudeCenter"),
+        assert(longitudeWidth >= 0, 'The longitude width must be positive'),
+        assert(
+          north >= south,
+          "The north latitude ($north) can't be smaller than the "
+          'south latitude ($south)',
+        ),
+        east = min(longitudeCenter + longitudeWidth / 2, maxLongitude),
+        west = max(longitudeCenter - longitudeWidth / 2, minLongitude);
 
   /// Create a [LatLngBounds] instance from raw edge values.
   ///
@@ -98,15 +131,52 @@ class LatLngBounds {
           east >= west,
           "The west longitude ($west) can't be smaller than the "
           'east longitude ($east)',
-        );
+        ),
+        longitudeCenter = (east + west) / 2,
+        longitudeWidth = (east - west).abs();
 
   /// Create a new [LatLngBounds] from a list of [LatLng] points. This
   /// calculates the bounding box of the provided points.
-  factory LatLngBounds.fromPoints(List<LatLng> points) {
+  factory LatLngBounds.fromPoints(
+    List<LatLng> points, {
+    bool drawInSingleWorld = false,
+  }) {
     assert(
       points.isNotEmpty,
       'LatLngBounds cannot be created with an empty List of LatLng',
     );
+    if (drawInSingleWorld) {
+      const double halfWorld = 180;
+      double previousLongitude = points.first.longitude;
+      double minX = previousLongitude;
+      double maxX = minX;
+      double minY = maxLatitude;
+      double maxY = minLatitude;
+      for (final point in points) {
+        double longitude = point.longitude;
+        while (longitude - previousLongitude >= halfWorld) {
+          longitude -= 2 * halfWorld;
+        }
+        while (longitude - previousLongitude <= -halfWorld) {
+          longitude += 2 * halfWorld;
+        }
+        if (minX > longitude) {
+          minX = longitude;
+        }
+        if (maxX < longitude) {
+          maxX = longitude;
+        }
+        if (point.latitude < minY) minY = point.latitude;
+        if (point.latitude > maxY) maxY = point.latitude;
+        previousLongitude = longitude;
+      }
+      return LatLngBounds.worldSafe(
+        north: maxY,
+        south: minY,
+        longitudeCenter: (maxX + minX) / 2,
+        longitudeWidth: maxX - minX,
+      );
+    }
     // initialize bounds with max values.
     double minX = maxLongitude;
     double maxX = minLongitude;
@@ -200,7 +270,7 @@ class LatLngBounds {
   }
 
   /// Obtain simple coordinates of the bounds center
-  LatLng get simpleCenter => LatLng((south + north) / 2, (east + west) / 2);
+  LatLng get simpleCenter => LatLng((south + north) / 2, longitudeCenter);
 
   /// Checks whether [point] is inside bounds
   bool contains(LatLng point) =>
@@ -221,10 +291,23 @@ class LatLngBounds {
   ///
   /// Bounding boxes that touch each other but don't overlap are counted as
   /// not overlapping.
-  bool isOverlapping(LatLngBounds other) => !(south > other.north ||
-      north < other.south ||
-      east < other.west ||
-      west > other.east);
+  bool isOverlapping(LatLngBounds other) {
+    if (south > other.north || north < other.south) {
+      return false;
+    }
+    if (longitudeWidth >= 360 || other.longitudeWidth >= 360) {
+      return true;
+    }
+    var delta = longitudeCenter - other.longitudeCenter;
+    while (delta >= 180) {
+      delta -= 360;
+    }
+    while (delta <= -180) {
+      delta += 360;
+    }
+    delta = delta.abs();
+    return delta < longitudeWidth || delta < other.longitudeWidth;
+  }
 
   @override
   int get hashCode => Object.hash(south, north, east, west);
@@ -240,5 +323,7 @@ class LatLngBounds {
 
   @override
   String toString() =>
-      'LatLngBounds(north: $north, south: $south, east: $east, west: $west)';
+      'LatLngBounds(north: $north, south: $south, east: $east, west: $west)'
+      ' (longitude center: $longitudeCenter)'
+      ' (longitude width: $longitudeWidth)';
 }

--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -298,6 +298,7 @@ class LatLngBounds {
     if (longitudeWidth >= 360 || other.longitudeWidth >= 360) {
       return true;
     }
+    // TODO may not be relevant for projections without world replication
     var delta = longitudeCenter - other.longitudeCenter;
     while (delta >= 180) {
       delta -= 360;

--- a/lib/src/map/camera/camera.dart
+++ b/lib/src/map/camera/camera.dart
@@ -61,20 +61,18 @@ class MapCamera {
   LatLngBounds get visibleBounds => _bounds ??= _computeVisibleBounds();
 
   LatLngBounds _computeVisibleBounds() {
+    final bottomLeft = unprojectAtZoom(pixelBounds.bottomLeft, zoom);
+    final topRight = unprojectAtZoom(pixelBounds.topRight, zoom);
     final worldWidth = getWorldWidthAtZoom(zoom);
     if (worldWidth == 0) {
-      return LatLngBounds(
-        unprojectAtZoom(pixelBounds.bottomLeft, zoom),
-        unprojectAtZoom(pixelBounds.topRight, zoom),
-      );
+      return LatLngBounds(bottomLeft, topRight);
     }
-    final LatLng southCenter = unprojectAtZoom(pixelBounds.bottomCenter, zoom);
-    final LatLng northCenter = unprojectAtZoom(pixelBounds.topCenter, zoom);
+    final center = unprojectAtZoom(pixelBounds.center, zoom);
     return LatLngBounds.worldSafe(
-      south: southCenter.latitude,
-      north: northCenter.latitude,
+      south: bottomLeft.latitude,
+      north: topRight.latitude,
       longitudeWidth: pixelBounds.width * 360 / worldWidth,
-      longitudeCenter: southCenter.longitude,
+      longitudeCenter: center.longitude,
     );
   }
 

--- a/lib/src/map/camera/camera.dart
+++ b/lib/src/map/camera/camera.dart
@@ -57,11 +57,26 @@ class MapCamera {
   Offset? _pixelOrigin;
 
   /// This is the [LatLngBounds] corresponding to four corners of this camera.
-  /// This takes rotation in to account.
-  LatLngBounds get visibleBounds => _bounds ??= LatLngBounds(
+  /// This takes rotation into account.
+  LatLngBounds get visibleBounds => _bounds ??= _computeVisibleBounds();
+
+  LatLngBounds _computeVisibleBounds() {
+    final worldWidth = getWorldWidthAtZoom(zoom);
+    if (worldWidth == 0) {
+      return LatLngBounds(
         unprojectAtZoom(pixelBounds.bottomLeft, zoom),
         unprojectAtZoom(pixelBounds.topRight, zoom),
       );
+    }
+    final LatLng southCenter = unprojectAtZoom(pixelBounds.bottomCenter, zoom);
+    final LatLng northCenter = unprojectAtZoom(pixelBounds.topCenter, zoom);
+    return LatLngBounds.worldSafe(
+      south: southCenter.latitude,
+      north: northCenter.latitude,
+      longitudeWidth: pixelBounds.width * 360 / worldWidth,
+      longitudeCenter: southCenter.longitude,
+    );
+  }
 
   /// The size of bounding box of this camera taking in to account its
   /// rotation. When the rotation is zero this will equal [nonRotatedSize],

--- a/test/map/map_controller_test.dart
+++ b/test/map/map_controller_test.dart
@@ -19,8 +19,8 @@ void main() {
     {
       final cameraConstraint = CameraFit.bounds(bounds: bounds);
       final expectedBounds = LatLngBounds(
-        const LatLng(51.00145915187144, -0.3079873797085076),
-        const LatLng(52.001427481787005, 1.298485398623206),
+        const LatLng(51.00145915187144, -0.3079873797085072),
+        const LatLng(52.001427481787005, 1.2984853986231855),
       );
       const expectedZoom = 7.451812751543818;
 
@@ -39,8 +39,8 @@ void main() {
       );
 
       final expectedBounds = LatLngBounds(
-        const LatLng(50.819818262156545, -0.6042480468750001),
-        const LatLng(52.1874047455997, 1.5930175781250002),
+        const LatLng(50.819818262156545, -0.604248046875),
+        const LatLng(52.1874047455997, 1.593017578125),
       );
       const expectedZoom = 7;
 
@@ -58,7 +58,7 @@ void main() {
       );
 
       final expectedBounds = LatLngBounds(
-        const LatLng(51.19148727133182, -6.195044477408375e-13),
+        const LatLng(51.19148727133182, -5.995204332975845e-13),
         const LatLng(51.8139520195805, 0.999999999999397),
       );
       const expectedZoom = 8.135709286104404;
@@ -79,7 +79,7 @@ void main() {
       );
 
       final expectedBounds = LatLngBounds(
-        const LatLng(51.33232774035881, 0.22521972656250003),
+        const LatLng(51.33232774035881, 0.22521972656250006),
         const LatLng(51.67425842259517, 0.7745361328125),
       );
       const expectedZoom = 9;


### PR DESCRIPTION
### What
- This PR introduces the concept of "world safe" latlng bounds: with a north, a south, a longitude center and a longitude width.
- With "world safe" bounds, we can have bounds wider than a world.
- The bounds of the camera are computed as wide as they actually are. Therefore, potentially wider than the world, instead of limited to the currently projected left and right sides of the page.
- A typical use-case is for the camera bounds when we're culling polygons. We now compare polygon bounds with more relevant camera bounds.
- TODO:
  - try to refactor so that polygons and polylines share significant parts of the culling algorithm
  - try to refactor as there's repeated code about poly continuity, as a list of pixels and as a list of latlngs
  - maybe copy/move the concept of "drawInSingleWorld" down to the polygon or polyline level

### Screenshots
| one world | the other world |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/1bffe3f6-067a-4ad8-8571-1db1ec391fcb) | ![image](https://github.com/user-attachments/assets/c6ca2af7-3cfc-4b30-b64a-53a97587e6d8) |

### Impacted files
* `camera.dart`: now computes "worldSafe" visible bounds
* `latlng_bounds.dart`: new "worldSafe" constructor, that can be wider than a world, and longitudeCenter and longitudeWidth concepts. Refactored "isOverlapping" accordingly.
* `polygon.dart`: added widgets for the test