### PR TITLE
fix: exclude the map's gesture detector from semantics

### DIFF
--- a/lib/src/gestures/map_interactive_viewer.dart
+++ b/lib/src/gestures/map_interactive_viewer.dart
@@ -359,6 +359,24 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
                   : Duration.zero,
           child: RawGestureDetector(
             gestures: _gestures,
+            // The map's gestures are pointer gestures, not semantic actions.
+            // Left included, `_gestures`' tap/long-press recognizers publish
+            // `SemanticsAction.tap`/`longPress` on a semantics node covering the
+            // map's whole hit area, which causes two problems once the semantics
+            // tree is enabled:
+            //
+            //  * A semantics-driven tap synthesises its position at the node's
+            //    centre, so `onTap` reports the map centre instead of where the
+            //    user tapped, with `kind: unknown` (#2176).
+            //  * On web, Flutter gives a tappable semantics node
+            //    `pointer-events: all`. A map-sized node therefore covers any
+            //    HtmlElementView layered above the map (`<iframe>`, `<video>`)
+            //    and swallows the mouse events those embeds need, leaving their
+            //    own controls unusable.
+            //
+            // Markers and other children keep their own semantics, so nothing
+            // that is meaningfully activatable loses its node here.
+            excludeFromSemantics: true,
             child: widget.builder(
               context,
               widget.controller.options,

--- a/test/gestures/map_interactive_viewer_test.dart
+++ b/test/gestures/map_interactive_viewer_test.dart
@@ -1,3 +1,6 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/gestures/map_interactive_viewer.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -43,6 +46,49 @@ void main() {
         expect(direction, const Offset(0.6, 0.8));
         expect(direction.dx.isFinite, isTrue);
         expect(direction.dy.isFinite, isTrue);
+      },
+    );
+  });
+
+  group('map gesture semantics', () {
+    testWidgets(
+      'the map does not publish a map-sized tap semantics action '
+      '(regression test: a tappable node covering the map made semantic taps '
+      'report the map centre instead of the tap position, and on web its '
+      'pointer-events swallowed the mouse events of any HtmlElementView '
+      'layered above the map - '
+      'https://github.com/fleaflet/flutter_map/issues/2176)',
+      (tester) async {
+        final semantics = tester.ensureSemantics();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FlutterMap(
+              options: const MapOptions(),
+              children: const [],
+            ),
+          ),
+        );
+
+        final actionable = <SemanticsNode>[];
+        void visit(SemanticsNode node) {
+          final data = node.getSemanticsData();
+          if (data.hasAction(SemanticsAction.tap) ||
+              data.hasAction(SemanticsAction.longPress)) {
+            actionable.add(node);
+          }
+          node.visitChildren((child) {
+            visit(child);
+            return true;
+          });
+        }
+
+        final root = tester.binding.pipelineOwner.semanticsOwner!
+            .rootSemanticsNode!;
+        visit(root);
+        semantics.dispose();
+
+        expect(actionable, isEmpty);
       },
     );
   });


### PR DESCRIPTION
Fixes #2176.

### The mechanism

`MapInteractiveViewer` builds `RawGestureDetector(gestures: _gestures, ...)` and leaves `excludeFromSemantics` at its default `false`. `_gestures` contains a `TapGestureRecognizer` and a `LongPressGestureRecognizer`, so Flutter wraps the child in `_GestureSemantics` and publishes `SemanticsAction.tap` / `longPress` on a semantics node covering the detector's whole hit area — i.e. the entire map.

Two consequences once the semantics tree is enabled (`SemanticsBinding.instance.ensureSemantics()`, or automatically when assistive technology is detected):

**1. `onTap` reports the map centre (#2176).** A semantics-driven activation doesn't carry a pointer position, so the framework synthesises one at the node's centre and the recognizer fires with `kind: unknown`. Since the node is the size of the map, that centre *is* the map centre — which is exactly the reported symptom, and why `kind` changes from `mouse` to `unknown`. Long-press is affected in principle for the same reason; drag recognizers publish no semantics action, which is why panning/zooming were unaffected and only `onTap` looked broken.

**2. On web it blankets any `HtmlElementView` over the map.** Flutter web gives a tappable semantics node `pointer-events: all`. Platform views are *not* part of the semantics tree, so a map-sized tappable node sits above any `<iframe>` / `<video>` composited over the map and swallows its mouse events — the embed renders and plays but its own controls never respond (a YouTube embed never even shows its control bar, because it never receives `mousemove`).

I confirmed (2) in a Flutter web app by measuring `document.elementFromPoint` over a playing embed: the top element was the map's `flt-semantics` node, viewport-sized, `pointer-events: all`, every ancestor correctly `none`. Setting `pointer-events: none` on that one node — changing nothing else — immediately restored the embed's full controls.

### The change

`excludeFromSemantics: true` on that `RawGestureDetector`. The map's gestures are pointer gestures, not semantic actions: a map-sized "tap" target isn't a meaningful screen-reader affordance, and its only current effect is to mis-report the tap position. Markers and other children keep their own semantics, so nothing meaningfully activatable loses a node.

### Testing

- New regression test in `test/gestures/map_interactive_viewer_test.dart`: with semantics enabled, a bare `FlutterMap` publishes no `tap`/`longPress` semantics action. It fails on `master` and passes with this change.
- Full suite green locally (118/118).

Happy to adjust the approach — if you'd rather keep a semantic affordance on the map and fix the position synthesis instead, say so and I'll rework it.

### AI disclosure

Per CONTRIBUTING: this was written with AI assistance (Claude). I've reviewed the diagnosis and the diff, ran the tests locally, and take responsibility for the change.
