### PR TITLE
fix: use smoothed velocity direction for touch flings to prevent off-axis glides

### DIFF
--- a/lib/src/gestures/map_interactive_viewer.dart
+++ b/lib/src/gestures/map_interactive_viewer.dart
@@ -64,6 +64,7 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
   bool _dragMode = false;
   int _gestureWinner = MultiFingerGesture.none;
   int _pointerCounter = 0;
+  PointerDeviceKind? _lastPointerKind;
   bool _isListeningForInterruptions = false;
 
   var _rotationStarted = false;
@@ -372,6 +373,7 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
 
   void _onPointerDown(PointerDownEvent event) {
     ++_pointerCounter;
+    _lastPointerKind = event.kind;
 
     if (_ckrTriggered.value) {
       _ckrInitialDegrees = _camera.rotation;
@@ -808,7 +810,16 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
       flingOffset: flingOffset,
       // `magnitude` is checked to be non-zero above, so this is always a
       // finite, non-zero-length direction and is a safe final fallback.
-      velocityDirection: details.velocity.pixelsPerSecond / magnitude,
+      // Negated so that it shares the convention of the tracked offsets,
+      // which run opposite to the pointer motion.
+      velocityDirection: -details.velocity.pixelsPerSecond / magnitude,
+      // On touch devices the pointer cannot leave the window mid-drag (the
+      // case the tracked offsets handle better than the velocity, see
+      // #2158), and the velocity - fitted over multiple recent samples - is
+      // far more stable than the final tracked segment: deriving the
+      // direction from the single last, noisy pointer segment sends fast
+      // swipes off-axis, so repeated flicks visibly zigzag.
+      preferVelocityDirection: _lastPointerKind == PointerDeviceKind.touch,
     );
     final distance = (Offset.zero & _camera.nonRotatedSize).shortestSide;
 
@@ -830,8 +841,19 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
 
   /// Calculates the direction a fling gesture should continue in.
   ///
-  /// Prefers the direction of the final tracked pointer segment, falling
-  /// back to the overall drag direction. If both [finalSegment] and
+  /// All three candidate vectors must share the same convention: the
+  /// direction the tracked pointer offsets travel in, i.e. opposite to the
+  /// pointer motion.
+  ///
+  /// With [preferVelocityDirection] the (already normalized)
+  /// [velocityDirection] is used directly: the velocity is fitted over
+  /// multiple recent samples and is therefore much more stable than the
+  /// final tracked segment. This is the right choice for touch input, where
+  /// the pointer cannot leave the window mid-drag.
+  ///
+  /// Otherwise prefers the direction of the final tracked pointer segment,
+  /// falling back to the overall drag direction - which handles the pointer
+  /// leaving the window on web/desktop (#2158). If both [finalSegment] and
   /// [flingOffset] have zero length - which can happen even when the
   /// gesture recognizer reports a velocity above the fling threshold, since
   /// the velocity is fitted over multiple recent samples and is not
@@ -843,7 +865,10 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
     required Offset finalSegment,
     required Offset flingOffset,
     required Offset velocityDirection,
+    required bool preferVelocityDirection,
   }) {
+    if (preferVelocityDirection) return velocityDirection;
+
     final finalSegmentDistance = finalSegment.distance;
     if (finalSegmentDistance > 0) return finalSegment / finalSegmentDistance;
 

--- a/test/gestures/map_interactive_viewer_test.dart
+++ b/test/gestures/map_interactive_viewer_test.dart
@@ -3,11 +3,30 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('MapInteractiveViewerState.flingDirection', () {
+    test(
+      'uses the velocity direction when preferred, even when the final '
+      'segment has non-zero length (touch input: the velocity is fitted '
+      'over multiple recent samples, while the single last pointer segment '
+      'is noisy on fast swipes and sends repeated flicks zigzagging '
+      'off-axis)',
+      () {
+        final direction = MapInteractiveViewerState.flingDirection(
+          finalSegment: const Offset(10, 2),
+          flingOffset: const Offset(100, 0),
+          velocityDirection: const Offset(0, 1),
+          preferVelocityDirection: true,
+        );
+
+        expect(direction, const Offset(0, 1));
+      },
+    );
+
     test('uses the final segment direction when it has non-zero length', () {
       final direction = MapInteractiveViewerState.flingDirection(
         finalSegment: const Offset(10, 0),
         flingOffset: const Offset(100, 0),
         velocityDirection: const Offset(0, 1),
+        preferVelocityDirection: false,
       );
 
       expect(direction, const Offset(1, 0));
@@ -21,6 +40,7 @@ void main() {
           finalSegment: Offset.zero,
           flingOffset: const Offset(0, -50),
           velocityDirection: const Offset(1, 0),
+          preferVelocityDirection: false,
         );
 
         expect(direction, const Offset(0, -1));
@@ -38,6 +58,7 @@ void main() {
           finalSegment: Offset.zero,
           flingOffset: Offset.zero,
           velocityDirection: const Offset(0.6, 0.8),
+          preferVelocityDirection: false,
         );
 
         expect(direction, const Offset(0.6, 0.8));


### PR DESCRIPTION
Fixes #2225.

## What

On touch input, derive the fling direction from the gesture recognizer's velocity (Flutter's `VelocityTracker`, a least-squares fit over the last ~100 ms of samples) instead of the single last tracked pointer segment. Mouse/trackpad input keeps the tracked-segment behaviour introduced in #2158, which handles the pointer leaving the window mid-drag — a case that cannot occur with touch.

Also negates the `velocityDirection` passed into `flingDirection()` as the division-by-zero fallback (#2220), so all three direction candidates share the tracked-offset sign convention (`end: flingOffset + direction * distance`). Previously the degenerate zero/zero case glided *against* the swipe, since `details.velocity.pixelsPerSecond` points along the pointer motion while `finalSegment`/`flingOffset` run opposite to it (8.2.2 used the velocity with `- direction * distance`).

## Why

The last tracked segment is one frame-to-frame delta. At fast swipe speeds it is dominated by touch-sampling noise and lift-off thumb-roll, so its direction routinely deviates 30–90° from the swipe axis: fast flicks glide off-axis and repeated flicks visibly zigzag (see #2225 for the full analysis). The fitted velocity direction is stable — it's what the pre-8.3.0 fling used and what platform map apps use.

## How

- `MapInteractiveViewerState` records the device kind of the last pointer-down.
- `flingDirection()` gains a `preferVelocityDirection` parameter; when set (touch), the already-normalized `velocityDirection` is returned directly, otherwise the existing preference order (final segment → overall drag offset → velocity fallback) is unchanged.
- Existing `flingDirection` tests updated for the new parameter; new test covers the touch preference.

All existing tests pass (`flutter test`), `dart analyze` clean, `dart format` clean.
