### PR TITLE
fix(docs): correct broken links for `TileLayer` & `MapController`

### DIFF
--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -20,12 +20,11 @@ part 'retina_mode.dart';
 part 'tile_error_evict_callback.dart';
 part 'wms_tile_layer_options.dart';
 
-/// Describes the needed properties to create a tile-based layer. A tile is an
+/// Describes the needed properties to create a raster tile layer. A tile is an
 /// image bound to a specific geographical position.
 ///
-/// You should read up about the options by exploring each one, or visiting
-/// https://docs.fleaflet.dev/usage/layers/tile-layer. Some are important to
-/// avoid issues.
+/// Read the [online documentation](https://docs.fleaflet.dev/layers/tile-layer)
+/// to get started by following the recommended setup.
 @immutable
 class TileLayer extends StatefulWidget {
   /// The URL template is a string that contains placeholders, which, when filled

--- a/lib/src/map/controller/map_controller.dart
+++ b/lib/src/map/controller/map_controller.dart
@@ -6,18 +6,15 @@ import 'package:flutter_map/src/map/inherited_model.dart';
 import 'package:flutter_map/src/misc/move_and_rotate_result.dart';
 import 'package:latlong2/latlong.dart';
 
-/// Controller to programmatically interact with [FlutterMap], such as
-/// controlling it and accessing some of its properties.
+/// Controller to programmatically interact with a [FlutterMap].
 ///
-/// See https://docs.fleaflet.dev/usage/controller#initialisation for information
-/// on how to set-up and connect a controller to a map widget instance.
+/// Read the [online documentation](https://docs.fleaflet.dev/usage/programmatic-interaction)
+/// to get started.
 abstract class MapController {
-  /// Controller to programmatically interact with [FlutterMap], such as
-  /// controlling it and accessing some of its properties.
+  /// Controller to programmatically interact with a [FlutterMap].
   ///
-  /// See https://docs.fleaflet.dev/usage/controller#initialisation for
-  /// information how to set-up and connect a controller to a map widget
-  /// instance.
+  /// Read the [online documentation](https://docs.fleaflet.dev/usage/programmatic-interaction)
+  /// to get started.
   ///
   /// Factory constructor redirects to underlying implementation's constructor.
   factory MapController() = MapControllerImpl;


### PR DESCRIPTION
Fixes #2189.