### PR TITLE
fix: respect `InteractionOptions.rotationThreshold` even when multi-finger gesture race is disabled

### DIFF
--- a/lib/src/gestures/map_interactive_viewer.dart
+++ b/lib/src/gestures/map_interactive_viewer.dart
@@ -597,7 +597,6 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
 
     if (hasGestureRace && _gestureWinner == MultiFingerGesture.none) {
       final gestureWinner = _determineMultiFingerGestureWinner(
-        _interactionOptions.rotationThreshold,
         currentRotation,
         details.scale,
         details.localFocalPoint,
@@ -704,7 +703,9 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
     ScaleUpdateDetails details,
     double currentRotation,
   ) {
-    if (!_rotationStarted && currentRotation != 0.0) {
+    if (!_rotationStarted &&
+        currentRotation != 0.0 &&
+        currentRotation.abs() >= _interactionOptions.rotationThreshold) {
       _rotationStarted = true;
       widget.controller.rotateStarted(MapEventSource.onMultiFinger);
     }
@@ -729,8 +730,11 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
     }
   }
 
-  int? _determineMultiFingerGestureWinner(double rotationThreshold,
-      double currentRotation, double scale, Offset focalOffset) {
+  int? _determineMultiFingerGestureWinner(
+    double currentRotation,
+    double scale,
+    Offset focalOffset,
+  ) {
     final int winner;
     if (InteractiveFlag.hasPinchZoom(_interactionOptions.flags) &&
         (_getZoomForScale(_mapZoomStart, scale) - _mapZoomStart).abs() >=
@@ -740,7 +744,7 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
       }
       winner = MultiFingerGesture.pinchZoom;
     } else if (InteractiveFlag.hasRotate(_interactionOptions.flags) &&
-        currentRotation.abs() >= rotationThreshold) {
+        currentRotation.abs() >= _interactionOptions.rotationThreshold) {
       if (_interactionOptions.debugMultiFingerGestureWinner) {
         debugPrint('Multi Finger Gesture winner: Rotate');
       }

--- a/lib/src/map/options/interaction.dart
+++ b/lib/src/map/options/interaction.dart
@@ -13,18 +13,27 @@ class InteractionOptions {
   /// Note: only takes effect if [enableMultiFingerGestureRace] is true
   final bool debugMultiFingerGestureWinner;
 
-  /// If true then [rotationThreshold] and [pinchZoomThreshold] and
-  /// [pinchMoveThreshold] will race If multiple gestures win at the same time
-  /// then precedence: [pinchZoomWinGestures] > [rotationWinGestures] >
-  /// [pinchMoveWinGestures]
+  /// Whether to race multi-finger gestures instead of allowing multiple
+  /// gestures to be recognised at the same time.
+  ///
+  /// Which gestures win is decided by [rotationThreshold],
+  /// [pinchZoomThreshold], and [pinchMoveThreshold].
+  ///
+  /// If multiple gestures win at the same time, then precedence is:
+  /// [pinchZoomWinGestures] > [rotationWinGestures] > [pinchMoveWinGestures].
+  ///
+  /// Defaults to `false`.
   final bool enableMultiFingerGestureRace;
 
-  /// Rotation threshold in degree default is 20.0 Map starts to rotate when
-  /// [rotationThreshold] has been achieved or another multi finger gesture wins
-  /// which allows [MultiFingerGesture.rotate].
+  /// Required angle of rotation (in degrees) of multi-finger gesture for map
+  /// to rotate.
   ///
-  /// Note: if [flags] doesn't contain [InteractiveFlag.rotate] or
-  /// [enableMultiFingerGestureRace] is false then rotate cannot win.
+  /// Prevents unintentional rotation of the map when zooming and panning.
+  ///
+  /// If [enableMultiFingerGestureRace] is enabled, then this will win over
+  /// other gestures once past this threshold.
+  ///
+  /// Defaults to 20 degrees.
   final double rotationThreshold;
 
   /// When [rotationThreshold] wins over [pinchZoomThreshold] and


### PR DESCRIPTION
Fixes #2232 

The thresholds for move and zoom are also not applied when not racing, but with some testing, it doesn't feel quite right to apply them.

I've categorised this as a fix, because even though I think it may have either been intentionally not applied or just an oversight when adding the racing(?), I have had complaints from other end-users that back-up #2232.