### PR TITLE
fix: sanitise non-finite zoom in MapCamera.clampZoom

### DIFF
--- a/lib/src/map/camera/camera.dart
+++ b/lib/src/map/camera/camera.dart
@@ -388,10 +388,22 @@ class MapCamera {
 
   /// Clamps the provided [zoom] to the range specified by [minZoom] and
   /// [maxZoom], if set.
-  double clampZoom(double zoom) => zoom.clamp(
-        minZoom ?? double.negativeInfinity,
-        maxZoom ?? double.infinity,
-      );
+  ///
+  /// A non-finite [zoom] (`NaN`/`Infinity`) is treated as an invalid update and
+  /// the current [zoom] is returned unchanged. Without this guard such a value
+  /// would flow into the camera and crash the tile range and marker cluster
+  /// layers — `num.clamp` returns `NaN` for a `NaN` input, so it cannot sanitise
+  /// it. This happens in practice during a rapid pinch zoom-out, where
+  /// `math.log` is fed a non-positive scale and produces a non-finite zoom.
+  double clampZoom(double zoom) {
+    if (!zoom.isFinite) {
+      return this.zoom;
+    }
+    return zoom.clamp(
+      minZoom ?? double.negativeInfinity,
+      maxZoom ?? double.infinity,
+    );
+  }
 
   /// Calculate the [LatLng] coordinates for a given [Offset] and an optional
   /// zoom level. If [zoom] is not provided the current zoom level of the

--- a/test/map/camera/camera_test.dart
+++ b/test/map/camera/camera_test.dart
@@ -1,0 +1,50 @@
+import 'dart:ui';
+
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+
+void main() {
+  group('MapCamera.clampZoom', () {
+    MapCamera cameraAtZoom(double zoom) => MapCamera(
+          crs: const Epsg3857(),
+          center: const LatLng(0, 0),
+          zoom: zoom,
+          rotation: 0,
+          nonRotatedSize: const Size(200, 300),
+          minZoom: 5,
+          maxZoom: 18,
+        );
+
+    test('clamps to minZoom / maxZoom', () {
+      final camera = cameraAtZoom(10);
+      expect(camera.clampZoom(2), 5);
+      expect(camera.clampZoom(20), 18);
+      expect(camera.clampZoom(12), 12);
+    });
+
+    test('keeps the current zoom for non-finite input', () {
+      // A non-positive pinch scale during a rapid zoom-out makes math.log
+      // produce a non-finite zoom. num.clamp does not sanitise NaN, so without
+      // the guard this value would flow into the camera and crash the tile
+      // range and marker cluster layers.
+      final camera = cameraAtZoom(10);
+      expect(camera.clampZoom(double.nan), 10);
+      expect(camera.clampZoom(double.infinity), 10);
+      expect(camera.clampZoom(double.negativeInfinity), 10);
+    });
+
+    test('does not clamp when no min/max is set', () {
+      final camera = MapCamera(
+        crs: const Epsg3857(),
+        center: const LatLng(0, 0),
+        zoom: 10,
+        rotation: 0,
+        nonRotatedSize: const Size(200, 300),
+      );
+      expect(camera.clampZoom(2), 2);
+      expect(camera.clampZoom(20), 20);
+      expect(camera.clampZoom(double.nan), 10);
+    });
+  });
+}


### PR DESCRIPTION
## What & why

During a rapid pinch zoom-out, the gesture handler calls `_getZoomForScale`,
which computes `startZoom + math.log(scale) / math.ln2`. When
`details.scale + _scaleCorrector` momentarily becomes non-positive (the scale
corrector can be negative), `math.log` returns `NaN` or `-Infinity`.

`clampZoom` relied on `num.clamp`, which returns `NaN` unchanged for a `NaN`
input and therefore cannot sanitise it. The invalid zoom was committed to the
camera and propagated into:

- **`TileRangeCalculator`** — `halfSize = size / (scale * 2)` becomes non-finite
  and `DiscreteTileRange.fromPixelBounds` throws
  `Unsupported operation: Infinity or NaN toInt` from `.floor()`.
- **`MarkerClusterLayer`** — the visible bounds become `NaN`, tripping the
  `north <= maxLatitude` assertion.

The crash is transient/self-healing (the next finite scale update recomputes a
valid zoom), but each bad frame surfaces as an uncaught framework error.

## Fix

`clampZoom` now treats any non-finite input as an invalid update and returns the
current (finite) zoom, keeping the camera in a valid state. Being the single
chokepoint every zoom mutation passes through (gestures and `moveRaw`), this
covers the whole class of NaN-zoom bugs. It also fixes the `minZoom == null`
case, where a `-Infinity` zoom crashed as well.

## Tests

Added `test/map/camera/camera_test.dart` covering the non-finite guard
(`NaN`/`±Infinity`), normal min/max clamping, and the no-min/max case. The
existing `camera/` tests still pass.

## Notes

- Related issues: #1759, #1370, #409, #524.

## AI disclosure

This change was written with the assistance of AI (Claude).