### PR TITLE
fix: prefer imports from 'pkg:flutter/widgets.dart' instead of 'material'

### DIFF
--- a/lib/src/gestures/positioned_tap_detector_2.dart
+++ b/lib/src/gestures/positioned_tap_detector_2.dart
@@ -9,7 +9,7 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 typedef TapPositionCallback = void Function(TapPosition position);
 

--- a/lib/src/layer/attribution_layer/rich/source.dart
+++ b/lib/src/layer/attribution_layer/rich/source.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' show Tooltip;
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:meta/meta.dart';
 

--- a/lib/src/layer/attribution_layer/rich/widget.dart
+++ b/lib/src/layer/attribution_layer/rich/widget.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' show IconButton, Icons, Theme, Colors;
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
 /// Position to anchor [RichAttributionWidget] to relative to the [FlutterMap]

--- a/lib/src/layer/attribution_layer/simple.dart
+++ b/lib/src/layer/attribution_layer/simple.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' show Theme;
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
 /// A simple, classic style, attribution layer

--- a/lib/src/layer/scalebar/scalebar.dart
+++ b/lib/src/layer/scalebar/scalebar.dart
@@ -2,7 +2,7 @@ import 'dart:math';
 import 'dart:typed_data';
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 

--- a/lib/src/layer/shared/layer_projection_simplification/state.dart
+++ b/lib/src/layer/shared/layer_projection_simplification/state.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/layer/shared/layer_projection_simplification/widget.dart';
 import 'package:flutter_map/src/misc/simplify.dart';

--- a/lib/src/layer/shared/layer_projection_simplification/widget.dart
+++ b/lib/src/layer/shared/layer_projection_simplification/widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/src/layer/shared/layer_projection_simplification/state.dart';
 
 /// A [StatefulWidget] that includes the properties used by the [State] component

--- a/lib/src/layer/shared/line_patterns/pixel_hiker.dart
+++ b/lib/src/layer/shared/line_patterns/pixel_hiker.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/material.dart';
+import 'dart:ui';
+
 import 'package:flutter_map/flutter_map.dart';
 import 'package:meta/meta.dart';
 

--- a/lib/src/layer/tile_layer/tile_builder.dart
+++ b/lib/src/layer/tile_layer/tile_builder.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
 /// Builder function that returns a [TileBuilder] instance.
@@ -56,15 +56,7 @@ Widget coordinateDebugTileBuilder(
     ),
     child: Stack(
       fit: StackFit.passthrough,
-      children: [
-        tileWidget,
-        Center(
-          child: Text(
-            readableKey,
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-        ),
-      ],
+      children: [tileWidget, Center(child: Text(readableKey))],
     ),
   );
 }
@@ -88,15 +80,7 @@ Widget loadingTimeDebugTileBuilder(
     ),
     child: Stack(
       fit: StackFit.passthrough,
-      children: [
-        tileWidget,
-        Center(
-          child: Text(
-            time,
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-        ),
-      ],
+      children: [tileWidget, Center(child: Text(time))],
     ),
   );
 }

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -3,7 +3,7 @@ import 'dart:math';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_bounds/tile_bounds.dart';

--- a/lib/src/layer/tile_layer/tile_provider/asset/provider.dart
+++ b/lib/src/layer/tile_layer/tile_provider/asset/provider.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
 /// Fetch tiles from the app's shipped assets, where the tile URL is a path

--- a/lib/src/map/camera/camera.dart
+++ b/lib/src/map/camera/camera.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/map/inherited_model.dart';
 import 'package:flutter_map/src/misc/deg_rad_conversions.dart';

--- a/lib/src/map/controller/map_controller.dart
+++ b/lib/src/map/controller/map_controller.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/map/inherited_model.dart';
 import 'package:flutter_map/src/misc/move_and_rotate_result.dart';

--- a/lib/src/map/inherited_model.dart
+++ b/lib/src/map/inherited_model.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
 /// Allows descendents of [FlutterMap] to access the [MapCamera], [MapOptions]


### PR DESCRIPTION
Fixes #2256.

To make some preparation towards the decoupling of the Material and Cupertino UIs from Flutter, we should not be using the material import in the following places where the base widgets import works fine.