### PR TITLE
fix: correct `LatLngBounds.isOverlapping` calculation

### DIFF
--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -307,7 +307,7 @@ class LatLngBounds {
       delta += 360;
     }
     delta = delta.abs();
-    return delta < longitudeWidth || delta < other.longitudeWidth;
+    return delta < (longitudeWidth + other.longitudeWidth) / 2;
   }
 
   @override

--- a/test/geo/latlng_bounds_test.dart
+++ b/test/geo/latlng_bounds_test.dart
@@ -94,5 +94,35 @@ void main() {
         expect(center.longitude, (-179.86 + 23.86) / 2);
       });
     });
+
+    group('isOverlapping', () {
+      test('should not overlap', () {
+        final bounds1 = LatLngBounds(
+          const LatLng(49.622376, 18.286332),
+          const LatLng(48.721399, 20.122905),
+        );
+        final bounds2 = LatLngBounds(
+          const LatLng(49.33295874620594, 20.58826958952466),
+          const LatLng(49.22512969150049, 20.676160214524646),
+        );
+
+        expect(bounds1.isOverlapping(bounds2), isFalse);
+        expect(bounds2.isOverlapping(bounds1), isFalse);
+      });
+
+      test('should overlap', () {
+        final bounds1 = LatLngBounds(
+          const LatLng(50, 20),
+          const LatLng(51, 21),
+        );
+        final bounds2 = LatLngBounds(
+          const LatLng(50.5, 20.5),
+          const LatLng(51.5, 21.5),
+        );
+
+        expect(bounds1.isOverlapping(bounds2), isTrue);
+        expect(bounds2.isOverlapping(bounds1), isTrue);
+      });
+    });
   });
 }


### PR DESCRIPTION
Original calculation was incorrect and could claim that two non-overlapping bounding boxes overlapped, such as in case of the bounding boxes defined in this geojson

<details>

<summary>Boxes</summary>

```geojson
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "Polygon",
        "coordinates": [
          [
            [
              18.286332,
              49.622376
            ],
            [
              18.286332,
              48.721399
            ],
            [
              20.122905,
              48.721399
            ],
            [
              20.122905,
              49.622376
            ],
            [
              18.286332,
              49.622376
            ]
          ]
        ]
      }
    },
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "Polygon",
        "coordinates": [
          [
            [
              20.58826958952466,
              49.33295874620594
            ],
            [
              20.58826958952466,
              49.22512969150049
            ],
            [
              20.676160214524646,
              49.22512969150049
            ],
            [
              20.676160214524646,
              49.33295874620594
            ],
            [
              20.58826958952466,
              49.33295874620594
            ]
          ]
        ]
      }
    }
  ]
}
```

</details>

This PR fixes the calculation using a version of the formula for determining whether two circles overlap (which the original code seemed to be attempting to do) by
1. Calculating distance between centers of the circles, or in this case centers of intervals along the longitudinal axis `delta = this.longitudeCenter - other.longitudeCenter`
2. Adding together radii of the two circles or in this case adding halves of longitudinal width of the bounding boxes `(this.longitudeWidth + other.longitudeWidth) / 2`
3. When distance between centers is greater than sum of their radii they don't overlap, when it's smaller they overlap