### PR TITLE
feat: add pointer move callback to MapOptions and handle it in MapInteractiveViewer

### DIFF
--- a/lib/src/gestures/map_interactive_viewer.dart
+++ b/lib/src/gestures/map_interactive_viewer.dart
@@ -420,6 +420,10 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
   }
 
   void _onPointerMove(PointerMoveEvent event) {
+    if (_options.onPointerMove != null) {
+      final latLng = _camera.offsetToCrs(event.localPosition);
+      _options.onPointerMove!(event, latLng);
+    }
     if (!_ckrTriggered.value) return;
 
     final baseSetNorth =

--- a/lib/src/map/options/options.dart
+++ b/lib/src/map/options/options.dart
@@ -40,6 +40,12 @@ typedef PointerHoverCallback = void Function(
   LatLng point,
 );
 
+/// Callback to notify when the map registers a pointer move event.
+typedef PointerMoveCallback = void Function(
+  PointerMoveEvent event,
+  LatLng point,
+);
+
 /// Callback that gets called when the viewport of the map changes.
 ///
 /// {@macro map_position.has_gesture}
@@ -109,6 +115,11 @@ class MapOptions {
   /// down (e.g. mouse pointers, but not most touch pointers)
   final PointerHoverCallback? onPointerHover;
 
+  /// Called when a pointer is down and moves.
+  /// If used while dragging the map, this should return the same location, but it might not due to map pixel snapping.
+  /// It is more useful to obtain pointer position while map camera position is not changing.
+  final PointerMoveCallback? onPointerMove;
+
   /// This callback fires when the [MapCamera] data has changed. This gets
   /// called if the zoom level, or map center changes.
   final PositionCallback? onPositionChanged;
@@ -158,6 +169,7 @@ class MapOptions {
     this.onPointerUp,
     this.onPointerCancel,
     this.onPointerHover,
+    this.onPointerMove,
     this.onPositionChanged,
     this.onMapEvent,
     this.onMapReady,


### PR DESCRIPTION
I needed a onPointerMove functionality but there was only onPointerHover. For example when I want to drag graphics on map, I disable map pan onTapDown and can use onPointerMove to reposition graphics. This cannot be done with onPointerHover as it does not respond when tap is also down. There already was an _onPointerMove method just not exposed to user. Any reason not to do this? 