### PR TITLE
feat: show a background grid while map tiles load

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Flutter's №1 non-commercially aimed map client: it's easy-to-use, versatile, vendor-free, fully cross-platform, and 100% pure-Flutter
 
+Maps show a subtle background grid while tiles load. It moves with the map and
+is covered as tiles render. Customize it with `MapOptions.backgroundGridColor`
+and `MapOptions.backgroundGridSpacing`, or set `backgroundGridColor: null` to
+use a plain background. Fully transparent map backgrounds remain transparent.
+
 * ### [📖 **Read the docs**](https://docs.fleaflet.dev/)
 
 * ### [🚀 **Launch the web demo**](https://demo.fleaflet.dev/)

--- a/example/lib/pages/tile_builder.dart
+++ b/example/lib/pages/tile_builder.dart
@@ -14,6 +14,7 @@ class TileBuilderPage extends StatefulWidget {
 
 class TileBuilderPageState extends State<TileBuilderPage> {
   bool enableGrid = true;
+  bool showBackgroundGrid = true;
   bool showCoordinates = true;
   bool showLoadingTime = true;
   bool darkMode = true;
@@ -82,6 +83,15 @@ class TileBuilderPageState extends State<TileBuilderPage> {
                   ),
                   const SizedBox.square(dimension: 12),
                   const Tooltip(
+                    message: 'Show Background Grid While Tiles Load',
+                    child: Icon(Icons.grid_on),
+                  ),
+                  Switch.adaptive(
+                    value: showBackgroundGrid,
+                    onChanged: (v) => setState(() => showBackgroundGrid = v),
+                  ),
+                  const SizedBox.square(dimension: 12),
+                  const Tooltip(
                     message: 'Show Coordinates',
                     child: Icon(Icons.location_on),
                   ),
@@ -113,9 +123,11 @@ class TileBuilderPageState extends State<TileBuilderPage> {
           ),
           Expanded(
             child: FlutterMap(
-              options: const MapOptions(
-                initialCenter: LatLng(51.5, -0.09),
+              options: MapOptions(
+                initialCenter: const LatLng(51.5, -0.09),
                 initialZoom: 5,
+                backgroundGridColor:
+                    showBackgroundGrid ? const Color(0x14000000) : null,
               ),
               children: [
                 _darkModeContainerIfEnabled(

--- a/lib/src/map/background.dart
+++ b/lib/src/map/background.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_map/src/layer/shared/mobile_layer_transformer.dart';
+import 'package:flutter_map/src/map/camera/camera.dart';
+import 'package:meta/meta.dart';
+
+/// The map background, covered by map layers as they render.
+@internal
+class MapBackground extends StatelessWidget {
+  /// Creates the map background and its optional grid.
+  const MapBackground({
+    super.key,
+    required this.color,
+    required this.gridColor,
+    required this.gridSpacing,
+  });
+
+  /// The background fill color.
+  final Color color;
+
+  /// The grid line color, or `null` to disable the grid.
+  final Color? gridColor;
+
+  /// The grid cell size at integer zoom levels.
+  final double gridSpacing;
+
+  @override
+  Widget build(BuildContext context) {
+    final gridColor = this.gridColor;
+    if (gridColor == null || gridColor.a == 0 || color.a == 0) {
+      return ColoredBox(color: color);
+    }
+    final camera = MapCamera.of(context);
+
+    return RepaintBoundary(
+      child: ColoredBox(
+        color: color,
+        child: IgnorePointer(
+          child: MobileLayerTransformer(
+            child: CustomPaint(
+              painter: _BackgroundGridPainter(
+                color: gridColor,
+                spacing: gridSpacing *
+                    camera.getZoomScale(
+                      camera.zoom,
+                      camera.zoom.floorToDouble(),
+                    ),
+                pixelOrigin: camera.pixelOrigin,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BackgroundGridPainter extends CustomPainter {
+  const _BackgroundGridPainter({
+    required this.color,
+    required this.spacing,
+    required this.pixelOrigin,
+  });
+
+  final Color color;
+  final double spacing;
+  final Offset pixelOrigin;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (size.isEmpty || !spacing.isFinite || spacing < 1) return;
+
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = 1
+      ..style = PaintingStyle.stroke;
+    final path = Path();
+
+    // Reduce the projected coordinates before drawing so the work depends on
+    // viewport size, even at high zoom levels or across repeated worlds.
+    for (var x = -pixelOrigin.dx % spacing; x < size.width; x += spacing) {
+      path
+        ..moveTo(x, 0)
+        ..lineTo(x, size.height);
+    }
+    for (var y = -pixelOrigin.dy % spacing; y < size.height; y += spacing) {
+      path
+        ..moveTo(0, y)
+        ..lineTo(size.width, y);
+    }
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(_BackgroundGridPainter oldDelegate) =>
+      color != oldDelegate.color ||
+      spacing != oldDelegate.spacing ||
+      pixelOrigin != oldDelegate.pixelOrigin;
+}

--- a/lib/src/map/options/options.dart
+++ b/lib/src/map/options/options.dart
@@ -84,6 +84,22 @@ class MapOptions {
   /// yellow grey-ish color.
   final Color backgroundColor;
 
+  /// Color of the grid drawn over [backgroundColor], beneath all map layers.
+  ///
+  /// The grid is visible while tiles load and is covered as opaque tiles fade
+  /// in. It also remains visible through transparent tiles and in empty areas.
+  /// Set to `null` to disable it. A fully transparent [backgroundColor] also
+  /// disables the grid.
+  ///
+  /// Enabled by default with a subtle black line color (`0x14000000`).
+  final Color? backgroundGridColor;
+
+  /// Grid cell size in logical pixels at integer zoom levels.
+  ///
+  /// The grid moves and rotates with the map, scaling between integer zoom
+  /// levels. Must be finite and at least 1. Defaults to 64.
+  final double backgroundGridSpacing;
+
   /// Callback that fires when the map gets tapped or clicked with the
   /// primary mouse button. This is normally the left mouse button. This
   /// callback does not fire if the gesture is recognized as a double click.
@@ -167,6 +183,8 @@ class MapOptions {
     this.minZoom,
     this.maxZoom,
     this.backgroundColor = const Color(0xFFE0E0E0),
+    this.backgroundGridColor = const Color(0x14000000),
+    this.backgroundGridSpacing = 64,
     this.onTap,
     this.onSecondaryTap,
     this.onLongPress,
@@ -179,7 +197,10 @@ class MapOptions {
     this.onMapEvent,
     this.onMapReady,
     this.keepAlive = false,
-  });
+  }) : assert(
+          backgroundGridSpacing >= 1 && backgroundGridSpacing < double.infinity,
+          'backgroundGridSpacing must be finite and at least 1',
+        );
 
   /// The options of the closest [FlutterMap] ancestor. If this is called from a
   /// context with no [FlutterMap] ancestor, null is returned.
@@ -204,6 +225,8 @@ class MapOptions {
       minZoom == other.minZoom &&
       maxZoom == other.maxZoom &&
       backgroundColor == other.backgroundColor &&
+      backgroundGridColor == other.backgroundGridColor &&
+      backgroundGridSpacing == other.backgroundGridSpacing &&
       onTap == other.onTap &&
       onSecondaryTap == other.onSecondaryTap &&
       onLongPress == other.onLongPress &&
@@ -228,6 +251,8 @@ class MapOptions {
         minZoom,
         maxZoom,
         backgroundColor,
+        backgroundGridColor,
+        backgroundGridSpacing,
         onTap,
         onSecondaryTap,
         onLongPress,

--- a/lib/src/map/widget.dart
+++ b/lib/src/map/widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/gestures/map_interactive_viewer.dart';
+import 'package:flutter_map/src/map/background.dart';
 import 'package:flutter_map/src/map/inherited_model.dart';
 
 /// An interactive geographical map
@@ -85,7 +86,11 @@ class _FlutterMapStateContainer extends State<FlutterMap>
       child: Stack(
         children: <Widget>[
           Positioned.fill(
-            child: ColoredBox(color: widget.options.backgroundColor),
+            child: MapBackground(
+              color: widget.options.backgroundColor,
+              gridColor: widget.options.backgroundGridColor,
+              gridSpacing: widget.options.backgroundGridSpacing,
+            ),
           ),
           ...widget.children,
         ],

--- a/test/map/background_test.dart
+++ b/test/map/background_test.dart
@@ -1,0 +1,266 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+
+const _captureKey = ValueKey('map capture');
+
+Widget _map({
+  MapController? controller,
+  MapOptions options = const MapOptions(
+    initialCenter: LatLng(0, 0),
+    initialZoom: 1,
+  ),
+  List<Widget> children = const [],
+}) =>
+    Directionality(
+      textDirection: TextDirection.ltr,
+      child: Center(
+        child: SizedBox.square(
+          dimension: 256,
+          child: RepaintBoundary(
+            key: _captureKey,
+            child: FlutterMap(
+              mapController: controller,
+              options: options,
+              children: children,
+            ),
+          ),
+        ),
+      ),
+    );
+
+Future<ByteData> _pixels(WidgetTester tester) async {
+  final boundary = tester.renderObject<RenderRepaintBoundary>(
+    find.byKey(_captureKey),
+  );
+  return (await tester.runAsync(() async {
+    final image = await boundary.toImage();
+    try {
+      return (await image.toByteData())!;
+    } finally {
+      image.dispose();
+    }
+  }))!;
+}
+
+int _red(ByteData pixels, int x, int y) => pixels.getUint8((y * 256 + x) * 4);
+
+Future<ui.Image> _whiteImage(WidgetTester tester) async =>
+    (await tester.runAsync(() async {
+      final recorder = ui.PictureRecorder();
+      Canvas(recorder).drawColor(const Color(0xFFFFFFFF), BlendMode.src);
+      final picture = recorder.endRecording();
+      try {
+        return await picture.toImage(1, 1);
+      } finally {
+        picture.dispose();
+      }
+    }))!;
+
+void main() {
+  for (final fade in [false, true]) {
+    testWidgets('grid is covered per tile as it loads (fade: $fade)',
+        (tester) async {
+      final provider = _DeferredTileProvider();
+      final white = await _whiteImage(tester);
+      addTearDown(white.dispose);
+
+      await tester.pumpWidget(_map(children: [
+        TileLayer(
+          tileProvider: provider,
+          tileDisplay: fade
+              ? const TileDisplay.fadeIn(
+                  duration: Duration(milliseconds: 200),
+                )
+              : const TileDisplay.instantaneous(),
+        ),
+      ]));
+
+      final loading = await _pixels(tester);
+      expect(_red(loading, 32, 32), 224);
+      expect(_red(loading, 63, 32), lessThan(224));
+      expect(_red(loading, 32, 63), lessThan(224));
+
+      // Complete only the top-left tile. Other tiles must keep their grid.
+      provider.images[const TileCoordinates(0, 0, 1)]!.complete(white);
+      await tester.pump();
+      if (fade) {
+        await tester.pump(const Duration(milliseconds: 100));
+        final fading = await _pixels(tester);
+        expect(
+            _red(fading, 63, 32), inExclusiveRange(_red(loading, 63, 32), 255));
+      }
+      await tester.pump(const Duration(milliseconds: 200));
+
+      final partial = await _pixels(tester);
+      expect(_red(partial, 63, 32), 255);
+      expect(_red(partial, 191, 224), _red(loading, 191, 224));
+
+      for (final image in provider.images.values) {
+        if (!image.completer.isCompleted) image.complete(white);
+      }
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      final loaded = await _pixels(tester);
+      expect(loaded.buffer.asUint8List(), everyElement(255));
+    });
+  }
+
+  testWidgets('loaded fallback tiles stay above the grid while zooming',
+      (tester) async {
+    final controller = MapController();
+    addTearDown(controller.dispose);
+    final provider = _DeferredTileProvider();
+    final white = await _whiteImage(tester);
+    addTearDown(white.dispose);
+    await tester.pumpWidget(_map(controller: controller, children: [
+      TileLayer(
+        tileProvider: provider,
+        tileDisplay: const TileDisplay.instantaneous(),
+      ),
+    ]));
+    for (final image in provider.images.values) {
+      image.complete(white);
+    }
+    await tester.pumpAndSettle();
+
+    controller.move(const LatLng(0, 0), 2);
+    await tester.pump();
+    expect(
+        provider.images.keys.any((coordinates) => coordinates.z == 2), isTrue);
+    final zooming = await _pixels(tester);
+    expect(zooming.buffer.asUint8List(), everyElement(255));
+  });
+
+  testWidgets('grid follows panning, fractional zoom and rotation',
+      (tester) async {
+    final controller = MapController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(_map(controller: controller));
+
+    final camera = controller.camera;
+    controller.move(
+      camera.unprojectAtZoom(
+        camera.projectAtZoom(camera.center) + const Offset(16, 0),
+      ),
+      camera.zoom,
+    );
+    await tester.pump();
+    final panned = await _pixels(tester);
+    expect(_red(panned, 63, 32), 224);
+    expect(_red(panned, 47, 32), lessThan(224));
+
+    controller.move(const LatLng(0, 0), 1.5);
+    await tester.pump();
+    final zoomed = await _pixels(tester);
+    // The line left of the center is now 64 * sqrt(2) pixels away.
+    expect(_red(zoomed, 37, 32), lessThan(224));
+    expect(_red(zoomed, 63, 32), 224);
+
+    controller.move(const LatLng(0, 0), 1);
+    controller.rotate(45);
+    await tester.pump();
+    final rotated = await _pixels(tester);
+    expect(_red(rotated, 100, 100), lessThan(224));
+    expect(_red(rotated, 100, 110), 224);
+    expect(_red(rotated, 0, 0), lessThan(224));
+    expect(_red(rotated, 255, 255), lessThan(224));
+  });
+
+  testWidgets('grid color, spacing and disabling update on rebuild',
+      (tester) async {
+    await tester.pumpWidget(_map());
+    await tester.pumpWidget(_map(
+      options: const MapOptions(
+        initialCenter: LatLng(0, 0),
+        initialZoom: 1,
+        backgroundGridColor: Color(0xFF000000),
+        backgroundGridSpacing: 32,
+      ),
+    ));
+    final custom = await _pixels(tester);
+    expect(_red(custom, 31, 16), lessThan(150));
+    expect(_red(custom, 16, 16), 224);
+
+    await tester.pumpWidget(_map(
+      options: const MapOptions(backgroundGridColor: null),
+    ));
+    final disabled = await _pixels(tester);
+    expect(_red(disabled, 31, 16), 224);
+    expect(_red(disabled, 63, 32), 224);
+  });
+
+  testWidgets('transparent map backgrounds stay transparent', (tester) async {
+    await tester.pumpWidget(_map(
+      options: const MapOptions(backgroundColor: Color(0x00000000)),
+    ));
+    final transparent = await _pixels(tester);
+    expect(transparent.buffer.asUint8List(), everyElement(0));
+  });
+
+  testWidgets('grid does not intercept map taps or drags', (tester) async {
+    final controller = MapController();
+    addTearDown(controller.dispose);
+    var taps = 0;
+    await tester.pumpWidget(_map(
+      controller: controller,
+      options: MapOptions(onTap: (_, __) => taps++),
+    ));
+    await tester.tap(find.byType(FlutterMap));
+    // Allow the map's double-tap recognition window to expire.
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pumpAndSettle();
+    expect(taps, 1);
+
+    final center = controller.camera.center;
+    await tester.drag(find.byType(FlutterMap), const Offset(50, 20));
+    await tester.pumpAndSettle();
+    expect(controller.camera.center, isNot(center));
+  });
+
+  test('grid options participate in equality and reject invalid spacing', () {
+    const defaults = MapOptions();
+    const disabled = MapOptions(backgroundGridColor: null);
+    const spacing = MapOptions(backgroundGridSpacing: 32);
+    expect(defaults, isNot(disabled));
+    expect(defaults, isNot(spacing));
+    expect({defaults, disabled, spacing}, hasLength(3));
+    for (final invalid in [0.0, -1.0, double.infinity, double.nan]) {
+      expect(() => MapOptions(backgroundGridSpacing: invalid),
+          throwsAssertionError);
+    }
+  });
+}
+
+class _DeferredTileProvider extends TileProvider {
+  final images = <TileCoordinates, _DeferredImage>{};
+
+  @override
+  ImageProvider getImage(TileCoordinates coordinates, TileLayer options) =>
+      images.putIfAbsent(coordinates, _DeferredImage.new);
+}
+
+class _DeferredImage extends ImageProvider<_DeferredImage> {
+  final completer = Completer<ImageInfo>();
+
+  void complete(ui.Image image) =>
+      completer.complete(ImageInfo(image: image.clone()));
+
+  @override
+  Future<_DeferredImage> obtainKey(ImageConfiguration configuration) =>
+      SynchronousFuture(this);
+
+  @override
+  ImageStreamCompleter loadImage(
+    _DeferredImage key,
+    ImageDecoderCallback decode,
+  ) =>
+      OneFrameImageStreamCompleter(completer.future);
+}


### PR DESCRIPTION
Empty map areas currently show a flat background while tiles load. Add a subtle grid beneath all map layers, enabled by default with 64 logical pixel cells at integer zoom levels. It follows panning, zooming, and rotation, and opaque tiles cover it as they fade in. Existing fallback tiles continue to cover the grid while replacement tiles load.

<img width="912" height="744" alt="Loading grid behind partially rendered map tiles" src="https://github.com/user-attachments/assets/e211c145-5db4-459e-a592-0380fc9fa638" />

Expose `MapOptions.backgroundGridColor` and `MapOptions.backgroundGridSpacing` for customization. Setting `backgroundGridColor: null` restores the plain background. Fully transparent map backgrounds remain transparent. When disabled, the background uses the existing plain `ColoredBox` without a grid painter or camera dependency.

This intentionally changes the default map appearance. The grid is a background decoration, so it also remains visible through transparent tiles and in areas without tiles. The Tile Builder example includes a toggle, and the API documentation describes these behaviors.

Validation:

- All 148 tests pass on the clean upstream-based branch, including 8 new tests for rendered grid pixels, partial loading, fade-in, fallback tiles, camera movement, customization, transparency, and gestures.
- Analysis passes for the library, tests, and example page; formatting checks pass for all changed Dart files.
- Tested with Flutter 3.41.9 / Dart 3.11.5. Minimum-supported-SDK validation remains for CI.

Developed and checked with OpenAI Codex; the validation listed above ran locally.
