### PR TITLE
fix: dispose the image handed to a tile pruned during dispatch

### DIFF
--- a/lib/src/layer/tile_layer/tile.dart
+++ b/lib/src/layer/tile_layer/tile.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui show Image;
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
@@ -89,7 +91,7 @@ class _TileState extends State<Tile> {
       );
     } else if (widget.tileImage.animation == null) {
       return RawImage(
-        image: widget.tileImage.imageInfo?.image,
+        image: _handOff(widget.tileImage),
         fit: BoxFit.fill,
         opacity: widget.tileImage.opacity == 1
             ? null
@@ -99,11 +101,19 @@ class _TileState extends State<Tile> {
       return AnimatedBuilder(
         animation: widget.tileImage.animation!,
         builder: (context, child) => RawImage(
-          image: widget.tileImage.imageInfo?.image,
+          image: _handOff(widget.tileImage),
           fit: BoxFit.fill,
           opacity: widget.tileImage.animation,
         ),
       );
     }
   }
+}
+
+/// Passes the tile's decoded handle to `RawImage` and records the ownership
+/// transfer — from here on `RenderImage` disposes it, so [TileImage] must not.
+ui.Image? _handOff(TileImage tileImage) {
+  final image = tileImage.imageInfo?.image;
+  if (image != null) tileImage.markImageHandedToRenderObject();
+  return image;
 }

--- a/lib/src/layer/tile_layer/tile.dart
+++ b/lib/src/layer/tile_layer/tile.dart
@@ -1,5 +1,3 @@
-import 'dart:ui' as ui show Image;
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
@@ -91,7 +89,7 @@ class _TileState extends State<Tile> {
       );
     } else if (widget.tileImage.animation == null) {
       return RawImage(
-        image: _handOff(widget.tileImage),
+        image: widget.tileImage.imageInfo?.image,
         fit: BoxFit.fill,
         opacity: widget.tileImage.opacity == 1
             ? null
@@ -101,7 +99,7 @@ class _TileState extends State<Tile> {
       return AnimatedBuilder(
         animation: widget.tileImage.animation!,
         builder: (context, child) => RawImage(
-          image: _handOff(widget.tileImage),
+          image: widget.tileImage.imageInfo?.image,
           fit: BoxFit.fill,
           opacity: widget.tileImage.animation,
         ),
@@ -110,10 +108,3 @@ class _TileState extends State<Tile> {
   }
 }
 
-/// Passes the tile's decoded handle to `RawImage` and records the ownership
-/// transfer — from here on `RenderImage` disposes it, so [TileImage] must not.
-ui.Image? _handOff(TileImage tileImage) {
-  final image = tileImage.imageInfo?.image;
-  if (image != null) tileImage.markImageHandedToRenderObject();
-  return image;
-}

--- a/lib/src/layer/tile_layer/tile.dart
+++ b/lib/src/layer/tile_layer/tile.dart
@@ -107,4 +107,3 @@ class _TileState extends State<Tile> {
     }
   }
 }
-

--- a/lib/src/layer/tile_layer/tile_image.dart
+++ b/lib/src/layer/tile_layer/tile_image.dart
@@ -56,8 +56,41 @@ class TileImage extends ChangeNotifier {
 
   /// Some meta data of the image.
   ImageInfo? imageInfo;
+
+  /// Whether [imageInfo]'s handle was passed to a `RawImage`.
+  ///
+  /// Ownership of the decoded image is transferred at build time: `RawImage`
+  /// hands the raw `ui.Image` to `RenderImage`, which disposes it when it is
+  /// replaced or unmounted. That is why [dispose] does not free [imageInfo] —
+  /// by then it belongs to the render object.
+  ///
+  /// The model assumes ONE frame per tile, which holds for static tiles. A
+  /// completer that emits a second frame (progressive tiles: a base frame
+  /// followed by a composed one) overwrites [imageInfo] before any build has
+  /// to happen. When both frames land within the same frame budget — the
+  /// common case on a fast device — the first handle is never handed to a
+  /// `RenderImage`, so nothing disposes it.
+  ///
+  /// Measured on an iPhone with 768x768 composed tiles: ~0.9 leaked handles
+  /// per tile, growing linearly with the number of tiles browsed and invisible
+  /// to `ImageCache` (which reported ~25 live images against 3336 alive
+  /// `ui.Image` objects).
+  bool _imageHandedToRenderObject = false;
+
   ImageStream? _imageStream;
   late ImageStreamListener _listener;
+
+  /// Records that [imageInfo]'s handle reached a `RawImage`, so the render
+  /// object owns it from now on and this class must not free it.
+  void markImageHandedToRenderObject() => _imageHandedToRenderObject = true;
+
+  /// Frees [imageInfo] only while it is still ours — i.e. no build has passed
+  /// it on. Disposing a handle already owned by a `RenderImage` would be a
+  /// double free.
+  void _disposeUnhandedImage() {
+    if (!_imageHandedToRenderObject) imageInfo?.dispose();
+    _imageHandedToRenderObject = false;
+  }
 
   /// Create a new object for a tile image.
   TileImage({
@@ -175,6 +208,10 @@ class TileImage extends ChangeNotifier {
       return;
     }
 
+    // A previous frame whose handle never reached a `RawImage` is ours to
+    // free — see [_imageHandedToRenderObject]. Without this, every tile that
+    // emits two frames within one frame budget leaks its first handle.
+    _disposeUnhandedImage();
     this.imageInfo = imageInfo;
     _display();
     onLoadComplete(coordinates);
@@ -256,6 +293,10 @@ class TileImage extends ChangeNotifier {
 
     _animationController?.dispose();
     _imageStream?.removeListener(_listener);
+    // Same ownership rule as on frame replacement: a handle that no build ever
+    // passed to a `RenderImage` would otherwise never be freed. Tiles pruned
+    // between load and paint hit this path.
+    _disposeUnhandedImage();
     super.dispose();
   }
 

--- a/lib/src/layer/tile_layer/tile_image.dart
+++ b/lib/src/layer/tile_layer/tile_image.dart
@@ -74,7 +74,6 @@ class TileImage extends ChangeNotifier {
   ImageStream? _imageStream;
   late ImageStreamListener _listener;
 
-
   /// Create a new object for a tile image.
   TileImage({
     required this.vsync,
@@ -175,10 +174,9 @@ class TileImage extends ChangeNotifier {
   void _onImageLoadSuccess(ImageInfo imageInfo, bool synchronousCall) {
     loadError = false;
 
-    // A disposed tile is never painted, so it never hands its image to a
-    // `RenderImage` — and `setImage` gives every listener its own handle to
-    // dispose. Keeping it here leaks the decoded image for the process
-    // lifetime.
+    // After dispose() the owner that would free this handle is gone (dispose
+    // ran and nulled the field — see the ownership note on [imageInfo]), so
+    // the handler frees it on the spot.
     //
     // `dispose()` removes the listener, but `setImage` dispatches over a copy
     // of the listener list, so a listener removed from inside that loop is
@@ -191,9 +189,8 @@ class TileImage extends ChangeNotifier {
       return;
     }
 
-    // The previous frame's handle is ours — `RawImage` clones for the render
-    // object, so nothing downstream frees this one. Without this line every
-    // PAINTED frame leaks its handle for the lifetime of the process.
+    // The previous frame's handle is ours to free — see the ownership note
+    // on [imageInfo].
     this.imageInfo?.dispose();
     this.imageInfo = imageInfo;
     _display();
@@ -276,10 +273,9 @@ class TileImage extends ChangeNotifier {
 
     _animationController?.dispose();
     _imageStream?.removeListener(_listener);
-    // Same ownership rule as on frame replacement: the handle is the tile's
-    // own, so the tile frees it. Nulling the field keeps a straggler build
-    // (dispose can race the layer rebuild) from cloning a disposed image —
-    // `RawImage` treats null as "paint nothing".
+    // Same ownership rule as on frame replacement (see [imageInfo]). Nulling
+    // the field keeps a straggler build — dispose can race the layer rebuild —
+    // from cloning a disposed image; `RawImage` treats null as "paint nothing".
     imageInfo?.dispose();
     imageInfo = null;
     super.dispose();

--- a/lib/src/layer/tile_layer/tile_image.dart
+++ b/lib/src/layer/tile_layer/tile_image.dart
@@ -55,42 +55,25 @@ class TileImage extends ChangeNotifier {
   DateTime? loadFinishedAt;
 
   /// Some meta data of the image.
+  ///
+  /// Ownership: this handle is ALWAYS the tile's own. `RawImage` clones the
+  /// image for its `RenderImage` (`createRenderObject`/`updateRenderObject`
+  /// both pass `image?.clone()`), so handing it to the widget tree never
+  /// transfers ownership — the render object frees its own clone, and this
+  /// one stays with the tile until the tile frees it: on frame replacement
+  /// and on [dispose].
+  ///
+  /// The previous model ("the render object takes over at build time") was
+  /// wrong and leaked exactly one handle per painted frame: measured on an
+  /// iPhone with 768x768 tiles as ~0.3-0.9 leaked handles per tile, invisible
+  /// to `ImageCache`, with the process eventually killed by jetsam. GC
+  /// finalizers reclaim such handles EVENTUALLY, which is why small default
+  /// tiles get away with it — 2.25 MB tiles do not.
   ImageInfo? imageInfo;
-
-  /// Whether [imageInfo]'s handle was passed to a `RawImage`.
-  ///
-  /// Ownership of the decoded image is transferred at build time: `RawImage`
-  /// hands the raw `ui.Image` to `RenderImage`, which disposes it when it is
-  /// replaced or unmounted. That is why [dispose] does not free [imageInfo] —
-  /// by then it belongs to the render object.
-  ///
-  /// The model assumes ONE frame per tile, which holds for static tiles. A
-  /// completer that emits a second frame (progressive tiles: a base frame
-  /// followed by a composed one) overwrites [imageInfo] before any build has
-  /// to happen. When both frames land within the same frame budget — the
-  /// common case on a fast device — the first handle is never handed to a
-  /// `RenderImage`, so nothing disposes it.
-  ///
-  /// Measured on an iPhone with 768x768 composed tiles: ~0.9 leaked handles
-  /// per tile, growing linearly with the number of tiles browsed and invisible
-  /// to `ImageCache` (which reported ~25 live images against 3336 alive
-  /// `ui.Image` objects).
-  bool _imageHandedToRenderObject = false;
 
   ImageStream? _imageStream;
   late ImageStreamListener _listener;
 
-  /// Records that [imageInfo]'s handle reached a `RawImage`, so the render
-  /// object owns it from now on and this class must not free it.
-  void markImageHandedToRenderObject() => _imageHandedToRenderObject = true;
-
-  /// Frees [imageInfo] only while it is still ours — i.e. no build has passed
-  /// it on. Disposing a handle already owned by a `RenderImage` would be a
-  /// double free.
-  void _disposeUnhandedImage() {
-    if (!_imageHandedToRenderObject) imageInfo?.dispose();
-    _imageHandedToRenderObject = false;
-  }
 
   /// Create a new object for a tile image.
   TileImage({
@@ -208,10 +191,10 @@ class TileImage extends ChangeNotifier {
       return;
     }
 
-    // A previous frame whose handle never reached a `RawImage` is ours to
-    // free — see [_imageHandedToRenderObject]. Without this, every tile that
-    // emits two frames within one frame budget leaks its first handle.
-    _disposeUnhandedImage();
+    // The previous frame's handle is ours — `RawImage` clones for the render
+    // object, so nothing downstream frees this one. Without this line every
+    // PAINTED frame leaks its handle for the lifetime of the process.
+    this.imageInfo?.dispose();
     this.imageInfo = imageInfo;
     _display();
     onLoadComplete(coordinates);
@@ -293,10 +276,12 @@ class TileImage extends ChangeNotifier {
 
     _animationController?.dispose();
     _imageStream?.removeListener(_listener);
-    // Same ownership rule as on frame replacement: a handle that no build ever
-    // passed to a `RenderImage` would otherwise never be freed. Tiles pruned
-    // between load and paint hit this path.
-    _disposeUnhandedImage();
+    // Same ownership rule as on frame replacement: the handle is the tile's
+    // own, so the tile frees it. Nulling the field keeps a straggler build
+    // (dispose can race the layer rebuild) from cloning a disposed image —
+    // `RawImage` treats null as "paint nothing".
+    imageInfo?.dispose();
+    imageInfo = null;
     super.dispose();
   }
 

--- a/lib/src/layer/tile_layer/tile_image.dart
+++ b/lib/src/layer/tile_layer/tile_image.dart
@@ -158,12 +158,26 @@ class TileImage extends ChangeNotifier {
 
   void _onImageLoadSuccess(ImageInfo imageInfo, bool synchronousCall) {
     loadError = false;
-    this.imageInfo = imageInfo;
 
-    if (!_disposed) {
-      _display();
-      onLoadComplete(coordinates);
+    // A disposed tile is never painted, so it never hands its image to a
+    // `RenderImage` — and `setImage` gives every listener its own handle to
+    // dispose. Keeping it here leaks the decoded image for the process
+    // lifetime.
+    //
+    // `dispose()` removes the listener, but `setImage` dispatches over a copy
+    // of the listener list, so a listener removed from inside that loop is
+    // still called. Tiles resolving equal keys share one completer, and
+    // `onLoadComplete` is where pruning happens (see the note in
+    // `TileImageManager.reloadImages`) — so a tile can be disposed
+    // mid-dispatch and handed an image anyway. See `tile_image_test.dart`.
+    if (_disposed) {
+      imageInfo.dispose();
+      return;
     }
+
+    this.imageInfo = imageInfo;
+    _display();
+    onLoadComplete(coordinates);
   }
 
   void _onImageLoadError(Object exception, StackTrace? stackTrace) {

--- a/test/layer/tile_layer/tile_image_test.dart
+++ b/test/layer/tile_layer/tile_image_test.dart
@@ -110,21 +110,21 @@ void main() {
   );
 
   testWidgets(
-    'frees the first frame when a second frame replaces it before any build',
+    'replacing a frame frees the previous handle — painted or not',
     (tester) async {
-      // Ownership of a tile's decoded image transfers at BUILD time: `RawImage`
-      // hands the handle to `RenderImage`, which frees it. With one frame per
-      // tile that always holds. A completer emitting a second frame can
-      // overwrite the first before any build happened — and then nobody frees
-      // the first handle. Measured on device: ~0.9 leaked handles per tile,
-      // invisible to `ImageCache`.
-      final images = (await tester.runAsync(() async => [
-            await createTestImage(width: 8, height: 8),
-            await createTestImage(width: 8, height: 8),
-          ]))!;
-      final first = images[0];
-      final second = images[1];
-      final baseline = first.debugGetOpenHandleStackTraces()!.length;
+      // Ownership truth (checked against Flutter sources, not assumed):
+      // `RawImage` CLONES the image for its `RenderImage` — both
+      // `createRenderObject` and `updateRenderObject` pass `image?.clone()`.
+      // So the render object only ever frees its own clone, and the tile's
+      // handle stays the tile's forever. The earlier model ("the render
+      // object takes over at build time") was wrong and leaked one handle
+      // per painted frame — measured on device as ~0.3/tile after the
+      // flag-based fix, because the flag exempted exactly the painted frames.
+      final first =
+          (await tester.runAsync(() => createTestImage(width: 8, height: 8, cache: false)))!;
+      final second =
+          (await tester.runAsync(() => createTestImage(width: 9, height: 9, cache: false)))!;
+      final base1 = first.debugGetOpenHandleStackTraces()!.length;
 
       final completer = _MultiFrameCompleter();
       final tile = _tile(x: 0, provider: _MultiFrameProvider(completer));
@@ -132,20 +132,19 @@ void main() {
 
       completer.emit(ImageInfo(image: first));
       expect(
-        first.debugGetOpenHandleStackTraces(),
-        hasLength(baseline + 1),
-        reason: 'the tile holds the first frame — the scenario needs that',
+        first.debugGetOpenHandleStackTraces()!.length,
+        greaterThan(base1),
+        reason: 'the tile must hold the first frame — the scenario needs that',
       );
 
-      // No pump: the second frame lands within the same frame budget, which is
-      // the common case on a fast device.
       completer.emit(ImageInfo(image: second));
 
       expect(
         first.debugGetOpenHandleStackTraces(),
-        hasLength(baseline),
-        reason: 'no build ever passed the first frame to a RenderImage, so the '
-            'tile still owned it and must free it on replacement',
+        hasLength(base1 - 1),
+        reason: 'on replacement the tile must free its own handle to the '
+            'previous frame; the completer freed the original at setImage, '
+            'hence one below baseline',
       );
 
       tile.dispose();
@@ -153,34 +152,31 @@ void main() {
   );
 
   testWidgets(
-    'keeps a frame the widget already handed to the render object',
+    'dispose frees the current handle and nulls the field',
     (tester) async {
-      // The mirror case: freeing a handle a `RenderImage` owns would be a
-      // double free. This is what makes the fix above safe rather than lucky.
-      final images = (await tester.runAsync(() async => [
-            await createTestImage(width: 8, height: 8),
-            await createTestImage(width: 8, height: 8),
-          ]))!;
-      final first = images[0];
-      final baseline = first.debugGetOpenHandleStackTraces()!.length;
+      final image =
+          (await tester.runAsync(() => createTestImage(width: 8, height: 8, cache: false)))!;
+      final baseline = image.debugGetOpenHandleStackTraces()!.length;
 
       final completer = _MultiFrameCompleter();
       final tile = _tile(x: 0, provider: _MultiFrameProvider(completer));
       tile.load();
-
-      completer.emit(ImageInfo(image: first));
-      // A build happened: `Tile` passed the handle on.
-      tile.markImageHandedToRenderObject();
-      completer.emit(ImageInfo(image: images[1]));
-
-      expect(
-        first.debugGetOpenHandleStackTraces(),
-        hasLength(baseline + 1),
-        reason: 'the render object owns this handle now and disposes it when '
-            'it is replaced — the tile must keep its hands off',
-      );
+      completer.emit(ImageInfo(image: image));
 
       tile.dispose();
+
+      expect(
+        image.debugGetOpenHandleStackTraces(),
+        hasLength(baseline),
+        reason: 'the tile owned its handle to the very end — dispose must '
+            'free it (the completer still holds the original it was given)',
+      );
+      expect(
+        tile.imageInfo,
+        isNull,
+        reason: 'dispose can race the layer rebuild; a straggler build must '
+            'see null (paint nothing), not a disposed image it would clone',
+      );
     },
   );
 }

--- a/test/layer/tile_layer/tile_image_test.dart
+++ b/test/layer/tile_layer/tile_image_test.dart
@@ -1,48 +1,10 @@
-import 'dart:async';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// An [ImageProvider] whose image is delivered only when the test says so, and
-/// whose key is itself, so that two [TileImage]s resolve to the SAME
-/// [ImageStreamCompleter] (which is what [ImageCache] does for equal keys).
-class _SharedManualImageProvider
-    extends ImageProvider<_SharedManualImageProvider> {
-  _SharedManualImageProvider(this.completer);
+import '../../test_utils/test_frame_driver.dart';
 
-  final Completer<ImageInfo> completer;
 
-  @override
-  Future<_SharedManualImageProvider> obtainKey(
-    ImageConfiguration configuration,
-  ) =>
-      SynchronousFuture<_SharedManualImageProvider>(this);
-
-  @override
-  ImageStreamCompleter loadImage(
-    _SharedManualImageProvider key,
-    ImageDecoderCallback decode,
-  ) =>
-      OneFrameImageStreamCompleter(completer.future);
-}
-
-TileImage _tile({
-  required int x,
-  required ImageProvider provider,
-  void Function(TileCoordinates)? onLoadComplete,
-}) =>
-    TileImage(
-      vsync: const TestVSync(),
-      coordinates: TileCoordinates(x, 0, 0),
-      imageProvider: provider,
-      onLoadComplete: onLoadComplete ?? (_) {},
-      onLoadError: (_, __, ___) {},
-      tileDisplay: const TileDisplay.instantaneous(),
-      errorImage: null,
-      cancelLoading: Completer<void>(),
-    );
 
 void main() {
   testWidgets(
@@ -56,8 +18,8 @@ void main() {
       // already has more than one handle open.
       final baseline = image.debugGetOpenHandleStackTraces()!.length;
 
-      final completer = Completer<ImageInfo>();
-      final provider = _SharedManualImageProvider(completer);
+      final completer = DrivenCompleter();
+      final provider = DrivenProvider(completer);
 
       late final TileImage second;
       var secondDisposed = false;
@@ -71,8 +33,7 @@ void main() {
       // a listener from inside that loop does not stop it from being called.
       // The first tile's completion runs `onLoadComplete` — which is where
       // flutter_map prunes tiles — disposing the second tile mid-dispatch.
-      final first = _tile(
-        x: 0,
+      final first = testTileImage(
         provider: provider,
         onLoadComplete: (_) {
           if (secondDisposed) return;
@@ -80,12 +41,12 @@ void main() {
           second.dispose();
         },
       );
-      second = _tile(x: 1, provider: provider);
+      second = testTileImage(x: 1, provider: provider);
 
       first.load();
       second.load();
 
-      completer.complete(ImageInfo(image: image));
+      completer.emit(ImageInfo(image: image));
       await tester.pump();
 
       expect(
@@ -126,8 +87,8 @@ void main() {
           (await tester.runAsync(() => createTestImage(width: 9, height: 9, cache: false)))!;
       final base1 = first.debugGetOpenHandleStackTraces()!.length;
 
-      final completer = _MultiFrameCompleter();
-      final tile = _tile(x: 0, provider: _MultiFrameProvider(completer));
+      final completer = DrivenCompleter();
+      final tile = testTileImage(provider: DrivenProvider(completer));
       tile.load();
 
       completer.emit(ImageInfo(image: first));
@@ -158,8 +119,8 @@ void main() {
           (await tester.runAsync(() => createTestImage(width: 8, height: 8, cache: false)))!;
       final baseline = image.debugGetOpenHandleStackTraces()!.length;
 
-      final completer = _MultiFrameCompleter();
-      final tile = _tile(x: 0, provider: _MultiFrameProvider(completer));
+      final completer = DrivenCompleter();
+      final tile = testTileImage(provider: DrivenProvider(completer));
       tile.load();
       completer.emit(ImageInfo(image: image));
 
@@ -179,27 +140,4 @@ void main() {
       );
     },
   );
-}
-
-/// A completer the test drives frame by frame — progressive tiles (a base
-/// frame followed by a composed one) emit more than once.
-class _MultiFrameCompleter extends ImageStreamCompleter {
-  void emit(ImageInfo info) => setImage(info);
-}
-
-class _MultiFrameProvider extends ImageProvider<_MultiFrameProvider> {
-  _MultiFrameProvider(this.completer);
-
-  final _MultiFrameCompleter completer;
-
-  @override
-  Future<_MultiFrameProvider> obtainKey(ImageConfiguration configuration) =>
-      SynchronousFuture<_MultiFrameProvider>(this);
-
-  @override
-  ImageStreamCompleter loadImage(
-    _MultiFrameProvider key,
-    ImageDecoderCallback decode,
-  ) =>
-      completer;
 }

--- a/test/layer/tile_layer/tile_image_test.dart
+++ b/test/layer/tile_layer/tile_image_test.dart
@@ -108,4 +108,102 @@ void main() {
       first.dispose();
     },
   );
+
+  testWidgets(
+    'frees the first frame when a second frame replaces it before any build',
+    (tester) async {
+      // Ownership of a tile's decoded image transfers at BUILD time: `RawImage`
+      // hands the handle to `RenderImage`, which frees it. With one frame per
+      // tile that always holds. A completer emitting a second frame can
+      // overwrite the first before any build happened — and then nobody frees
+      // the first handle. Measured on device: ~0.9 leaked handles per tile,
+      // invisible to `ImageCache`.
+      final images = (await tester.runAsync(() async => [
+            await createTestImage(width: 8, height: 8),
+            await createTestImage(width: 8, height: 8),
+          ]))!;
+      final first = images[0];
+      final second = images[1];
+      final baseline = first.debugGetOpenHandleStackTraces()!.length;
+
+      final completer = _MultiFrameCompleter();
+      final tile = _tile(x: 0, provider: _MultiFrameProvider(completer));
+      tile.load();
+
+      completer.emit(ImageInfo(image: first));
+      expect(
+        first.debugGetOpenHandleStackTraces(),
+        hasLength(baseline + 1),
+        reason: 'the tile holds the first frame — the scenario needs that',
+      );
+
+      // No pump: the second frame lands within the same frame budget, which is
+      // the common case on a fast device.
+      completer.emit(ImageInfo(image: second));
+
+      expect(
+        first.debugGetOpenHandleStackTraces(),
+        hasLength(baseline),
+        reason: 'no build ever passed the first frame to a RenderImage, so the '
+            'tile still owned it and must free it on replacement',
+      );
+
+      tile.dispose();
+    },
+  );
+
+  testWidgets(
+    'keeps a frame the widget already handed to the render object',
+    (tester) async {
+      // The mirror case: freeing a handle a `RenderImage` owns would be a
+      // double free. This is what makes the fix above safe rather than lucky.
+      final images = (await tester.runAsync(() async => [
+            await createTestImage(width: 8, height: 8),
+            await createTestImage(width: 8, height: 8),
+          ]))!;
+      final first = images[0];
+      final baseline = first.debugGetOpenHandleStackTraces()!.length;
+
+      final completer = _MultiFrameCompleter();
+      final tile = _tile(x: 0, provider: _MultiFrameProvider(completer));
+      tile.load();
+
+      completer.emit(ImageInfo(image: first));
+      // A build happened: `Tile` passed the handle on.
+      tile.markImageHandedToRenderObject();
+      completer.emit(ImageInfo(image: images[1]));
+
+      expect(
+        first.debugGetOpenHandleStackTraces(),
+        hasLength(baseline + 1),
+        reason: 'the render object owns this handle now and disposes it when '
+            'it is replaced — the tile must keep its hands off',
+      );
+
+      tile.dispose();
+    },
+  );
+}
+
+/// A completer the test drives frame by frame — progressive tiles (a base
+/// frame followed by a composed one) emit more than once.
+class _MultiFrameCompleter extends ImageStreamCompleter {
+  void emit(ImageInfo info) => setImage(info);
+}
+
+class _MultiFrameProvider extends ImageProvider<_MultiFrameProvider> {
+  _MultiFrameProvider(this.completer);
+
+  final _MultiFrameCompleter completer;
+
+  @override
+  Future<_MultiFrameProvider> obtainKey(ImageConfiguration configuration) =>
+      SynchronousFuture<_MultiFrameProvider>(this);
+
+  @override
+  ImageStreamCompleter loadImage(
+    _MultiFrameProvider key,
+    ImageDecoderCallback decode,
+  ) =>
+      completer;
 }

--- a/test/layer/tile_layer/tile_image_test.dart
+++ b/test/layer/tile_layer/tile_image_test.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// An [ImageProvider] whose image is delivered only when the test says so, and
+/// whose key is itself, so that two [TileImage]s resolve to the SAME
+/// [ImageStreamCompleter] (which is what [ImageCache] does for equal keys).
+class _SharedManualImageProvider
+    extends ImageProvider<_SharedManualImageProvider> {
+  _SharedManualImageProvider(this.completer);
+
+  final Completer<ImageInfo> completer;
+
+  @override
+  Future<_SharedManualImageProvider> obtainKey(
+    ImageConfiguration configuration,
+  ) =>
+      SynchronousFuture<_SharedManualImageProvider>(this);
+
+  @override
+  ImageStreamCompleter loadImage(
+    _SharedManualImageProvider key,
+    ImageDecoderCallback decode,
+  ) =>
+      OneFrameImageStreamCompleter(completer.future);
+}
+
+TileImage _tile({
+  required int x,
+  required ImageProvider provider,
+  void Function(TileCoordinates)? onLoadComplete,
+}) =>
+    TileImage(
+      vsync: const TestVSync(),
+      coordinates: TileCoordinates(x, 0, 0),
+      imageProvider: provider,
+      onLoadComplete: onLoadComplete ?? (_) {},
+      onLoadError: (_, __, ___) {},
+      tileDisplay: const TileDisplay.instantaneous(),
+      errorImage: null,
+      cancelLoading: Completer<void>(),
+    );
+
+void main() {
+  testWidgets(
+    'disposes the image handed to a tile pruned during listener dispatch',
+    (tester) async {
+      // `runAsync`: decoding needs real async, which the fake clock inside
+      // `testWidgets` never advances — awaiting it directly hangs the test.
+      final image =
+          (await tester.runAsync(() => createTestImage(width: 8, height: 8)))!;
+      // Measured, not assumed: `createTestImage` may hand back an image that
+      // already has more than one handle open.
+      final baseline = image.debugGetOpenHandleStackTraces()!.length;
+
+      final completer = Completer<ImageInfo>();
+      final provider = _SharedManualImageProvider(completer);
+
+      late final TileImage second;
+      var secondDisposed = false;
+
+      // Two tiles sharing one ImageStreamCompleter, which is what ImageCache
+      // does whenever two tiles resolve equal keys — e.g. a tile that leaves
+      // the viewport and comes back while its image is still in flight.
+      //
+      // `ImageStreamCompleter.setImage` dispatches over a COPY of its listener
+      // list ("Make a copy to allow for concurrent modification"), so removing
+      // a listener from inside that loop does not stop it from being called.
+      // The first tile's completion runs `onLoadComplete` — which is where
+      // flutter_map prunes tiles — disposing the second tile mid-dispatch.
+      final first = _tile(
+        x: 0,
+        provider: provider,
+        onLoadComplete: (_) {
+          if (secondDisposed) return;
+          secondDisposed = true;
+          second.dispose();
+        },
+      );
+      second = _tile(x: 1, provider: provider);
+
+      first.load();
+      second.load();
+
+      completer.complete(ImageInfo(image: image));
+      await tester.pump();
+
+      expect(
+        secondDisposed,
+        isTrue,
+        reason: 'the scenario under test never happened',
+      );
+      expect(
+        second.imageInfo,
+        isNull,
+        reason: 'a disposed tile must not keep an image nobody will paint',
+      );
+      expect(
+        image.debugGetOpenHandleStackTraces(),
+        hasLength(baseline + 1),
+        reason: 'only the live tile may still hold a handle; the one handed to '
+            'the disposed tile must be released',
+      );
+
+      first.dispose();
+    },
+  );
+}

--- a/test/layer/tile_layer/tile_widget_handles_test.dart
+++ b/test/layer/tile_layer/tile_widget_handles_test.dart
@@ -1,10 +1,9 @@
-import 'dart:async';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../../test_utils/test_frame_driver.dart';
 
 /// Handle accounting through the FULL widget cycle: TileImage → Tile →
 /// RawImage → RenderImage.
@@ -22,37 +21,7 @@ import 'package:flutter_test/flutter_test.dart';
 /// ⚠️ `cache: false` and DIFFERENT sizes are load-bearing: `createTestImage`
 /// caches by size and returns clones of one shared image, which makes two
 /// "independent" counters move in lockstep and hides per-frame attribution.
-class _DrivenCompleter extends ImageStreamCompleter {
-  void emit(ImageInfo info) => setImage(info);
-}
 
-class _DrivenProvider extends ImageProvider<_DrivenProvider> {
-  _DrivenProvider(this.completer);
-
-  final _DrivenCompleter completer;
-
-  @override
-  Future<_DrivenProvider> obtainKey(ImageConfiguration configuration) =>
-      SynchronousFuture<_DrivenProvider>(this);
-
-  @override
-  ImageStreamCompleter loadImage(
-    _DrivenProvider key,
-    ImageDecoderCallback decode,
-  ) =>
-      completer;
-}
-
-TileImage _tileImage(ImageProvider provider) => TileImage(
-      vsync: const TestVSync(),
-      coordinates: const TileCoordinates(0, 0, 0),
-      imageProvider: provider,
-      onLoadComplete: (_) {},
-      onLoadError: (_, __, ___) {},
-      tileDisplay: const TileDisplay.instantaneous(),
-      errorImage: null,
-      cancelLoading: Completer<void>(),
-    );
 
 Widget _host(TileImage tileImage) => Directionality(
       textDirection: TextDirection.ltr,
@@ -80,8 +49,8 @@ void main() {
       final base1 = images[0].debugGetOpenHandleStackTraces()!.length;
       final base2 = images[1].debugGetOpenHandleStackTraces()!.length;
 
-      final completer = _DrivenCompleter();
-      final tileImage = _tileImage(_DrivenProvider(completer));
+      final completer = DrivenCompleter();
+      final tileImage = testTileImage(provider: DrivenProvider(completer));
       tileImage.load();
 
       await tester.pumpWidget(_host(tileImage));
@@ -127,8 +96,8 @@ void main() {
       final base1 = images[0].debugGetOpenHandleStackTraces()!.length;
       final base2 = images[1].debugGetOpenHandleStackTraces()!.length;
 
-      final completer = _DrivenCompleter();
-      final tileImage = _tileImage(_DrivenProvider(completer));
+      final completer = DrivenCompleter();
+      final tileImage = testTileImage(provider: DrivenProvider(completer));
       tileImage.load();
       await tester.pumpWidget(_host(tileImage));
 
@@ -164,8 +133,8 @@ void main() {
       final base1 = images[0].debugGetOpenHandleStackTraces()!.length;
       final base2 = images[1].debugGetOpenHandleStackTraces()!.length;
 
-      final completer = _DrivenCompleter();
-      final tileImage = _tileImage(_DrivenProvider(completer));
+      final completer = DrivenCompleter();
+      final tileImage = testTileImage(provider: DrivenProvider(completer));
       tileImage.load();
       await tester.pumpWidget(_host(tileImage));
 

--- a/test/layer/tile_layer/tile_widget_handles_test.dart
+++ b/test/layer/tile_layer/tile_widget_handles_test.dart
@@ -1,0 +1,195 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/layer/tile_layer/tile.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Handle accounting through the FULL widget cycle: TileImage → Tile →
+/// RawImage → RenderImage.
+///
+/// This is the test that CAUGHT the second leak (0806): the flag-based fix
+/// assumed `RawImage` hands ownership to `RenderImage` at build time. It does
+/// not — `RawImage` CLONES for the render object, so the tile's own handle
+/// stayed open forever on every painted frame (~0.3/tile on device after the
+/// flag fix, because the flag exempted exactly the painted frames).
+///
+/// Pure-TileImage tests can't see this: the bug lived in what the widget
+/// integration does NOT do with the handle. Hence full cycle here, counting
+/// OPEN HANDLES on the raw images after complete teardown — not code presence.
+///
+/// ⚠️ `cache: false` and DIFFERENT sizes are load-bearing: `createTestImage`
+/// caches by size and returns clones of one shared image, which makes two
+/// "independent" counters move in lockstep and hides per-frame attribution.
+class _DrivenCompleter extends ImageStreamCompleter {
+  void emit(ImageInfo info) => setImage(info);
+}
+
+class _DrivenProvider extends ImageProvider<_DrivenProvider> {
+  _DrivenProvider(this.completer);
+
+  final _DrivenCompleter completer;
+
+  @override
+  Future<_DrivenProvider> obtainKey(ImageConfiguration configuration) =>
+      SynchronousFuture<_DrivenProvider>(this);
+
+  @override
+  ImageStreamCompleter loadImage(
+    _DrivenProvider key,
+    ImageDecoderCallback decode,
+  ) =>
+      completer;
+}
+
+TileImage _tileImage(ImageProvider provider) => TileImage(
+      vsync: const TestVSync(),
+      coordinates: const TileCoordinates(0, 0, 0),
+      imageProvider: provider,
+      onLoadComplete: (_) {},
+      onLoadError: (_, __, ___) {},
+      tileDisplay: const TileDisplay.instantaneous(),
+      errorImage: null,
+      cancelLoading: Completer<void>(),
+    );
+
+Widget _host(TileImage tileImage) => Directionality(
+      textDirection: TextDirection.ltr,
+      child: Stack(
+        children: [
+          Tile(
+            scaledTileDimension: 256,
+            currentPixelOrigin: Offset.zero,
+            tileImage: tileImage,
+            tileBuilder: null,
+            positionCoordinates: const TileCoordinates(0, 0, 0),
+          ),
+        ],
+      ),
+    );
+
+void main() {
+  testWidgets(
+    'two frames with a build in between: after unmount every handle is closed',
+    (tester) async {
+      final images = (await tester.runAsync(() async => [
+            await createTestImage(width: 8, height: 8, cache: false),
+            await createTestImage(width: 9, height: 9, cache: false),
+          ]))!;
+      final base1 = images[0].debugGetOpenHandleStackTraces()!.length;
+      final base2 = images[1].debugGetOpenHandleStackTraces()!.length;
+
+      final completer = _DrivenCompleter();
+      final tileImage = _tileImage(_DrivenProvider(completer));
+      tileImage.load();
+
+      await tester.pumpWidget(_host(tileImage));
+
+      // Frame 1, then a real build (the widget hands the handle on), then
+      // frame 2, then another build.
+      completer.emit(ImageInfo(image: images[0]));
+      await tester.pump();
+      completer.emit(ImageInfo(image: images[1]));
+      await tester.pump();
+
+      // Tile leaves the tree (prune) and the TileImage is disposed — the full
+      // real-life teardown.
+      await tester.pumpWidget(const SizedBox());
+      tileImage.dispose();
+      // The completer outlives the tile in reality only while ImageCache holds
+      // it; here nobody does, so its current image must go too.
+
+      expect(
+        images[0].debugGetOpenHandleStackTraces(),
+        hasLength(base1 - 1),
+        reason: 'frame 1: the completer freed the original at setImage and '
+            'the tile freed its clone on replacement — after teardown NOTHING '
+            'may hold it (this exact assertion caught the flag-based leak)',
+      );
+      expect(
+        images[1].debugGetOpenHandleStackTraces(),
+        hasLength(base2),
+        reason: 'frame 2: the only open handle is the ORIGINAL one, now owned '
+            'by the completer as its current image (ImageCache would own the '
+            'completer in production) — the tile\'s clone must be gone',
+      );
+    },
+  );
+
+  testWidgets(
+    'two frames in the SAME frame budget: after unmount every handle is closed',
+    (tester) async {
+      final images = (await tester.runAsync(() async => [
+            await createTestImage(width: 8, height: 8, cache: false),
+            await createTestImage(width: 9, height: 9, cache: false),
+          ]))!;
+      final base1 = images[0].debugGetOpenHandleStackTraces()!.length;
+      final base2 = images[1].debugGetOpenHandleStackTraces()!.length;
+
+      final completer = _DrivenCompleter();
+      final tileImage = _tileImage(_DrivenProvider(completer));
+      tileImage.load();
+      await tester.pumpWidget(_host(tileImage));
+
+      // Both frames before any pump — the fast-device case that leaked.
+      completer.emit(ImageInfo(image: images[0]));
+      completer.emit(ImageInfo(image: images[1]));
+      await tester.pump();
+
+      await tester.pumpWidget(const SizedBox());
+      tileImage.dispose();
+
+      expect(
+        images[0].debugGetOpenHandleStackTraces(),
+        hasLength(base1 - 1),
+        reason: 'frame 1: no build between frames — same rule, the tile frees '
+            'its own handle on replacement',
+      );
+      expect(
+        images[1].debugGetOpenHandleStackTraces(),
+        hasLength(base2),
+        reason: 'frame 2: only the original handle (completer-owned) remains',
+      );
+    },
+  );
+
+  testWidgets(
+    'tile pruned between the frames: after teardown every handle is closed',
+    (tester) async {
+      final images = (await tester.runAsync(() async => [
+            await createTestImage(width: 8, height: 8, cache: false),
+            await createTestImage(width: 9, height: 9, cache: false),
+          ]))!;
+      final base1 = images[0].debugGetOpenHandleStackTraces()!.length;
+      final base2 = images[1].debugGetOpenHandleStackTraces()!.length;
+
+      final completer = _DrivenCompleter();
+      final tileImage = _tileImage(_DrivenProvider(completer));
+      tileImage.load();
+      await tester.pumpWidget(_host(tileImage));
+
+      completer.emit(ImageInfo(image: images[0]));
+      await tester.pump();
+
+      // Prune happens NOW — then the (shared, cache-held) completer still
+      // delivers frame 2 to nobody.
+      await tester.pumpWidget(const SizedBox());
+      tileImage.dispose();
+      completer.emit(ImageInfo(image: images[1]));
+
+      expect(
+        images[0].debugGetOpenHandleStackTraces(),
+        hasLength(base1 - 1),
+        reason: 'frame 1 went through a build; teardown must close every '
+            'handle to it',
+      );
+      expect(
+        images[1].debugGetOpenHandleStackTraces(),
+        hasLength(base2),
+        reason: 'frame 2: only the original handle (completer-owned) remains '
+            '— delivered to nobody, cloned by nobody',
+      );
+    },
+  );
+}

--- a/test/test_utils/test_frame_driver.dart
+++ b/test/test_utils/test_frame_driver.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A completer the test drives frame by frame — progressive tiles (a base
+/// frame followed by a composed one) emit more than once, and handle-ownership
+/// tests need to control exactly when each frame lands.
+class DrivenCompleter extends ImageStreamCompleter {
+  /// Delivers [info] to every listener as the next frame.
+  void emit(ImageInfo info) => setImage(info);
+}
+
+/// An [ImageProvider] whose key is itself, so every [TileImage] resolving it
+/// shares ONE completer — exactly what [ImageCache] does for equal keys.
+class DrivenProvider extends ImageProvider<DrivenProvider> {
+  /// Creates a provider that exposes [completer] to all resolvers.
+  DrivenProvider(this.completer);
+
+  /// The completer shared by every resolve of this provider.
+  final ImageStreamCompleter completer;
+
+  @override
+  Future<DrivenProvider> obtainKey(ImageConfiguration configuration) =>
+      SynchronousFuture<DrivenProvider>(this);
+
+  @override
+  ImageStreamCompleter loadImage(
+    DrivenProvider key,
+    ImageDecoderCallback decode,
+  ) =>
+      completer;
+}
+
+/// One factory for the handle-ownership tests — the [TileImage] constructor
+/// takes eight arguments and duplicating the boilerplate per test file meant a
+/// constructor change touched every copy.
+TileImage testTileImage({
+  required ImageProvider provider,
+  int x = 0,
+  void Function(TileCoordinates)? onLoadComplete,
+}) =>
+    TileImage(
+      vsync: const TestVSync(),
+      coordinates: TileCoordinates(x, 0, 0),
+      imageProvider: provider,
+      onLoadComplete: onLoadComplete ?? (_) {},
+      onLoadError: (_, __, ___) {},
+      tileDisplay: const TileDisplay.instantaneous(),
+      errorImage: null,
+      cancelLoading: Completer<void>(),
+    );


### PR DESCRIPTION
`TileImage._onImageLoadSuccess` stores the `ImageInfo` even when the tile is already disposed. `ImageStreamCompleter.setImage` gives every listener its own handle and the listener owns it: a displayed tile passes ownership to `RenderImage`, which disposes it — but a disposed tile never builds one, so the decoded image stays alive for the lifetime of the process.

## Why `dispose()` removing the listener isn't enough

This is **not** reachable by simply disposing a tile and then completing its image — `dispose()` removes the listener and `setImage` early-returns on an empty listener list.

It is reachable because `setImage` dispatches over a **copy** of the listener list:

```dart
// Make a copy to allow for concurrent modification.
final localListeners = List<ImageStreamListener>.of(_listeners);
for (final listener in localListeners) {
  listener.onImage(image.clone(), false);
}
```

A listener removed from inside that loop is still called. Two tiles resolving equal keys share one completer, and `onLoadComplete` is where tiles get pruned — as `TileImageManager.reloadImages` already notes:

> If a TileImage's imageInfo is already available when load() is called it will call its onLoadComplete callback synchronously which can trigger pruning.

So the first tile's completion can dispose the second tile mid-dispatch, and the second tile is handed an image anyway.

## Impact

Unnoticeable with 256×256 tiles (256 KB). With 768×768 RGBA tiles (2.25 MB each) it killed an app on iOS while browsing the map — the process was terminated at its memory limit after a few minutes of panning.

## Test

Adds `test/layer/tile_layer/tile_image_test.dart`, which reproduces the dispatch race with two tiles sharing one completer and asserts both that the disposed tile keeps no `ImageInfo` and that the handle it was given is released (`debugGetOpenHandleStackTraces`).

On the current code it fails with:

```
Expected: null
  Actual: ImageInfo:<[8x8] @ 1.0x>
```

Full suite passes with the change (118/118).

---

**AI usage disclosure** (per CONTRIBUTING): this patch and its test were written with AI assistance (Claude). I reviewed the change and the reasoning, ran the test suite, and verified that the added test fails on unpatched `master` and passes with the fix. I take responsibility for the code.