### PR TITLE
fix: remove polygons with fewer than 3 points after simplification

### DIFF
--- a/lib/src/layer/polygon_layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer/polygon_layer.dart
@@ -201,7 +201,7 @@ class _PolygonLayerState<R extends Object> extends State<PolygonLayer<R>>
             highQuality: true,
           ),
           growable: false,
-        ),
+        ).where((h) => h.length >= 3).toList(),
       );
 
   @override


### PR DESCRIPTION
When you have a (multi) polygon with lots of tiny polygons the simplification can shrink a polygon to e.g. two points, this will cause a this assertion error:

```
The following assertion was thrown while handling a pointer data packet: not a polygon 'package:flutter_map/src/misc/point_in_polygon.dart': Failed assertion: line 10 pos 10: 'len >= 3'
When the exception was thrown, this was the stack:
#2 isPointInPolygon (package:flutter_map/src/misc/point_in_polygon.dart:10:10)
#3 _PolygonPainter.elementHitTest.<anonymous> (package:flutter_map/src/layer/polygon_layer/painter.dart:85:17)
#4 _PolygonPainter.elementHitTest (package:flutter_map/src/layer/polygon_layer/painter.dart:90:10)
#5 HitDetectablePainter.hitTest (package:flutter_map/src/layer/shared/layer_interactivity/internal_hit_detectable.dart:75:11)
#6 HitTestRequiresCameraOrigin.hitTest (package:flutter_map/src/layer/shared/layer_interactivity/internal_hit_detectable.dart:112:18)
#7 RenderCustomPaint.hitTestSelf (package:flutter/src/rendering/custom_paint.dart:569:43)
#8 RenderBox.hitTest (package:flutter/src/rendering/box.dart:2953:58)</anonymous>
```

My fix simply removes those polygons entirely. That happens when you hover a `PolygonLayer` as workaround you can use `simplificationTolerance: 0` but that is based on the geometry quite bad for the performance.