### PR TITLE
chore: allow 'pkg:latlong2' v0.10.x dependency

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   http: ^1.6.0
-  latlong2: ^0.9.1
+  latlong2: ">=0.9.1 <0.11.0"
   proj4dart: ^3.0.0
   shared_preferences: ^2.5.3
   url_launcher: ^6.3.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.5.0
-  latlong2: ^0.9.1
+  latlong2: ">=0.9.1 <0.11.0"
   meta: ^1.11.0
   path: ^1.9.0
   path_provider: ^2.1.5


### PR DESCRIPTION
As already mentioned, 0.10.x was not really a breaking release. Hence, it can be supported side-by-side with 0.9.x.
1.x will be breaking - but that will take a few more rounds of alpha tests before being published...