### PR TITLE
fix(example): prevent widget overflow in tile builder demo

### DIFF
--- a/example/lib/pages/tile_builder.dart
+++ b/example/lib/pages/tile_builder.dart
@@ -32,23 +32,27 @@ class TileBuilderPageState extends State<TileBuilderPage> {
         children: [
           tileWidget,
           if (showLoadingTime || showCoordinates)
-            Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                if (showCoordinates)
-                  Text(
-                    '${coords.x} : ${coords.y} : ${coords.z}',
-                    style: Theme.of(context).textTheme.headlineSmall,
-                  ),
-                if (showLoadingTime)
-                  Text(
-                    tile.loadFinishedAt == null
-                        ? 'Loading'
-                        // sometimes result is negative which shouldn't happen, abs() corrects it
-                        : '${(tile.loadFinishedAt!.millisecond - tile.loadStarted!.millisecond).abs()} ms',
-                    style: Theme.of(context).textTheme.headlineSmall,
-                  ),
-              ],
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              alignment: Alignment.center,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  if (showCoordinates)
+                    Text(
+                      '${coords.x} : ${coords.y} : ${coords.z}',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                  if (showLoadingTime)
+                    Text(
+                      tile.loadFinishedAt == null
+                          ? 'Loading'
+                          // sometimes result is negative which shouldn't happen, abs() corrects it
+                          : '${(tile.loadFinishedAt!.millisecond - tile.loadStarted!.millisecond).abs()} ms',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                ],
+              ),
             ),
         ],
       ),


### PR DESCRIPTION
There was an overflow problems in tile builder demo. 

Another exception was thrown: A RenderFlex overflowed by 37 pixels on the bottom.

The specific RenderFlex in question is: RenderFlex#3b4bf OVERFLOWING:
  creator: Column ← Stack ← DecoratedBox ← Positioned ← Tile-[TileRenderer#07efd] ← Stack ← Transform
    ← OverflowBox ← MobileLayerTransformer ← TileLayer ← ColorFiltered ← Stack ← ⋯

Putting a Column into Fitted box resolves this problem. 