### PR TITLE
fix: prevent NaN camera state from non-positive pinch scale

### DIFF
--- a/lib/src/gestures/map_interactive_viewer.dart
+++ b/lib/src/gestures/map_interactive_viewer.dart
@@ -1380,6 +1380,7 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
   // Utilities
 
   double _getZoomForScale(double startZoom, double scale) {
+    if (scale <= 0) return _camera.clampZoom(startZoom);
     final resultZoom =
         scale == 1.0 ? startZoom : startZoom + math.log(scale) / math.ln2;
     return _camera.clampZoom(resultZoom);


### PR DESCRIPTION
## What

One-line guard in `_getZoomForScale`
(`lib/src/gestures/map_interactive_viewer.dart`) to return the clamped
start zoom instead of calling `math.log` when the effective pinch `scale`
is non-positive.

```dart
// before
double _getZoomForScale(double startZoom, double scale) {
  final resultZoom =
      scale == 1.0 ? startZoom : startZoom + math.log(scale) / math.ln2;
  return _camera.clampZoom(resultZoom);
}

// after
double _getZoomForScale(double startZoom, double scale) {
  if (scale <= 0) return _camera.clampZoom(startZoom);
  final resultZoom =
      scale == 1.0 ? startZoom : startZoom + math.log(scale) / math.ln2;
  return _camera.clampZoom(resultZoom);
}
```

## Why

When `enableMultiFingerGestureRace` is `true` (the default), the map waits
until one multi-finger gesture crosses its threshold before acting. At the
moment the winner is decided, it records:

```dart
_scaleCorrector = 1.0 - _lastScale;   // map_interactive_viewer.dart:617
```

If the user had been pinching **inward** before the winner was latched,
`_lastScale > 1` and `_scaleCorrector` is negative. On a subsequent gesture
frame the effective scale passed to `_getZoomForScale` is:

```dart
details.scale + _scaleCorrector        // map_interactive_viewer.dart:653
```

`details.scale` is guarded to be `> 0.0` (line 650), but the guard does
**not** cover the corrected value. If `_scaleCorrector` is large and
negative the sum can go negative or zero.

`math.log` of a non-positive number returns `NaN`. That `NaN` propagates
through the zoom calculation and into `_calculatePinchZoomAndMove`:

1. `projectAtZoom(camera.center, NaN)` → `Offset(NaN, NaN)`
2. `unprojectAtZoom(Offset(NaN, NaN), NaN)` → `LatLng(NaN, NaN)`
   (`_clampSym` / `_inclusiveLat` / `_inclusiveLng` pass `NaN` through
   unchanged because `NaN < x` and `NaN > x` are both `false`)
3. `moveRaw(LatLng(NaN, NaN), NaN, ...)` silently stores the NaN as
   `camera.center` and `camera.zoom`.

On the very next single-finger drag, `dragUpdated` calls
`camera.projectAtZoom(camera.center)` → `Epsg3857.latLngToOffset` →
`Crs.checkLatLng` throws:

```
Exception: LatLng is not finite: LatLng(latitude:NaN, longitude:NaN)
#0      Crs.checkLatLng (package:flutter_map/src/geo/crs.dart:82)
#1      Epsg3857.latLngToOffset (package:flutter_map/src/geo/crs.dart:189)
#2      MapCamera.projectAtZoom (package:flutter_map/src/map/camera/camera.dart:278)
#3      MapControllerImpl.dragUpdated (package:flutter_map/src/map/controller/map_controller_impl.dart:377)
#4      MapInteractiveViewerState._handleScaleDragUpdate (package:flutter_map/src/gestures/map_interactive_viewer.dart:597)
#5      MapInteractiveViewerState._handleScaleUpdate (package:flutter_map/src/gestures/map_interactive_viewer.dart:569)
```

## Behaviour change

None for normal gestures. The guard only fires when
`details.scale + _scaleCorrector <= 0`, which was previously an error
condition producing `NaN`. The safe fallback — returning the clamped
`startZoom` — treats the frame as a no-zoom-change event, identical to
what already happens when `scale == 1.0`.