### PR TITLE
perf: replace unstable `Tile` widget key with dedicated stable `TileKey`

### DIFF
--- a/lib/src/layer/tile_layer/tile_key.dart
+++ b/lib/src/layer/tile_layer/tile_key.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_map/src/layer/tile_layer/tile_coordinates.dart';
+import 'package:flutter_map/src/layer/tile_layer/tile_image.dart';
+import 'package:flutter_map/src/layer/tile_layer/tile_renderer.dart';
+
+/// A key that identifies rendering of a [TileImage] at given [TileCoordinates].
+///
+/// Two [TileKey]s are equal when they reference the same [TileImage]
+/// instance and have equal [positionCoordinates].
+final class TileKey extends LocalKey {
+  /// Tile image to identify by instance.
+  final TileImage tileImage;
+
+  /// Position where [tileImage] is rendered.
+  final TileCoordinates positionCoordinates;
+
+  /// Creates a [TileKey] for the given [TileRenderer].
+  ///
+  /// The [tileImage] is compared by identity, while [positionCoordinates] are
+  /// compared by value.
+  TileKey(TileRenderer renderer)
+      : tileImage = renderer.tileImage,
+        positionCoordinates = renderer.positionCoordinates;
+
+  @override
+  bool operator ==(Object other) {
+    return other is TileKey &&
+        identical(other.tileImage, tileImage) &&
+        other.positionCoordinates == positionCoordinates;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        identityHashCode(tileImage),
+        positionCoordinates,
+      );
+}

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -9,6 +9,7 @@ import 'package:flutter_map/src/layer/tile_layer/tile.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_bounds/tile_bounds.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_bounds/tile_bounds_at_zoom.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_image_manager.dart';
+import 'package:flutter_map/src/layer/tile_layer/tile_key.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_range.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_range_calculator.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_scale_calculator.dart';
@@ -561,7 +562,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
         .map((tileRenderer) => Tile(
               // Must be an ObjectKey, not a ValueKey using the coordinates, in
               // case we remove and replace the TileImage with a different one.
-              key: ObjectKey(tileRenderer),
+              key: TileKey(tileRenderer),
               scaledTileDimension: _tileScaleCalculator.scaledTileDimension(
                 map.zoom,
                 tileRenderer.positionCoordinates.z,


### PR DESCRIPTION
Previously tiles were keyed with `ObjectKey(tileRenderer)`, but `TileRenderer` instances are recreated on every build. Because of that, the key was unstable even when the logical tile did not change. The root cause of this issue was introduced in commit
[182c4fc](https://github.com/fleaflet/flutter_map/commit/182c4fc0c73411e2be10774dd227d0da9cf4276a) when unbounded horizontal scroll was introduced.

As a result, Flutter could not match the new widget with the existing element and treated the tile as a new widget. This led to repeated disposal and recreation of `_TileState` instead of updating the existing state.

The fix replaces that key with a stable `TileKey` based on `TileImage` identity and `positionCoordinates`. This preserves `_TileState` for the same rendered tile and avoids unnecessary remounting.

Before:
![before](https://github.com/user-attachments/assets/f8af5338-501b-4d2c-be7c-61d7a101bfbd)

After fix:
![after](https://github.com/user-attachments/assets/e54270dc-ebcb-4625-92c6-c36524779646)

You can check simple code to reproduce before/after examples here:
https://github.com/braindamagedman/flutter_map/tree/test/tile-key