### PR TITLE
fix: stop MarkerLayer wrap loops on a non-finite camera

### DIFF
--- a/lib/src/layer/marker_layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer/marker_layer.dart
@@ -98,6 +98,16 @@ class _MarkerLayerState extends State<MarkerLayer> {
     final pixelOrigin = map.pixelOrigin;
     final markers = widget.markers;
 
+    // A non-finite camera makes Rect.overlaps return true for every world
+    // copy, so the wrap loops never terminate (OOM/ANR). #2178 only guards
+    // Marker.point. See https://github.com/fleaflet/flutter_map/issues/2240.
+    if (!worldWidth.isFinite ||
+        !pixelBounds.left.isFinite ||
+        !pixelBounds.right.isFinite ||
+        !map.rotation.isFinite) {
+      return const SizedBox.shrink();
+    }
+
     return MobileLayerTransformer(
       child: Stack(
         children: () sync* {
@@ -166,14 +176,37 @@ class _MarkerLayerState extends State<MarkerLayer> {
 
             // Repeat over all worlds (<--||-->) until culling determines that
             // that marker is out of view, and therefore all further markers in
-            // that direction will also be
-            if (worldWidth == 0) continue;
+            // that direction will also be.
+            // Also skip wrapping when the projected point is non-finite; the
+            // camera-level guard above does not cover that case.
+            if (worldWidth == 0 ||
+                !worldWidth.isFinite ||
+                !pxPoint.dx.isFinite ||
+                !pxPoint.dy.isFinite ||
+                !pixelBounds.left.isFinite ||
+                !pixelBounds.right.isFinite) {
+              continue;
+            }
+
+            // Same backstop as FeatureLayerUtils.workAcrossWorlds (#2052/#2111).
+            const maxShiftsCount = 30;
+            var shiftsCount = 0;
             for (double shift = -worldWidth;; shift -= worldWidth) {
+              if (++shiftsCount > maxShiftsCount) {
+                throw AssertionError(
+                  'Infinite loop going beyond $maxShiftsCount for world width $worldWidth',
+                );
+              }
               final additional = getPositioned(shift);
               if (additional == null) break;
               yield additional;
             }
             for (double shift = worldWidth;; shift += worldWidth) {
+              if (++shiftsCount > maxShiftsCount) {
+                throw AssertionError(
+                  'Infinite loop going beyond $maxShiftsCount for world width $worldWidth',
+                );
+              }
               final additional = getPositioned(shift);
               if (additional == null) break;
               yield additional;

--- a/test/layer/marker_layer_test.dart
+++ b/test/layer/marker_layer_test.dart
@@ -24,4 +24,41 @@ void main() {
     expect(find.byType(MarkerLayer), findsWidgets);
     expect(find.byKey(key), findsOneWidget);
   });
+
+  // #2178 only rejects a non-finite Marker.point. A finite marker plus a
+  // non-finite camera still makes Rect.overlaps return true for every world
+  // copy, so the wrap loops never stop (OOM / ANR). See #2240.
+  testWidgets('non-finite camera rotation does not hang MarkerLayer',
+      (tester) async {
+    final controller = MapController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FlutterMap(
+          mapController: controller,
+          options: const MapOptions(
+            initialCenter: LatLng(16.6, 120.9),
+            initialZoom: 12,
+          ),
+          children: const [
+            MarkerLayer(
+              markers: [
+                Marker(
+                  point: LatLng(16.6, 120.9),
+                  width: 40,
+                  height: 40,
+                  child: SizedBox.shrink(),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+
+    controller.rotate(double.nan);
+    await tester.pump();
+
+    expect(find.byType(FlutterMap), findsOneWidget);
+    expect(find.byType(MarkerLayer), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Fixes #2240

#2178 only rejects a non-finite `Marker.point`. A NaN camera still makes `Rect.overlaps` return true for every world copy, so the wrap loops never stop.

I skip `MarkerLayer` when the camera isn't finite, and I skip wrapping a marker if its projected point isn't finite either. There's also a 30-shift cap like `workAcrossWorlds`, so a future never-culls bug throws instead of taking the process down.

Widget test: `rotate(double.nan)`, then `pump()` has to return.
