### PR TITLE
feat: allow antimeridian span for LatLngBounds and CameraFit

### DIFF
--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -96,6 +96,40 @@ class LatLngBounds {
         east = min(longitudeCenter + longitudeWidth / 2, maxLongitude),
         west = max(longitudeCenter - longitudeWidth / 2, minLongitude);
 
+  /// Creates bounds that can span the antimeridian. If this is the case,
+  /// [west] will be larger than [east].
+  LatLngBounds.unconstrainedLng({
+    required this.north,
+    required this.south,
+    required this.longitudeCenter,
+    required this.longitudeWidth,
+  })  : assert(north <= maxLatitude,
+            "The north latitude can't be bigger than $maxLatitude: $north"),
+        assert(north >= minLatitude,
+            "The north latitude can't be smaller than $minLatitude: $north"),
+        assert(south <= maxLatitude,
+            "The south latitude can't be bigger than $maxLatitude: $south"),
+        assert(south >= minLatitude,
+            "The south latitude can't be smaller than $minLatitude: $south"),
+        assert(longitudeCenter <= maxLongitude,
+            "The longitude center can't be bigger than $maxLongitude: $longitudeCenter"),
+        assert(longitudeCenter >= minLongitude,
+            "The longitude center can't be smaller than $minLongitude: $longitudeCenter"),
+        assert(longitudeWidth >= 0, 'The longitude width must be positive'),
+        assert(
+          north >= south,
+          "The north latitude ($north) can't be smaller than the "
+          'south latitude ($south)',
+        ),
+        east = _wrapLng(longitudeCenter + longitudeWidth / 2),
+        west = _wrapLng(longitudeCenter - longitudeWidth / 2);
+
+  static double _wrapLng(double longitude) => longitude > maxLongitude
+      ? longitude - 360
+      : longitude < minLongitude
+          ? longitude + 360
+          : longitude;
+
   /// Create a [LatLngBounds] instance from raw edge values.
   ///
   /// Potentially throws assertion errors if the coordinates exceed their max

--- a/lib/src/map/camera/camera_fit.dart
+++ b/lib/src/map/camera/camera_fit.dart
@@ -126,7 +126,11 @@ class FitBounds extends CameraFit {
       projectedCenter = (swPoint + nePoint) / 2 + paddingOffset;
     }
 
-    final center = camera.unprojectAtZoom(projectedCenter, newZoom);
+    final center = _correctBoundsCenterForAntimeridianSpan(
+      camera.unprojectAtZoom(projectedCenter, newZoom),
+      bounds,
+    );
+
     return camera.withPosition(
       center: center,
       zoom: newZoom,
@@ -137,16 +141,13 @@ class FitBounds extends CameraFit {
     MapCamera camera,
     Offset pixelPadding,
   ) {
-    final nw = bounds.northWest;
-    final se = bounds.southEast;
     var size = camera.nonRotatedSize - pixelPadding as Size;
     // Prevent negative size which results in NaN zoom value later on in the calculation
 
     size = Size(math.max(0, size.width), math.max(0, size.height));
-    var boundsSize = Rect.fromPoints(
-      camera.projectAtZoom(se, camera.zoom),
-      camera.projectAtZoom(nw, camera.zoom),
-    ).size;
+
+    Size boundsSize = _boundsSizeWithPossibleAntimeridianSpan(bounds, camera);
+
     if (camera.rotation != 0.0) {
       final cosAngle = math.cos(camera.rotationRad).abs();
       final sinAngle = math.sin(camera.rotationRad).abs();
@@ -225,10 +226,8 @@ class FitInsideBounds extends CameraFit {
 
     final cameraSize = camera.nonRotatedSize - paddingTotalXY as Size;
 
-    final projectedBoundsSize = Rect.fromPoints(
-      camera.projectAtZoom(bounds.southEast, camera.zoom),
-      camera.projectAtZoom(bounds.northWest, camera.zoom),
-    ).size;
+    final projectedBoundsSize =
+        _boundsSizeWithPossibleAntimeridianSpan(bounds, camera);
 
     final scale = _rectInRotRectScale(
       angleRad: camera.rotationRad,
@@ -254,10 +253,13 @@ class FitInsideBounds extends CameraFit {
     );
     newZoom = newZoom.clamp(min, max);
 
-    final newCenter = _getCenter(
-      camera,
-      newZoom: newZoom,
-      paddingOffset: paddingOffset,
+    final newCenter = _correctBoundsCenterForAntimeridianSpan(
+      _getCenter(
+        camera,
+        newZoom: newZoom,
+        paddingOffset: paddingOffset,
+      ),
+      bounds,
     );
 
     return camera.withPosition(
@@ -494,5 +496,43 @@ class FitCoordinates extends CameraFit {
       maxZoom ?? double.infinity,
     );
     return newZoom.clamp(min, max);
+  }
+}
+
+LatLng _correctBoundsCenterForAntimeridianSpan(
+  LatLng center,
+  LatLngBounds bounds,
+) {
+  if (bounds.west > bounds.east) {
+    // Handle a bounding box that spans the antimeridian
+    var centerLng = (bounds.west + (bounds.east + 360)) / 2;
+    if (centerLng > 180) {
+      centerLng -= 360;
+    }
+
+    return LatLng(center.latitude, centerLng);
+  } else {
+    return center;
+  }
+}
+
+Size _boundsSizeWithPossibleAntimeridianSpan(
+  LatLngBounds bounds,
+  MapCamera camera,
+) {
+  if (bounds.west > bounds.east) {
+    // Handle a bounding box that spans the antimeridian
+    return Rect.fromPoints(
+      camera.projectAtZoom(
+        LatLng(bounds.south, bounds.east + 360),
+        camera.zoom,
+      ),
+      camera.projectAtZoom(bounds.northWest, camera.zoom),
+    ).size;
+  } else {
+    return Rect.fromPoints(
+      camera.projectAtZoom(bounds.southEast, camera.zoom),
+      camera.projectAtZoom(bounds.northWest, camera.zoom),
+    ).size;
   }
 }


### PR DESCRIPTION
This addition allows a ```CameraFit``` spanning the antimeridian to be created using ```CameraFit.bounds```or ```CameraFit.insideBounds```. It was also necessary to add a new constructor ```LatLngBounds.unconstrainedLng``` to be able to create bounds that span the antimeridian.

Example: showing the airports at Magadan and Anchorage on a map.

Before (using ```CameraFit.bounds``` with ```LatLngBounds.worldSafe```):
<img width="744" height="1133" alt="Simulator Screenshot - iPad mini (A17 Pro) - 2026-04-26 at 18 11 39" src="https://github.com/user-attachments/assets/e844d109-2ef9-4bb0-8d63-1634f7bc5046" />

After (using ```CameraFit.bounds``` with ```LatLngBounds.unconstrainedLng```):
<img width="744" height="1133" alt="Simulator Screenshot - iPad mini (A17 Pro) - 2026-04-26 at 18 13 59" src="https://github.com/user-attachments/assets/232d012b-1498-4749-8da2-a6768b2c9f02" />
