### PR TITLE
fix: prevent NaN fling direction when tracked pointer offsets are zero

### DIFF
--- a/lib/src/gestures/map_interactive_viewer.dart
+++ b/lib/src/gestures/map_interactive_viewer.dart
@@ -802,17 +802,14 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
     // gestures where the user changes direction during the drag.
     final flingOffset = _focalStartLocal - _lastFocalLocal;
     final finalSegment = _prevFocalLocal - _lastFocalLocal;
-    final finalSegmentDistance = finalSegment.distance;
 
-    // Use final segment direction if available, otherwise fall back to overall
-    // direction for edge cases where the final segment has no movement.
-    final Offset direction;
-    if (finalSegmentDistance > 0) {
-      direction = finalSegment / finalSegmentDistance;
-    } else {
-      final flingDistance = flingOffset.distance;
-      direction = flingOffset / flingDistance;
-    }
+    final direction = flingDirection(
+      finalSegment: finalSegment,
+      flingOffset: flingOffset,
+      // `magnitude` is checked to be non-zero above, so this is always a
+      // finite, non-zero-length direction and is a safe final fallback.
+      velocityDirection: details.velocity.pixelsPerSecond / magnitude,
+    );
     final distance = (Offset.zero & _camera.nonRotatedSize).shortestSide;
 
     _flingAnimation = Tween<Offset>(
@@ -829,6 +826,31 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
             stiffness: 1000,
             ratio: _interactionOptions.flingAnimationDampingRatio,
           ));
+  }
+
+  /// Calculates the direction a fling gesture should continue in.
+  ///
+  /// Prefers the direction of the final tracked pointer segment, falling
+  /// back to the overall drag direction. If both [finalSegment] and
+  /// [flingOffset] have zero length - which can happen even when the
+  /// gesture recognizer reports a velocity above the fling threshold, since
+  /// the velocity is fitted over multiple recent samples and is not
+  /// necessarily proportional to the last tracked position deltas - falls
+  /// back to [velocityDirection] to avoid a division by zero (which would
+  /// otherwise produce a `NaN` direction and corrupt the camera position).
+  @visibleForTesting
+  static Offset flingDirection({
+    required Offset finalSegment,
+    required Offset flingOffset,
+    required Offset velocityDirection,
+  }) {
+    final finalSegmentDistance = finalSegment.distance;
+    if (finalSegmentDistance > 0) return finalSegment / finalSegmentDistance;
+
+    final flingDistance = flingOffset.distance;
+    if (flingDistance > 0) return flingOffset / flingDistance;
+
+    return velocityDirection;
   }
 
   void _handleTap(TapPosition position) {

--- a/test/gestures/map_interactive_viewer_test.dart
+++ b/test/gestures/map_interactive_viewer_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_map/src/gestures/map_interactive_viewer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MapInteractiveViewerState.flingDirection', () {
+    test('uses the final segment direction when it has non-zero length', () {
+      final direction = MapInteractiveViewerState.flingDirection(
+        finalSegment: const Offset(10, 0),
+        flingOffset: const Offset(100, 0),
+        velocityDirection: const Offset(0, 1),
+      );
+
+      expect(direction, const Offset(1, 0));
+    });
+
+    test(
+      'falls back to the overall drag direction when the final segment has '
+      'zero length',
+      () {
+        final direction = MapInteractiveViewerState.flingDirection(
+          finalSegment: Offset.zero,
+          flingOffset: const Offset(0, -50),
+          velocityDirection: const Offset(1, 0),
+        );
+
+        expect(direction, const Offset(0, -1));
+      },
+    );
+
+    test(
+      'falls back to the velocity direction instead of dividing by zero '
+      'when both the final segment and the overall drag offset have zero '
+      'length (regression test: this previously produced a NaN direction, '
+      'which corrupted the camera position - '
+      'https://github.com/fleaflet/flutter_map/issues/2199)',
+      () {
+        final direction = MapInteractiveViewerState.flingDirection(
+          finalSegment: Offset.zero,
+          flingOffset: Offset.zero,
+          velocityDirection: const Offset(0.6, 0.8),
+        );
+
+        expect(direction, const Offset(0.6, 0.8));
+        expect(direction.dx.isFinite, isTrue);
+        expect(direction.dy.isFinite, isTrue);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Fixes #2221 - see that issue for the full bug report,
reproduction steps and root-cause analysis.

## Fix

`MapInteractiveViewerState._handleScaleEnd` could divide `flingOffset` by a
zero `flingDistance` (`0.0 / 0.0 = NaN`) when both the final tracked pointer
segment and the overall drag offset happened to have zero length, even
though the gesture's reported velocity was above the fling threshold.

Extracted the direction calculation into a small, pure, unit-testable
`flingDirection` helper, and added a final fallback to the (already
guaranteed non-zero) velocity direction instead of dividing by zero:

```dart
if (finalSegmentDistance > 0) return finalSegment / finalSegmentDistance;
if (flingDistance > 0) return flingOffset / flingDistance;
return velocityDirection;
```

This preserves the existing behaviour (prefer the final tracked segment,
then the overall drag direction) and only changes behaviour for the
previously-undefined zero/zero edge case, where it now falls back to the
same velocity-based direction that flutter_map used prior to #2158 (8.2.2
and earlier).

`velocityDirection` is guaranteed finite: `magnitude` is already checked to
be `>= _kMinFlingVelocity` before this is called, and Flutter's own
`VelocityTracker` / `LeastSquaresSolver` never return `NaN` - they fall back
to `Offset.zero` / `null` on ill-conditioned samples - so this can never
itself be a source of `NaN`.

## Testing

- Added `test/gestures/map_interactive_viewer_test.dart` covering all three
  branches of `flingDirection`, including a regression test for the
  zero/zero case.
- Full existing test suite passes locally with no regressions.
- Manually verified on a physical Android device: confirmed the crash on
  8.3.0/8.3.1, confirmed it does *not* occur on 8.2.2, and confirmed this
  fix resolves it while pointing a reproduction app at this branch via a
  `dependency_overrides: path:` entry.

## AI disclosure

Per `CONTRIBUTING.md`: I used AI assistance (Claude Code) to help diagnose
the root cause and draft this fix and its tests. I've reviewed the change,
verified it against the project's lint rules and test suite, and manually
confirmed the fix resolves the crash on a physical device.
