### PR TITLE
fix: adjust infinite loop protection in `workAcrossWorlds`

### DIFF
--- a/lib/src/layer/shared/feature_layer_utils.dart
+++ b/lib/src/layer/shared/feature_layer_utils.dart
@@ -63,8 +63,14 @@ mixin FeatureLayerUtils on CustomPainter {
     const maxShiftsCount = 30;
     int shiftsCount = 0;
 
+    final worldWidth = this.worldWidth;
+
     void protectInfiniteLoop() {
-      if (++shiftsCount > maxShiftsCount) throw const StackOverflowError();
+      if (++shiftsCount > maxShiftsCount) {
+        throw AssertionError(
+          'Infinite loop going beyond $maxShiftsCount for world width $worldWidth',
+        );
+      }
     }
 
     protectInfiniteLoop();


### PR DESCRIPTION
As discussed in https://github.com/fleaflet/flutter_map/issues/2111#issuecomment-2996083734, some fine-tuning about infinite loop error.