### PR TITLE
fix: throw if `MapCamera` is constructed with a non-finite `zoom`

### DIFF
--- a/lib/src/map/camera/camera.dart
+++ b/lib/src/map/camera/camera.dart
@@ -143,18 +143,26 @@ class MapCamera {
   })  : _cameraSize = size,
         _pixelBounds = pixelBounds,
         _bounds = bounds,
-        _pixelOrigin = pixelOrigin;
+        _pixelOrigin = pixelOrigin,
+        assert(
+          zoom.isFinite,
+          'Camera `zoom` must be finite (and usually positive).\n'
+          '(This may occur if the map tried to fit to a zero-area bounds, such '
+          'as a bounds defined by only a single point.)',
+        );
 
   /// Initializes [MapCamera] from the given [options] and with the
   /// [nonRotatedSize] set to [kImpossibleSize].
   MapCamera.initialCamera(MapOptions options)
-      : crs = options.crs,
-        minZoom = options.minZoom,
-        maxZoom = options.maxZoom,
-        center = options.initialCenter,
-        zoom = options.initialZoom,
-        rotation = options.initialRotation,
-        nonRotatedSize = kImpossibleSize;
+      : this(
+          crs: options.crs,
+          minZoom: options.minZoom,
+          maxZoom: options.maxZoom,
+          center: options.initialCenter,
+          zoom: options.initialZoom,
+          rotation: options.initialRotation,
+          nonRotatedSize: kImpossibleSize,
+        );
 
   /// Returns a new instance of [MapCamera] with the given [nonRotatedSize].
   MapCamera withNonRotatedSize(Size nonRotatedSize) {


### PR DESCRIPTION
Whilst some layers may technically function with an infinite/NaN zoom (I haven't tested), the `TileLayer` definitely doesn't, and it doesn't make conceptual sense for the other layers too.

Fixes #2135, but not at the camera fitting, as this feels like a better catch-all.