### PR TITLE
fix: preserve double tap drag zoom state

### DIFF
--- a/lib/src/gestures/map_interactive_viewer.dart
+++ b/lib/src/gestures/map_interactive_viewer.dart
@@ -359,13 +359,20 @@ class MapInteractiveViewerState extends State<MapInteractiveViewer>
         child: PositionedTapDetector2(
           controller: _positionedTapController,
           onTap: _handleTap,
+          onDoubleTapDown: (_) {
+            if (_pointerCounter == 1) _doubleTapHoldMaxDelay?.cancel();
+          },
           onSecondaryTap: _handleSecondaryTap,
           onLongPress: _handleLongPress,
           onDoubleTap: _handleDoubleTap,
-          doubleTapDelay:
-              InteractiveFlag.hasDoubleTapZoom(_interactionOptions.flags)
-                  ? null
-                  : Duration.zero,
+          doubleTapDelay: InteractiveFlag.hasDoubleTapZoom(
+                    _interactionOptions.flags,
+                  ) ||
+                  InteractiveFlag.hasDoubleTapDragZoom(
+                    _interactionOptions.flags,
+                  )
+              ? null
+              : Duration.zero,
           child: RawGestureDetector(
             gestures: _gestures,
             child: widget.builder(

--- a/lib/src/gestures/positioned_tap_detector_2.dart
+++ b/lib/src/gestures/positioned_tap_detector_2.dart
@@ -20,6 +20,7 @@ class PositionedTapDetector2 extends StatefulWidget {
     this.child,
     this.onTap,
     this.onDoubleTap,
+    this.onDoubleTapDown,
     this.onSecondaryTap,
     this.onLongPress,
     Duration? doubleTapDelay,
@@ -33,6 +34,7 @@ class PositionedTapDetector2 extends StatefulWidget {
   final Widget? child;
   final HitTestBehavior? behavior;
   final TapPositionCallback? onTap;
+  final TapPositionCallback? onDoubleTapDown;
   final TapPositionCallback? onSecondaryTap;
   final TapPositionCallback? onDoubleTap;
   final TapPositionCallback? onLongPress;
@@ -54,6 +56,7 @@ class _TapPositionDetectorState extends State<PositionedTapDetector2> {
   PositionedTapController? _tapController;
   TapDownDetails? _pendingTap;
   TapDownDetails? _firstTap;
+  TapDownDetails? _firstTapCandidate;
 
   @override
   void initState() {
@@ -98,6 +101,7 @@ class _TapPositionDetectorState extends State<PositionedTapDetector2> {
   void _onTapConfirmed(TapDownDetails details) {
     if (_firstTap == null) {
       _firstTap = details;
+      _firstTapCandidate = null;
     } else {
       _handleSecondTap(details);
     }
@@ -125,6 +129,12 @@ class _TapPositionDetectorState extends State<PositionedTapDetector2> {
 
   void _onTapDownEvent(TapDownDetails details) {
     _pendingTap = details;
+    final firstTap = _firstTap ?? _firstTapCandidate;
+    if (firstTap != null && _isDoubleTap(firstTap, details)) {
+      widget.onDoubleTapDown?.call(
+        TapPosition(details.globalPosition, details.localPosition),
+      );
+    }
   }
 
   void _onTapEvent() {
@@ -134,6 +144,7 @@ class _TapPositionDetectorState extends State<PositionedTapDetector2> {
     if (widget.onDoubleTap == null) {
       _postCallback(pending, widget.onTap);
     } else {
+      if (_firstTap == null) _firstTapCandidate = pending;
       _sink.add(pending);
     }
 
@@ -165,6 +176,7 @@ class _TapPositionDetectorState extends State<PositionedTapDetector2> {
     TapPositionCallback? callback,
   ) async {
     _firstTap = null;
+    _firstTapCandidate = null;
     if (callback != null) {
       callback(TapPosition(details.globalPosition, details.localPosition));
     }

--- a/test/gestures/map_interactive_viewer_test.dart
+++ b/test/gestures/map_interactive_viewer_test.dart
@@ -1,7 +1,109 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/gestures/map_interactive_viewer.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../test_utils/test_app.dart';
+
 void main() {
+  for (final kind in [PointerDeviceKind.touch, PointerDeviceKind.mouse]) {
+    testWidgets(
+      'double-tap drag zoom remains active while the second $kind pointer is '
+      'held',
+      (tester) async {
+        final controller = MapController();
+        await tester.pumpWidget(
+          TestApp(
+            controller: controller,
+            interactionOptions: const InteractionOptions(
+              flags: InteractiveFlag.doubleTapDragZoom,
+            ),
+          ),
+        );
+
+        final center = tester.getCenter(find.byType(FlutterMap));
+        final firstTap = TestPointer(1, kind);
+        tester.binding.handlePointerEvent(firstTap.down(center));
+        tester.binding.handlePointerEvent(firstTap.up());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final secondTap = TestPointer(2, kind);
+        tester.binding.handlePointerEvent(secondTap.down(center));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final zoomBeforeDrag = controller.camera.zoom;
+        final centerBeforeDrag = controller.camera.center;
+        tester.binding.handlePointerEvent(
+          secondTap.move(center.translate(0, -20)),
+        );
+        tester.binding.handlePointerEvent(
+          secondTap.move(center.translate(0, -100)),
+        );
+        tester.binding.handlePointerEvent(
+          secondTap.move(center.translate(0, -150)),
+        );
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(controller.camera.zoom, isNot(zoomBeforeDrag));
+        expect(controller.camera.center, centerBeforeDrag);
+
+        tester.binding.handlePointerEvent(secondTap.up());
+      },
+    );
+  }
+
+  testWidgets('a distant second tap does not enable double-tap drag zoom',
+      (tester) async {
+    final controller = MapController();
+    await tester.pumpWidget(
+      TestApp(
+        controller: controller,
+        interactionOptions: const InteractionOptions(
+          flags: InteractiveFlag.doubleTapDragZoom,
+        ),
+      ),
+    );
+
+    final center = tester.getCenter(find.byType(FlutterMap));
+    await tester.tapAt(center);
+    await tester.pump(const Duration(milliseconds: 100));
+
+    final secondTap = await tester.startGesture(center.translate(100, 0));
+    await tester.pump(const Duration(milliseconds: 300));
+    final zoomBeforeDrag = controller.camera.zoom;
+    await secondTap.moveBy(const Offset(0, -150));
+    await tester.pump();
+
+    expect(controller.camera.zoom, zoomBeforeDrag);
+    await secondTap.up();
+  });
+
+  testWidgets('a second pointer does not enable double-tap drag zoom',
+      (tester) async {
+    final controller = MapController();
+    await tester.pumpWidget(
+      TestApp(
+        controller: controller,
+        interactionOptions: const InteractionOptions(
+          flags: InteractiveFlag.doubleTapDragZoom,
+        ),
+      ),
+    );
+
+    final center = tester.getCenter(find.byType(FlutterMap));
+    final firstPointer = await tester.startGesture(center);
+    final secondPointer = await tester.startGesture(center.translate(10, 0));
+    await tester.pump(const Duration(milliseconds: 300));
+    final zoomBeforeDrag = controller.camera.zoom;
+    await secondPointer.moveBy(const Offset(0, -150));
+    await tester.pump();
+
+    expect(controller.camera.zoom, zoomBeforeDrag);
+    await firstPointer.up();
+    await secondPointer.up();
+  });
+
   group('MapInteractiveViewerState.flingDirection', () {
     test('uses the final segment direction when it has non-zero length', () {
       final direction = MapInteractiveViewerState.flingDirection(


### PR DESCRIPTION
## What does this PR do?

Fixes the `doubleTapDragZoom` state being cleared before the second pointer is dragged when the second tap is held longer than the inter-tap delay.

The detector now keeps the delay enabled for double-tap drag zoom and cancels it only after a valid second tap is recognized. Unrelated distant taps and additional pointers do not activate the gesture.

Fixes #2246

## Checklist

- [x] The code change is covered by tests.
- [x] Touch and mouse pointer behavior are covered.
- [x] Multiple-pointer and distant-second-tap behavior are covered.
- [x] `flutter analyze` passes.
- [x] `dart format` passes for changed files.
- [x] Targeted Flutter tests pass (`9/9`).

## AI Disclosure

OpenCode using the gpt-5.6-sol model assisted with repository research and implementation. The human submitter reviewed the changes and validation results before submission.