### PR TITLE
chore: adjust OSM warning message & consider User-Agent

### DIFF
--- a/lib/src/layer/tile_layer/unblock_osm.dart
+++ b/lib/src/layer/tile_layer/unblock_osm.dart
@@ -1,5 +1,5 @@
 /// @nodoc
-final unblockOSM = [
+final osmUnblockingString = [
   79,
   117,
   114,


### PR DESCRIPTION
As a result of us becoming more compliant with OSM TUP by default (with the introduction of caching), the main remaining issue is users failing to set a good User-Agent (with `userAgentPackageName`, for example).

Therefore, this PR adjusts the wording of the OSM warning, shortens it down, and makes it an info level log by default. Where the user has not set UAPN nor used another method to set the UA, it adds a more detailed warning specifically for this case, and upgrades it to a warning level.

In future, if we choose to block OSM without a good UA, the framework is now in place. I've removed references to blocking OSM in future in the lower-level message.

See also https://github.com/openstreetmap/operations/issues/1243.